### PR TITLE
Fix GitHub action summary option

### DIFF
--- a/packages/cli/src/utils/github-summary.utils.ts
+++ b/packages/cli/src/utils/github-summary.utils.ts
@@ -1,13 +1,20 @@
-import { writeFile } from "fs/promises";
+import { appendFile } from "fs/promises";
 import { getTestRunUrl, TestRun } from "../api/test-run.api";
 import { TestCaseResult } from "../config/config.types";
-
-const GITHUB_SUMMARY_FILE = "github-summary.md";
 
 export const writeGitHubSummary: (options: {
   testRun: TestRun;
   results: TestCaseResult[];
 }) => Promise<void> = async ({ testRun, results }) => {
+  const summaryFile = process.env["GITHUB_STEP_SUMMARY"] || "";
+
+  if (!summaryFile) {
+    console.log(
+      "Warning: $GITHUB_STEP_SUMMARY is not defined, skipping writing GitHub action summary"
+    );
+    return;
+  }
+
   const testRunUrl = getTestRunUrl(testRun);
 
   const summary = `# Test Results
@@ -32,5 +39,5 @@ ${results
 </table>
 `;
 
-  await writeFile(GITHUB_SUMMARY_FILE, summary, "utf-8");
+  await appendFile(summaryFile, summary, "utf-8");
 };


### PR DESCRIPTION
* We now directly write to the file located at `$GITHUB_STEP_SUMMARY`.