### PR TITLE
Add --deflake options to run-all-tests command

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -37,7 +37,7 @@ import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 import { diffScreenshots } from "../screenshot-diff/screenshot-diff.command";
 
-interface Options {
+export interface ReplayCommandHandlerOptions {
   apiToken?: string | null | undefined;
   commitSha?: string | null | undefined;
   sessionId: string;
@@ -59,7 +59,9 @@ interface Options {
   cookiesFile?: string | null | undefined;
 }
 
-export const replayCommandHandler: (options: Options) => Promise<any> = async ({
+export const replayCommandHandler: (
+  options: ReplayCommandHandlerOptions
+) => Promise<any> = async ({
   apiToken,
   commitSha: commitSha_,
   sessionId,
@@ -291,11 +293,13 @@ export const replayCommandHandler: (options: Options) => Promise<any> = async ({
   return replay;
 };
 
-const handler: (options: Options) => Promise<void> = async (options) => {
+const handler: (options: ReplayCommandHandlerOptions) => Promise<void> = async (
+  options
+) => {
   await replayCommandHandler({ ...options, exitOnMismatch: true });
 };
 
-export const replay: CommandModule<unknown, Options> = {
+export const replay: CommandModule<unknown, ReplayCommandHandlerOptions> = {
   command: "replay",
   describe: "Replay a recorded session",
   builder: {

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -1,0 +1,64 @@
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import log from "loglevel";
+import {
+  replayCommandHandler,
+  ReplayCommandHandlerOptions,
+} from "../commands/replay/replay.command";
+import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
+import { TestCase, TestCaseResult } from "../config/config.types";
+
+const handleReplay: (options: {
+  testCase: TestCase;
+  options: ReplayCommandHandlerOptions;
+}) => Promise<TestCaseResult> = async ({ testCase, options }) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  const replayPromise = replayCommandHandler(options);
+  const result: TestCaseResult = await replayPromise
+    .then(
+      (replay) =>
+        ({
+          ...testCase,
+          headReplayId: replay.id,
+          result: "pass",
+        } as TestCaseResult)
+    )
+    .catch((error) => {
+      if (error instanceof DiffError && error.extras) {
+        return {
+          ...testCase,
+          headReplayId: error.extras.headReplayId,
+          result: "fail",
+        };
+      }
+      logger.error(error);
+      return { ...testCase, headReplayId: "", result: "fail" };
+    });
+  return result;
+};
+
+export interface DeflakeReplayCommandHandlerOptions
+  extends ReplayCommandHandlerOptions {
+  testCase: TestCase;
+  deflake: boolean;
+}
+
+export const deflakeReplayCommandHandler: (
+  options: DeflakeReplayCommandHandlerOptions
+) => Promise<TestCaseResult> = async ({ testCase, deflake, ...options }) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  const firstResult = await handleReplay({ testCase, options });
+  if (firstResult.result === "pass" || !deflake) {
+    return firstResult;
+  }
+
+  const secondResult = await handleReplay({ testCase, options });
+  if (secondResult.result === "fail") {
+    return secondResult;
+  }
+
+  const thirdResult = await handleReplay({ testCase, options });
+  logger.info(`FLAKE: ${thirdResult.title} => ${thirdResult.result}`);
+  return thirdResult;
+};

--- a/packages/cli/src/parallel-tests/messages.types.ts
+++ b/packages/cli/src/parallel-tests/messages.types.ts
@@ -19,6 +19,7 @@ export interface InitMessage {
       networkStubbing: boolean;
     };
     testCase: TestCase;
+    deflake: boolean;
   };
 }
 

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -31,6 +31,7 @@ export interface RunAllTestsInParallelOptions {
   padTime: boolean;
   networkStubbing: boolean;
   parallelTasks: number | null | undefined;
+  deflake: boolean;
 }
 
 /** Handler for running Meticulous tests in parallel using child processes */
@@ -51,6 +52,7 @@ export const runAllTestsInParallel: (
   padTime,
   networkStubbing,
   parallelTasks,
+  deflake,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -116,6 +118,7 @@ export const runAllTestsInParallel: (
           networkStubbing,
         },
         testCase,
+        deflake,
       },
     };
     child.send(initMessage);


### PR DESCRIPTION
Current deflaking steps:
1. Run the test case (run #1)
2. If run #1 is 'pass' then return 'pass'
3. Run the test case (run #2)
4. If run #2 is 'fail' then return 'fail'
5. Run the test case (run #3)
6. Return result of run #3

This is makes the test pass if both re-runs pass after failure on the
initial run.