### PR TITLE
Specify window to match viewport

### DIFF
--- a/packages/record/src/record/record.ts
+++ b/packages/record/src/record/record.ts
@@ -33,6 +33,7 @@ export const recordSession: (
     browser_ ||
     (await puppeteer.launch({
       defaultViewport,
+      args: [`--window-size=${width},${height}`],
       headless: false,
       devtools: devTools || false,
     }));

--- a/packages/replayer/src/replayer/replay-events.ts
+++ b/packages/replayer/src/replayer/replay-events.ts
@@ -68,6 +68,7 @@ export const replayEvents: (options: ReplayEventsOptions) => Promise<{
     browser_ ||
     (await puppeteer.launch({
       defaultViewport,
+      args: [`--window-size=${width},${height}`],
       headless: headless || false,
       devtools: devTools || false,
     }));


### PR DESCRIPTION
This makes it easier to view replays when they are running locally. 