### PR TITLE
Change screenshot log statement to debug level

### DIFF
--- a/packages/replayer/src/replayer/screenshot.utils.ts
+++ b/packages/replayer/src/replayer/screenshot.utils.ts
@@ -37,5 +37,5 @@ export const takeScreenshot: (
     path: screenshotFile,
     screenshotSelector,
   });
-  logger.info(`Wrote screenshot to ${screenshotFile}`);
+  logger.debug(`Wrote screenshot to ${screenshotFile}`);
 };


### PR DESCRIPTION
We should display a single next action for the user to take and currently the link into the Meticulous dashboard provides this. 