### PR TITLE
Add support to run multiple test replays with Meticulous

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "adm-zip": "^0.5.9",
     "archiver": "^5.3.0",
     "axios": "^0.25.0",
+    "cosmiconfig": "^7.0.1",
     "luxon": "^2.2.0",
     "pixelmatch": "^5.2.1",
     "pngjs": "^6.0.0",

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -1,0 +1,102 @@
+import { CommandModule } from "yargs";
+import { readConfig } from "../../config/config";
+import { TestCase } from "../../config/config.types";
+import { replayCommandHandler } from "../replay/replay.command";
+
+interface Options {
+  apiToken?: string | null | undefined;
+  commitSha?: string | null | undefined;
+  appUrl: string;
+  headless?: boolean | null | undefined;
+  devTools?: boolean | null | undefined;
+  diffThreshold?: number | null | undefined;
+  diffPixelThreshold?: number | null | undefined;
+}
+
+interface TestCaseResult extends TestCase {
+  result: "pass" | "fail";
+}
+
+const handler: (options: Options) => Promise<void> = async ({
+  apiToken,
+  commitSha,
+  appUrl,
+  headless,
+  devTools,
+  diffThreshold,
+  diffPixelThreshold,
+}) => {
+  const config = await readConfig();
+  const testCases = config.testCases || [];
+
+  if (!testCases.length) {
+    console.error("Error! No test case defined");
+    process.exit(1);
+  }
+
+  const results: TestCaseResult[] = [];
+  for (const testCase of testCases) {
+    const { sessionId, baseReplayId } = testCase;
+    const replayPromise = replayCommandHandler({
+      apiToken,
+      commitSha,
+      sessionId,
+      appUrl,
+      headless,
+      devTools,
+      screenshot: true,
+      baseReplayId,
+      diffThreshold,
+      diffPixelThreshold,
+      save: false,
+      exitOnMismatch: false,
+    });
+    const result: TestCaseResult = await replayPromise
+      .then(() => ({ ...testCase, result: "pass" } as TestCaseResult))
+      .catch(() => ({ ...testCase, result: "fail" }));
+    results.push(result);
+  }
+
+  console.log("");
+  console.log("Results");
+  console.log("=======");
+  results.forEach(({ sessionId, baseReplayId, result }) => {
+    console.log(`${sessionId} | ${baseReplayId} => ${result}`);
+  });
+
+  if (results.find(({ result }) => result === "fail")) {
+    process.exit(1);
+  }
+};
+
+export const runAllTests: CommandModule<unknown, Options> = {
+  command: "run-all-tests",
+  describe: "Run all replay test cases",
+  builder: {
+    apiToken: {
+      string: true,
+    },
+    commitSha: {
+      string: true,
+    },
+    appUrl: {
+      string: true,
+      demandOption: true,
+    },
+    headless: {
+      boolean: true,
+      description: "Start browser in headless mode",
+    },
+    devTools: {
+      boolean: true,
+      description: "Open Chrome Dev Tools",
+    },
+    diffThreshold: {
+      number: true,
+    },
+    diffPixelThreshold: {
+      number: true,
+    },
+  },
+  handler,
+};

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -21,6 +21,7 @@ export const diffScreenshots: (options: {
   headScreenshot: PNG;
   threshold: number | null | undefined;
   pixelThreshold: number | null | undefined;
+  exitOnMismatch: boolean;
 }) => Promise<void> = async ({
   client,
   baseReplayId,
@@ -29,6 +30,7 @@ export const diffScreenshots: (options: {
   headScreenshot,
   threshold: threshold_,
   pixelThreshold,
+  exitOnMismatch,
 }) => {
   const threshold = threshold_ || DEFAULT_MISMATCH_THRESHOLD;
 
@@ -65,7 +67,10 @@ export const diffScreenshots: (options: {
 
   if (mismatchFraction > threshold) {
     console.log("Screenshots do not match!");
-    process.exit(1);
+    if (exitOnMismatch) {
+      process.exit(1);
+    }
+    throw new Error("Screenshots do not match!");
   }
 };
 
@@ -102,6 +107,7 @@ const handler: (options: Options) => Promise<void> = async ({
     headScreenshot,
     threshold,
     pixelThreshold,
+    exitOnMismatch: true,
   });
 };
 

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -1,0 +1,8 @@
+export interface TestCase {
+  sessionId: string;
+  baseReplayId: string;
+}
+
+export interface MeticulousCliConfig {
+  testCases?: TestCase[];
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,8 @@
+export { downloadReplay } from "./commands/download-replay/download-replay.command";
 export { downloadSession } from "./commands/download-session/download-session.command";
 export { record } from "./commands/record/record.command";
 export { replay } from "./commands/replay/replay.command";
+export { runAllTests } from "./commands/run-all-tests/run-all-tests.command";
+export { screenshotDiff } from "./commands/screenshot-diff/screenshot-diff.command";
 export { showProject } from "./commands/show-project/show-project.command";
 export { uploadBuild } from "./commands/upload-build/upload-build.command";

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,6 +3,7 @@ import { downloadReplay } from "./commands/download-replay/download-replay.comma
 import { downloadSession } from "./commands/download-session/download-session.command";
 import { record } from "./commands/record/record.command";
 import { replay } from "./commands/replay/replay.command";
+import { runAllTests } from "./commands/run-all-tests/run-all-tests.command";
 import { screenshotDiff } from "./commands/screenshot-diff/screenshot-diff.command";
 import { showProject } from "./commands/show-project/show-project.command";
 import { uploadBuild } from "./commands/upload-build/upload-build.command";
@@ -26,6 +27,7 @@ export const main: () => void = () => {
     .command(downloadSession)
     .command(record)
     .command(replay)
+    .command(runAllTests)
     .command(screenshotDiff)
     .command(showProject)
     .command(uploadBuild)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,7 +1772,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@^7.0.0:
+cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==


### PR DESCRIPTION
Usage:

1. Create a test case:
```
npx replay --apiToken=<TOKEN> --sessionId=<SESSION_ID> --appUrl=<APP_URL> --screenshot --headless --save
```

2. Run all tests (e.g. in CI):
```
npx run-all-tests --apiToken=<TOKEN> --appUrl=<APP_URL> --headless
```