### PR TITLE
Add the update-tests command to update test cases

### DIFF
--- a/packages/cli/src/api/test-run.api.ts
+++ b/packages/cli/src/api/test-run.api.ts
@@ -1,9 +1,30 @@
-import { AxiosInstance } from "axios";
+import axios, { AxiosInstance } from "axios";
+import { TestCaseResult } from "../config/config.types";
 
 export interface TestRun {
   id: string;
+  status: "Running" | "Success" | "Failure";
+  resultData?: {
+    results: TestCaseResult[];
+    [key: string]: any;
+  };
   [key: string]: any;
 }
+
+export const getTestRun: (options: {
+  client: AxiosInstance;
+  testRunId: string;
+}) => Promise<TestRun | null> = async ({ client, testRunId }) => {
+  const { data } = await client.get(`test-runs/${testRunId}`).catch((error) => {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 404) {
+        return { data: null };
+      }
+    }
+    throw error;
+  });
+  return data;
+};
 
 export const createTestRun: (options: {
   client: AxiosInstance;

--- a/packages/cli/src/commands/update-tests/update-tests.command.ts
+++ b/packages/cli/src/commands/update-tests/update-tests.command.ts
@@ -1,0 +1,122 @@
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import log from "loglevel";
+import { CommandModule } from "yargs";
+import { createClient } from "../../api/client";
+import { getTestRun } from "../../api/test-run.api";
+import { readConfig, saveConfig } from "../../config/config";
+import { MeticulousCliConfig, TestCaseResult } from "../../config/config.types";
+import { wrapHandler } from "../../utils/sentry.utils";
+
+interface Options {
+  apiToken?: string | null | undefined;
+  testRunId: string;
+  accept?: string[] | null | undefined;
+  acceptAll?: boolean | null | undefined;
+}
+
+const handler: (options: Options) => Promise<void> = async ({
+  apiToken,
+  testRunId,
+  accept: accept_,
+  acceptAll: acceptAll_,
+}) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  const client = createClient({ apiToken });
+
+  const config = await readConfig();
+  const testCases = config.testCases || [];
+
+  if (!testCases.length) {
+    logger.error("Error! No test case defined");
+    process.exit(1);
+  }
+
+  const testRun = await getTestRun({ client, testRunId });
+  if (!testRun) {
+    logger.error(
+      "Error: Could not retrieve test run. Is the API token correct?"
+    );
+    process.exit(1);
+  }
+
+  if (testRun.status === "Success") {
+    logger.info("Test run successful, no tests to updates");
+    return;
+  }
+
+  if (testRun.status === "Running") {
+    logger.error("Error: Tests are still running");
+    process.exit(1);
+  }
+
+  const testRunResults = testRun.resultData?.results || [];
+
+  const accept = accept_ || [];
+  const acceptAll = acceptAll_ || false;
+  if (!acceptAll && !accept.length) {
+    throw new Error("One of --accept or --acceptAll needs to be specified.");
+  }
+
+  const testRunResultsBySessionId = new Map<string, TestCaseResult>();
+  testRunResults.forEach((result) => {
+    testRunResultsBySessionId.set(result.sessionId, result);
+  });
+
+  const newTestCases = testCases.map((testCase) => {
+    const { sessionId } = testCase;
+    const matched = testRunResultsBySessionId.get(sessionId);
+    if (!matched) {
+      logger.warn(`WARNING: ${sessionId} not found in test run`);
+      return testCase;
+    }
+
+    if (
+      matched.result === "pass" ||
+      (!acceptAll &&
+        !accept.find((replayId) => replayId === matched.headReplayId))
+    ) {
+      return testCase;
+    }
+
+    const headReplayId = matched.headReplayId || "";
+    if (!headReplayId) {
+      logger.warn(`WARNING: ${sessionId} has no new replay id`);
+      return testCase;
+    }
+
+    const newTestCase = { ...testCase, baseReplayId: headReplayId };
+    return newTestCase;
+  });
+
+  const newConfig: MeticulousCliConfig = {
+    ...config,
+    testCases: newTestCases,
+  };
+  await saveConfig(newConfig);
+};
+
+export const updateTests: CommandModule<unknown, Options> = {
+  command: "update-tests",
+  describe: "Updates test cases",
+  builder: {
+    apiToken: {
+      string: true,
+    },
+    testRunId: {
+      string: true,
+      demandOption: true,
+      description: "Test run id to fix",
+    },
+    accept: {
+      array: true,
+      description: "Replay ids to accept as valid",
+    },
+    acceptAll: {
+      boolean: true,
+      description: "Accept all failing tests as valid",
+      conflicts: "accept",
+    },
+  },
+  handler: wrapHandler(handler),
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,4 +6,5 @@ export { replay } from "./commands/replay/replay.command";
 export { runAllTests } from "./commands/run-all-tests/run-all-tests.command";
 export { screenshotDiff } from "./commands/screenshot-diff/screenshot-diff.command";
 export { showProject } from "./commands/show-project/show-project.command";
+export { updateTests } from "./commands/update-tests/update-tests.command";
 export { uploadBuild } from "./commands/upload-build/upload-build.command";

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -8,6 +8,7 @@ import { replay } from "./commands/replay/replay.command";
 import { runAllTests } from "./commands/run-all-tests/run-all-tests.command";
 import { screenshotDiff } from "./commands/screenshot-diff/screenshot-diff.command";
 import { showProject } from "./commands/show-project/show-project.command";
+import { updateTests } from "./commands/update-tests/update-tests.command";
 import { uploadBuild } from "./commands/upload-build/upload-build.command";
 import { initLogger, setLogLevel } from "./utils/logger.utils";
 import { initSentry, setOptions } from "./utils/sentry.utils";
@@ -37,6 +38,7 @@ export const main: () => void = () => {
     .command(runAllTests)
     .command(screenshotDiff)
     .command(showProject)
+    .command(updateTests)
     .command(uploadBuild)
     .help()
     .strict()


### PR DESCRIPTION
* `update-tests` can be used after running Meticulous tests to update
  the meticulous.json file with new reference replays