### PR TITLE
Replay: add option to bypass CSP

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -40,6 +40,7 @@ interface Options {
   appUrl?: string | null | undefined;
   headless?: boolean | null | undefined;
   devTools?: boolean | null | undefined;
+  bypassCSP?: boolean | null | undefined;
   screenshot?: boolean | null | undefined;
   screenshotSelector?: string | null | undefined;
   baseReplayId?: string | null | undefined;
@@ -56,6 +57,7 @@ export const replayCommandHandler: (options: Options) => Promise<any> = async ({
   appUrl,
   headless,
   devTools,
+  bypassCSP,
   screenshot,
   screenshotSelector,
   baseReplayId: baseReplayId_,
@@ -125,6 +127,7 @@ export const replayCommandHandler: (options: Options) => Promise<any> = async ({
     meticulousSha: "meticulousSha",
     headless: headless || false,
     devTools: devTools || false,
+    bypassCSP: bypassCSP || false,
     dependencies: {
       reanimator: {
         key: "reanimator",

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -20,6 +20,7 @@ interface Options {
   appUrl?: string | null | undefined;
   headless?: boolean | null | undefined;
   devTools?: boolean | null | undefined;
+  bypassCSP?: boolean | null | undefined;
   diffThreshold?: number | null | undefined;
   diffPixelThreshold?: number | null | undefined;
   githubSummary?: boolean | null | undefined;
@@ -31,6 +32,7 @@ const handler: (options: Options) => Promise<void> = async ({
   appUrl,
   headless,
   devTools,
+  bypassCSP,
   diffThreshold,
   diffPixelThreshold,
   githubSummary,
@@ -69,6 +71,7 @@ const handler: (options: Options) => Promise<void> = async ({
       appUrl,
       headless,
       devTools,
+      bypassCSP,
       screenshot: true,
       baseReplayId,
       diffThreshold,

--- a/packages/replayer/src/replayer/replay-events.ts
+++ b/packages/replayer/src/replayer/replay-events.ts
@@ -24,6 +24,7 @@ export interface ReplayEventsOptions {
   meticulousSha: string;
   headless?: boolean;
   devTools?: boolean;
+  bypassCSP?: boolean;
   verbose?: boolean;
   dependencies: ReplayEventsDependencies;
   screenshot?: boolean;
@@ -42,6 +43,7 @@ export const replayEvents: (options: ReplayEventsOptions) => Promise<{
     meticulousSha,
     headless,
     devTools,
+    bypassCSP,
     verbose,
     dependencies,
   } = options;
@@ -70,6 +72,10 @@ export const replayEvents: (options: ReplayEventsOptions) => Promise<{
   const page = await context.newPage();
   console.log("Created page");
   page.setDefaultNavigationTimeout(120000); // 2 minutes
+
+  if (bypassCSP) {
+    await page.setBypassCSP(true);
+  }
 
   // Set viewport
   await page.setViewport({


### PR DESCRIPTION
* Content Security Policies may prevent replay from loading js snippets