### PR TITLE
drop screenshot argument of create-test command

### DIFF
--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -31,7 +31,6 @@ const handler: (options: Options) => Promise<void> = async ({
   trace,
   // Replay options
   headless,
-  screenshot,
   screenshotSelector,
   padTime,
   shiftTime,
@@ -80,7 +79,7 @@ const handler: (options: Options) => Promise<void> = async ({
     headless,
     devTools,
     bypassCSP,
-    screenshot,
+    screenshot: true,
     screenshotSelector,
     padTime,
     shiftTime,
@@ -135,11 +134,6 @@ export const createTest: CommandModule<unknown, Options> = {
     headless: {
       boolean: true,
       description: "Start browser in headless mode",
-      default: true,
-    },
-    screenshot: {
-      boolean: true,
-      description: "Take a screenshot at the end of simulation",
       default: true,
     },
     screenshotSelector: {


### PR DESCRIPTION
Tests are based on visual difference of the final simulation state so screenshots are a requirement for creating a test at the moment. 