### PR TITLE
Add Sentry to report CLI failures

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "cli:dev": "ts-node src/main.ts"
   },
   "dependencies": {
+    "@sentry/node": "^6.19.7",
     "adm-zip": "^0.5.9",
     "archiver": "^5.3.0",
     "axios": "^0.25.0",

--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -6,6 +6,7 @@ import {
   getOrFetchRecordedSession,
   getOrFetchRecordedSessionData,
 } from "../../local-data/sessions";
+import { wrapHandler } from "../../utils/sentry.utils";
 
 interface Options {
   apiToken?: string | null | undefined;
@@ -78,5 +79,5 @@ export const debugReplay: CommandModule<unknown, Options> = {
       description: "Open Chrome Dev Tools",
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/download-replay/download-replay.command.ts
+++ b/packages/cli/src/commands/download-replay/download-replay.command.ts
@@ -4,6 +4,7 @@ import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
 } from "../../local-data/replays";
+import { wrapHandler } from "../../utils/sentry.utils";
 
 interface Options {
   apiToken?: string | null | undefined;
@@ -32,5 +33,5 @@ export const downloadReplay: CommandModule<unknown, Options> = {
       demandOption: true,
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/download-session/download-session.command.ts
+++ b/packages/cli/src/commands/download-session/download-session.command.ts
@@ -4,6 +4,7 @@ import {
   getOrFetchRecordedSession,
   getOrFetchRecordedSessionData,
 } from "../../local-data/sessions";
+import { wrapHandler } from "../../utils/sentry.utils";
 
 interface Options {
   apiToken?: string | null | undefined;
@@ -32,5 +33,5 @@ export const downloadSession: CommandModule<unknown, Options> = {
       demandOption: true,
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -10,6 +10,7 @@ import {
 import { getMeticulousLocalDataDir } from "../../local-data/local-data";
 import { fetchAsset } from "../../local-data/replay-assets";
 import { getCommitSha } from "../../utils/commit-sha.utils";
+import { wrapHandler } from "../../utils/sentry.utils";
 
 interface Options {
   apiToken?: string | null | undefined;
@@ -128,5 +129,5 @@ export const record: CommandModule<unknown, Options> = {
       default: true,
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -29,6 +29,7 @@ import {
   getOrFetchRecordedSessionData,
 } from "../../local-data/sessions";
 import { getCommitSha } from "../../utils/commit-sha.utils";
+import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 import { diffScreenshots } from "../screenshot-diff/screenshot-diff.command";
 
@@ -264,6 +265,10 @@ export const replayCommandHandler: (options: Options) => Promise<any> = async ({
   return replay;
 };
 
+const handler: (options: Options) => Promise<void> = async (options) => {
+  await replayCommandHandler({ ...options, exitOnMismatch: true });
+};
+
 export const replay: CommandModule<unknown, Options> = {
   command: "replay",
   describe: "Replay a recorded session",
@@ -315,6 +320,5 @@ export const replay: CommandModule<unknown, Options> = {
         "Adds the replay to the list of test cases in meticulous.json",
     },
   },
-  handler: (options: Options) =>
-    replayCommandHandler({ ...options, exitOnMismatch: true }),
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -9,6 +9,7 @@ import { readConfig } from "../../config/config";
 import { TestCaseResult } from "../../config/config.types";
 import { getCommitSha } from "../../utils/commit-sha.utils";
 import { writeGitHubSummary } from "../../utils/github-summary.utils";
+import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 import { replayCommandHandler } from "../replay/replay.command";
 import { DiffError } from "../screenshot-diff/screenshot-diff.command";
@@ -163,5 +164,5 @@ export const runAllTests: CommandModule<unknown, Options> = {
       description: "Outputs a summary page for GitHub actions",
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -10,6 +10,7 @@ import {
   readReplayScreenshot,
 } from "../../local-data/replays";
 import { writeScreenshotDiff } from "../../local-data/screenshot-diffs";
+import { wrapHandler } from "../../utils/sentry.utils";
 
 const DEFAULT_MISMATCH_THRESHOLD = 0.01;
 
@@ -166,5 +167,5 @@ export const screenshotDiff: CommandModule<unknown, Options> = {
       number: true,
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/show-project/show-project.command.ts
+++ b/packages/cli/src/commands/show-project/show-project.command.ts
@@ -1,6 +1,7 @@
 import { CommandModule } from "yargs";
 import { createClient } from "../../api/client";
 import { getProject } from "../../api/project.api";
+import { wrapHandler } from "../../utils/sentry.utils";
 
 interface Options {
   apiToken?: string | null | undefined;
@@ -24,5 +25,5 @@ export const showProject: CommandModule<unknown, Options> = {
       string: true,
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/commands/upload-build/upload-build.command.ts
+++ b/packages/cli/src/commands/upload-build/upload-build.command.ts
@@ -13,6 +13,7 @@ import {
   deleteArchive,
 } from "../../archive/archive";
 import { getCommitSha } from "../../utils/commit-sha.utils";
+import { wrapHandler } from "../../utils/sentry.utils";
 
 interface Options {
   apiToken?: string | null | undefined;
@@ -106,5 +107,5 @@ export const uploadBuild: CommandModule<unknown, Options> = {
       demandOption: true,
     },
   },
-  handler,
+  handler: wrapHandler(handler),
 };

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -9,6 +9,7 @@ import { screenshotDiff } from "./commands/screenshot-diff/screenshot-diff.comma
 import { showProject } from "./commands/show-project/show-project.command";
 import { uploadBuild } from "./commands/upload-build/upload-build.command";
 import { getMeticulousLocalDataDir } from "./local-data/local-data";
+import { initSentry, setOptions } from "./utils/sentry.utils";
 
 const handleDataDir: (dataDir: string | null | undefined) => void = (
   dataDir
@@ -17,6 +18,8 @@ const handleDataDir: (dataDir: string | null | undefined) => void = (
 };
 
 export const main: () => void = () => {
+  initSentry();
+
   const promise = yargs
     .scriptName("meticulous")
     .usage(
@@ -42,7 +45,10 @@ export const main: () => void = () => {
         description: "Where Meticulous stores data (sessions, replays, etc.)",
       },
     })
-    .middleware([(argv) => handleDataDir(argv.dataDir)]).argv;
+    .middleware([
+      (argv) => handleDataDir(argv.dataDir),
+      (argv) => setOptions(argv),
+    ]).argv;
 
   if (promise instanceof Promise) {
     promise.catch((error) => {

--- a/packages/cli/src/utils/sentry.utils.ts
+++ b/packages/cli/src/utils/sentry.utils.ts
@@ -1,0 +1,34 @@
+import * as Sentry from "@sentry/node";
+import { Duration } from "luxon";
+
+const SENTRY_DSN =
+  "https://10c6a6c9f5434786b37fb81b01323798@o914390.ingest.sentry.io/6435232";
+const SENTRY_FLUSH_TIMEOUT = Duration.fromObject({ seconds: 1 });
+
+export const initSentry: () => void = () => {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+  });
+};
+
+export const setOptions: (options: any) => void = (options) => {
+  Sentry.setContext("invoke-options", options);
+};
+
+export const reportHandlerError: (error: any) => Promise<void> = async (
+  error
+) => {
+  Sentry.captureException(error);
+  await Sentry.flush(SENTRY_FLUSH_TIMEOUT.toMillis());
+};
+
+export const wrapHandler = function wrapHandler_<T>(
+  handler: (args: T) => Promise<void>
+): (args: T) => Promise<void> {
+  return async (args: T) => {
+    await handler(args).catch(async (error) => {
+      await reportHandlerError(error);
+      throw error;
+    });
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,6 +1029,62 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz#6801033be7ff87a6b7cadaf5b337c9f366a3c4b0"
   integrity sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw==
 
+"@sentry/core@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.7.tgz#156aaa56dd7fad8c89c145be6ad7a4f7209f9785"
+  integrity sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==
+  dependencies:
+    "@sentry/hub" "6.19.7"
+    "@sentry/minimal" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.7.tgz#58ad7776bbd31e9596a8ec46365b45cd8b9cfd11"
+  integrity sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==
+  dependencies:
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.7.tgz#b3ee46d6abef9ef3dd4837ebcb6bdfd01b9aa7b4"
+  integrity sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==
+  dependencies:
+    "@sentry/hub" "6.19.7"
+    "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/node@^6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.19.7.tgz#32963b36b48daebbd559e6f13b1deb2415448592"
+  integrity sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==
+  dependencies:
+    "@sentry/core" "6.19.7"
+    "@sentry/hub" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
+  integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
+
+"@sentry/utils@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.19.7.tgz#6edd739f8185fd71afe49cbe351c1bbf5e7b7c79"
+  integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
+  dependencies:
+    "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
+
 "@tailwindcss/forms@^0.5.1":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.1.tgz#7fe86b9b67e6d91cb902e2d3f4ebe561cc057a13"
@@ -2208,6 +2264,11 @@ conventional-recommended-bump@^6.1.0:
     git-semver-tags "^4.1.1"
     meow "^8.0.0"
     q "^1.5.1"
+
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-js-pure@^3.20.2:
   version "3.22.5"
@@ -4247,6 +4308,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 luxon@^2.2.0:
   version "2.3.1"
@@ -6434,7 +6500,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
* Add Sentry for error reporting
* Invoke options are captured.

Note: some command handlers also exit by calling `process.exit(1)` which is not instrumented yet.