### PR TITLE
Replay resize events

### DIFF
--- a/packages/replay-debugger/src/replayer/replay-debugger.ui.ts
+++ b/packages/replay-debugger/src/replayer/replay-debugger.ui.ts
@@ -67,6 +67,21 @@ export const createReplayDebuggerUI: <T = ReplayableEvent>(
     event: T;
     target: JSHandle;
   }) => {
+    const { type } = event as any;
+    // Special handling for window events.
+    if (type.selector === "window") {
+      if (type === "resize") {
+        const { innerHeight, innerWidth } = event as any;
+        const viewport = { height: innerHeight, width: innerWidth };
+
+        await replayedPage.setViewport(viewport);
+        return;
+      }
+
+      console.log(`Unknown window event ${type}`);
+      return;
+    }
+
     await replayedPage.evaluate(
       (event, target) => {
         (window as any).__meticulous.replayFunctions.simulateEvent({

--- a/packages/replayer/src/index.ts
+++ b/packages/replayer/src/index.ts
@@ -1,2 +1,2 @@
 export { replayEvents } from "./replayer/replay-events";
-export { exposeMouseMove, getStartUrl } from "./replayer/replay.utils";
+export { getStartUrl } from "./replayer/replay.utils";


### PR DESCRIPTION
### Changes
This PR adds support for handling window resize events.

For simulation we expose a `setViewport` puppeteer function which is invoked as part of "resize" event simulation.