### PR TITLE
Run meticulous tests in parallel if requested

### DIFF
--- a/packages/cli/src/parallel-tests/messages.types.ts
+++ b/packages/cli/src/parallel-tests/messages.types.ts
@@ -1,0 +1,30 @@
+import log from "loglevel";
+import { TestCase, TestCaseResult } from "../config/config.types";
+
+export interface InitMessage {
+  kind: "init";
+  data: {
+    logLevel: log.LogLevel[keyof log.LogLevel];
+    dataDir: string;
+    runAllOptions: {
+      apiToken: string | null | undefined;
+      commitSha: string | null | undefined;
+      appUrl: string | null | undefined;
+      headless: boolean | null | undefined;
+      devTools: boolean | null | undefined;
+      bypassCSP: boolean | null | undefined;
+      diffThreshold: number | null | undefined;
+      diffPixelThreshold: number | null | undefined;
+      padTime: boolean;
+      networkStubbing: boolean;
+    };
+    testCase: TestCase;
+  };
+}
+
+export interface ResultMessage {
+  kind: "result";
+  data: {
+    result: TestCaseResult;
+  };
+}

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -1,0 +1,178 @@
+import {
+  defer,
+  getMeticulousLocalDataDir,
+  METICULOUS_LOGGER_NAME,
+} from "@alwaysmeticulous/common";
+import { AxiosInstance } from "axios";
+import { fork } from "child_process";
+import log from "loglevel";
+import { cpus } from "os";
+import { join } from "path";
+import { putTestRunResults, TestRun } from "../api/test-run.api";
+import {
+  MeticulousCliConfig,
+  TestCase,
+  TestCaseResult,
+} from "../config/config.types";
+import { InitMessage, ResultMessage } from "./messages.types";
+
+export interface RunAllTestsInParallelOptions {
+  config: MeticulousCliConfig;
+  client: AxiosInstance;
+  testRun: TestRun;
+  apiToken: string | null | undefined;
+  commitSha: string | null | undefined;
+  appUrl: string | null | undefined;
+  headless: boolean | null | undefined;
+  devTools: boolean | null | undefined;
+  bypassCSP: boolean | null | undefined;
+  diffThreshold: number | null | undefined;
+  diffPixelThreshold: number | null | undefined;
+  padTime: boolean;
+  networkStubbing: boolean;
+  parallelTasks: number | null | undefined;
+}
+
+/** Handler for running Meticulous tests in parallel using child processes */
+export const runAllTestsInParallel: (
+  options: RunAllTestsInParallelOptions
+) => Promise<TestCaseResult[]> = async ({
+  config,
+  client,
+  testRun,
+  apiToken,
+  commitSha,
+  appUrl,
+  headless,
+  devTools,
+  bypassCSP,
+  diffThreshold,
+  diffPixelThreshold,
+  padTime,
+  networkStubbing,
+  parallelTasks,
+}) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  const results: TestCaseResult[] = [];
+  const queue = [...(config.testCases || [])];
+
+  const allTasksDone = defer<void>();
+
+  let inProgress = 0;
+  const maxTasks = parallelTasks ?? Math.max(cpus().length, 1);
+  logger.debug(`Running with ${maxTasks} maximum tasks in parallel`);
+
+  const taskHandler = join(__dirname, "task.handler.js");
+
+  // Starts running a test case in a child process
+  const startTask = (testCase: TestCase) => {
+    const deferredResult = defer<TestCaseResult>();
+    const child = fork(taskHandler, [], { stdio: "inherit" });
+
+    const messageHandler = (message: unknown) => {
+      if (
+        message &&
+        typeof message === "object" &&
+        (message as any)["kind"] === "result"
+      ) {
+        const resultMessage = message as ResultMessage;
+        deferredResult.resolve(resultMessage.data.result);
+        child.off("message", messageHandler);
+      }
+    };
+
+    child.on("error", (error) => {
+      if (deferredResult.getState() === "pending") {
+        deferredResult.reject(error);
+      }
+    });
+    child.on("exit", (code) => {
+      if (code) {
+        logger.debug(`child exited with code: ${code}`);
+      }
+      if (deferredResult.getState() === "pending") {
+        deferredResult.reject(new Error("No result"));
+      }
+    });
+    child.on("message", messageHandler);
+
+    // Send test case and arguments to child process
+    const initMessage: InitMessage = {
+      kind: "init",
+      data: {
+        logLevel: logger.getLevel(),
+        dataDir: getMeticulousLocalDataDir(),
+        runAllOptions: {
+          apiToken,
+          commitSha,
+          appUrl,
+          headless,
+          devTools,
+          bypassCSP,
+          diffThreshold,
+          diffPixelThreshold,
+          padTime,
+          networkStubbing,
+        },
+        testCase,
+      },
+    };
+    child.send(initMessage);
+
+    // Handle task completion
+    deferredResult.promise
+      .catch(() => {
+        const result: TestCaseResult = {
+          ...testCase,
+          headReplayId: "",
+          result: "fail",
+        };
+        return result;
+      })
+      .then(async (result) => {
+        --inProgress;
+
+        results.push(result);
+        putTestRunResults({
+          client,
+          testRunId: testRun.id,
+          status: "Running",
+          resultData: { results },
+        })
+          .catch((error) => {
+            logger.error(`Error while pushing partial results: ${error}`);
+          })
+          .then(() => {
+            if (results.length === (config.testCases?.length || 0)) {
+              allTasksDone.resolve();
+            }
+          });
+
+        process.nextTick(checkNextTask);
+      });
+  };
+
+  // Checks if we can start a new child process
+  const checkNextTask = () => {
+    if (inProgress >= maxTasks) {
+      return;
+    }
+
+    const testCase = queue.shift();
+    if (!testCase) {
+      return;
+    }
+    ++inProgress;
+
+    startTask(testCase);
+
+    process.nextTick(checkNextTask);
+  };
+
+  process.nextTick(checkNextTask);
+
+  await allTasksDone.promise;
+
+  return results;
+};

