### PR TITLE
Default to https for app URL

### DIFF
--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -11,7 +11,7 @@ import { wrapHandler } from "../../utils/sentry.utils";
 interface Options {
   apiToken?: string | null | undefined;
   sessionId: string;
-  appUrl: string;
+  appUrl?: string | null | undefined;
   devTools?: boolean | null | undefined;
 }
 
@@ -47,7 +47,7 @@ const handler: (options: Options) => Promise<void> = async ({
   // 5. Start replay debugger
   const createReplayerParams: Parameters<typeof createReplayer>[0] = {
     sessionData,
-    appUrl,
+    appUrl: appUrl || "",
     devTools: devTools || false,
     dependencies: {
       replayDebugger: {
@@ -72,7 +72,6 @@ export const debugReplay: CommandModule<unknown, Options> = {
     },
     appUrl: {
       string: true,
-      demandOption: true,
     },
     devTools: {
       boolean: true,

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -37,7 +37,7 @@ interface Options {
   apiToken?: string | null | undefined;
   commitSha?: string | null | undefined;
   sessionId: string;
-  appUrl: string;
+  appUrl?: string | null | undefined;
   headless?: boolean | null | undefined;
   devTools?: boolean | null | undefined;
   screenshot?: boolean | null | undefined;
@@ -116,7 +116,7 @@ export const replayCommandHandler: (options: Options) => Promise<any> = async ({
 
   // 6. Create and save replay parameters
   const replayEventsParams: Parameters<typeof replayEvents>[0] = {
-    appUrl,
+    appUrl: appUrl || "",
     browser: null,
     tempDir,
     session,
@@ -285,7 +285,6 @@ export const replay: CommandModule<unknown, Options> = {
     },
     appUrl: {
       string: true,
-      demandOption: true,
     },
     headless: {
       boolean: true,

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -17,7 +17,7 @@ import { DiffError } from "../screenshot-diff/screenshot-diff.command";
 interface Options {
   apiToken?: string | null | undefined;
   commitSha?: string | null | undefined;
-  appUrl: string;
+  appUrl?: string | null | undefined;
   headless?: boolean | null | undefined;
   devTools?: boolean | null | undefined;
   diffThreshold?: number | null | undefined;
@@ -143,7 +143,6 @@ export const runAllTests: CommandModule<unknown, Options> = {
     },
     appUrl: {
       string: true,
-      demandOption: true,
     },
     headless: {
       boolean: true,

--- a/packages/replay-debugger/src/replayer/replay.utils.ts
+++ b/packages/replay-debugger/src/replayer/replay.utils.ts
@@ -11,17 +11,34 @@ export interface ReplayEventsDependencies extends BaseReplayEventsDependencies {
   replayDebugger: ReplayEventsDependency<"replayDebugger">;
 }
 
-export const getStartUrl = ({
+const getAppUrl: (options: { sessionData: any; appUrl: string }) => string = ({
   sessionData,
   appUrl,
-}: {
+}) => {
+  if (!appUrl) {
+    const { startUrl, startURL } = sessionData.userEvents.window;
+    return startUrl || startURL;
+  }
+  try {
+    const url = new URL(appUrl);
+    return url.toString();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      const urlHttps = new URL(`https://${appUrl}`);
+      return urlHttps.toString();
+    }
+    throw error;
+  }
+};
+
+export const getStartUrl: (options: {
   sessionData: any;
   appUrl: string;
-}) => {
+}) => string = ({ sessionData, appUrl }) => {
   const { startUrl, startURL } = sessionData.userEvents.window;
 
   // Default to the base URL if we did not record startURL (legacy sessions)
-  const appUrlObj = new URL(appUrl);
+  const appUrlObj = new URL(getAppUrl({ sessionData, appUrl }));
   const startRouteUrl =
     appUrlObj.pathname === "/" && !appUrlObj.search && !appUrlObj.hash
       ? new URL(startUrl || startURL)

--- a/packages/replayer/src/replayer/replay.utils.ts
+++ b/packages/replayer/src/replayer/replay.utils.ts
@@ -57,6 +57,47 @@ export interface ReplayEventsDependencies extends BaseReplayEventsDependencies {
   rrweb: ReplayEventsDependency<"rrweb">;
 }
 
+const getAppUrl: (options: { sessionData: any; appUrl: string }) => string = ({
+  sessionData,
+  appUrl,
+}) => {
+  if (!appUrl) {
+    const { startUrl, startURL } = sessionData.userEvents.window;
+    return startUrl || startURL;
+  }
+  try {
+    const url = new URL(appUrl);
+    return url.toString();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      const urlHttps = new URL(`https://${appUrl}`);
+      return urlHttps.toString();
+    }
+    throw error;
+  }
+};
+
+export const getStartUrl: (options: {
+  sessionData: any;
+  appUrl: string;
+}) => string = ({ sessionData, appUrl }) => {
+  const { startUrl, startURL } = sessionData.userEvents.window;
+
+  // Default to the base URL if we did not record startURL (legacy sessions)
+  const appUrlObj = new URL(getAppUrl({ sessionData, appUrl }));
+  const startRouteUrl =
+    appUrlObj.pathname === "/" && !appUrlObj.search && !appUrlObj.hash
+      ? new URL(startUrl || startURL)
+      : appUrlObj;
+  startRouteUrl.host = appUrlObj.host;
+  startRouteUrl.port = appUrlObj.port;
+  startRouteUrl.protocol = appUrlObj.protocol;
+  startRouteUrl.username = appUrlObj.username;
+  startRouteUrl.password = appUrlObj.password;
+
+  return startRouteUrl.toString();
+};
+
 // This utility function sets up polly, jsreplay, reanimator and logging.
 export async function bootstrapPage(
   page: Page,


### PR DESCRIPTION
Makes `appUrl` optional. Replay will use the start URL if `appUrl`
is not provided.