### PR TITLE
Use start URL from session metadata

### DIFF
--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -38,7 +38,7 @@ const handler: (options: Options) => Promise<void> = async ({
   const client = createClient({ apiToken });
 
   // 1. Check session files
-  await getOrFetchRecordedSession(client, sessionId);
+  const session = await getOrFetchRecordedSession(client, sessionId);
   const sessionData = await getOrFetchRecordedSessionData(client, sessionId);
 
   // 3. Load replay assets
@@ -66,6 +66,7 @@ const handler: (options: Options) => Promise<void> = async ({
 
   // 5. Start replay debugger
   const createReplayerParams: Parameters<typeof createReplayer>[0] = {
+    session,
     sessionData,
     appUrl: appUrl || "",
     devTools: devTools || false,

--- a/packages/common/src/types/replay-debugger.types.ts
+++ b/packages/common/src/types/replay-debugger.types.ts
@@ -2,7 +2,7 @@ import {
   BaseReplayEventsDependencies,
   ReplayEventsDependency,
 } from "./replay.types";
-import { SessionData } from "./session.types";
+import { RecordedSession, SessionData } from "./session.types";
 
 export interface ReplayDebuggerDependencies
   extends BaseReplayEventsDependencies {
@@ -12,6 +12,7 @@ export interface ReplayDebuggerDependencies
 }
 
 export interface ReplayDebuggerOptions {
+  session: RecordedSession;
   sessionData: SessionData;
   appUrl: string;
   devTools: boolean;

--- a/packages/replay-debugger/src/replayer/replayer.ts
+++ b/packages/replay-debugger/src/replayer/replayer.ts
@@ -9,6 +9,7 @@ import { bootstrapPage, setupPageCookies } from "./debugger.utils";
 import { createReplayDebuggerUI } from "./replay-debugger.ui";
 
 export const createReplayer: CreateReplayDebuggerFn = async ({
+  session,
   sessionData,
   appUrl,
   devTools,
@@ -61,7 +62,7 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     await setupPageCookies({ page, cookiesFile });
   }
 
-  const startUrl = getStartUrl({ sessionData, appUrl });
+  const startUrl = getStartUrl({ session, sessionData, appUrl });
   logger.debug(`Navigating to ${startUrl}...`);
   const res = await page.goto(startUrl, {
     waitUntil: "domcontentloaded",

--- a/packages/replayer/src/replayer/replay-events.ts
+++ b/packages/replayer/src/replayer/replay-events.ts
@@ -129,7 +129,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
   }
 
   // Navigate to the URL that the session originated on/from.
-  const startUrl = getStartUrl({ sessionData, appUrl });
+  const startUrl = getStartUrl({ session, sessionData, appUrl });
   logger.debug(`Navigating to ${startUrl}`);
   const res = await page.goto(startUrl, {
     waitUntil: "domcontentloaded",

--- a/packages/replayer/src/replayer/replay.utils.ts
+++ b/packages/replayer/src/replayer/replay.utils.ts
@@ -1,5 +1,6 @@
 import {
   METICULOUS_LOGGER_NAME,
+  RecordedSession,
   ReplayEventsDependencies,
   SessionData,
 } from "@alwaysmeticulous/common";
@@ -85,16 +86,20 @@ const getAppUrl: (options: { sessionData: any; appUrl: string }) => string = ({
 };
 
 export const getStartUrl: (options: {
+  session: RecordedSession;
   sessionData: any;
   appUrl: string;
-}) => string = ({ sessionData, appUrl }) => {
+}) => string = ({ session, sessionData, appUrl }) => {
+  // We prefer to use the start URL from the session metadata but default to
+  // startURLs present within the events data for backwards-compatibility.
+  const { startUrl: sessionStartUrl } = session;
   const { startUrl, startURL } = sessionData.userEvents.window;
 
   // Default to the base URL if we did not record startURL (legacy sessions)
   const appUrlObj = new URL(getAppUrl({ sessionData, appUrl }));
   const startRouteUrl =
     appUrlObj.pathname === "/" && !appUrlObj.search && !appUrlObj.hash
-      ? new URL(startUrl || startURL)
+      ? new URL(sessionStartUrl || startUrl || startURL)
       : appUrlObj;
   startRouteUrl.host = appUrlObj.host;
   startRouteUrl.port = appUrlObj.port;


### PR DESCRIPTION
### Motivation

The session metadata `startURL` is now considered the canonical way of getting the first URL of a session so during replay we should use that.

Most session now should have a startURL defined in metadata but keeping the old event-stream startURL logic in place for backward-compatibility, we can drop it in the future.