--- a/packages/cli/src/parallel-tests/task.handler.ts
+++ b/packages/cli/src/parallel-tests/task.handler.ts
@@ -1,0 +1,122 @@
+import {
+  getMeticulousLocalDataDir,
+  METICULOUS_LOGGER_NAME,
+} from "@alwaysmeticulous/common";
+import log from "loglevel";
+import { Duration } from "luxon";
+import { replayCommandHandler } from "../commands/replay/replay.command";
+import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
+import { TestCaseResult } from "../config/config.types";
+import { initLogger } from "../utils/logger.utils";
+import { InitMessage, ResultMessage } from "./messages.types";
+
+const INIT_TIMEOUT = Duration.fromObject({ second: 1 });
+
+const waitForInitMessage: () => Promise<InitMessage> = () => {
+  return Promise.race([
+    new Promise<InitMessage>((resolve) => {
+      const messageHandler = (message: unknown) => {
+        if (
+          message &&
+          typeof message === "object" &&
+          (message as any)["kind"] === "init"
+        ) {
+          const initMessage = message as InitMessage;
+          resolve(initMessage);
+          process.off("message", messageHandler);
+        }
+      };
+
+      process.on("message", messageHandler);
+    }),
+    new Promise<InitMessage>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error("Timed out waiting for init message"));
+      }, INIT_TIMEOUT.toMillis());
+    }),
+  ]);
+};
+
+const main = async () => {
+  initLogger();
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  if (!process.send) {
+    console.error("Error: not started as a child process");
+    process.exit(1);
+  }
+
+  const initMessage = await waitForInitMessage();
+
+  const { logLevel, dataDir, runAllOptions, testCase } = initMessage.data;
+  logger.setLevel(logLevel);
+  getMeticulousLocalDataDir(dataDir);
+
+  const {
+    apiToken,
+    commitSha,
+    appUrl,
+    headless,
+    devTools,
+    bypassCSP,
+    diffThreshold,
+    diffPixelThreshold,
+    padTime,
+    networkStubbing,
+  } = runAllOptions;
+  const { sessionId, baseReplayId, options } = testCase;
+
+  const replayPromise = replayCommandHandler({
+    apiToken,
+    commitSha,
+    sessionId,
+    appUrl,
+    headless,
+    devTools,
+    bypassCSP,
+    screenshot: true,
+    baseReplayId,
+    diffThreshold,
+    diffPixelThreshold,
+    save: false,
+    exitOnMismatch: false,
+    padTime,
+    networkStubbing,
+    ...options,
+  });
+  const result: TestCaseResult = await replayPromise
+    .then(
+      (replay) =>
+        ({
+          ...testCase,
+          headReplayId: replay.id,
+          result: "pass",
+        } as TestCaseResult)
+    )
+    .catch((error) => {
+      if (error instanceof DiffError && error.extras) {
+        return {
+          ...testCase,
+          headReplayId: error.extras.headReplayId,
+          result: "fail",
+        };
+      }
+      logger.error(error);
+      return { ...testCase, headReplayId: "", result: "fail" };
+    });
+
+  const resultMessage: ResultMessage = {
+    kind: "result",
+    data: {
+      result,
+    },
+  };
+
+  process.send(resultMessage);
+  process.disconnect();
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/common/src/defer.ts
+++ b/packages/common/src/defer.ts
@@ -1,0 +1,32 @@
+export type DeferredStatus = "pending" | "fulfilled" | "rejected";
+
+export interface Deferred<T = void> {
+  resolve: (value: T) => void;
+  reject: (reason?: any) => void;
+  promise: Promise<T>;
+  getState: () => DeferredStatus;
+}
+
+export function defer<T = void>(): Deferred<T> {
+  let state: DeferredStatus = "pending";
+  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
+  let reject: ((reason?: any) => void) | null = null;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.then(
+    () => {
+      state = "fulfilled";
+    },
+    () => {
+      state = "rejected";
+    }
+  );
+  return {
+    resolve: resolve as any,
+    reject: reject as any,
+    promise,
+    getState: () => state,
+  };
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,3 +1,4 @@
+export { defer, Deferred, DeferredStatus } from "./defer";
 export { getMeticulousLocalDataDir } from "./local-data/local-data";
 export { METICULOUS_LOGGER_NAME } from "./logger/console-logger";
 export { DebugLogger } from "./logger/debug-logger";


### PR DESCRIPTION
Adds `--parallelize` and `--parallelTasks` options to the `run-all-tests` test command to run Meticulous replay tests in parallel.

With `--parallelize`, a child process is spawned for each replay.