### PR TITLE
CLI: add the `bootstrap` command to set up a project

### DIFF
--- a/packages/cli/src/commands/bootstrap/bootstrap.command.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.command.ts
@@ -1,0 +1,35 @@
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import chalk from "chalk";
+import log from "loglevel";
+import { CommandModule } from "yargs";
+import { readConfig, saveConfig } from "../../config/config";
+import { MeticulousCliConfig } from "../../config/config.types";
+import { npmSetScript } from "../../utils/npm-set-script.utils";
+import { wrapHandler } from "../../utils/sentry.utils";
+
+interface Options {}
+
+const handler: (options: Options) => Promise<void> = async ({}) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  logger.info(`Setting up ${chalk.green("meticulous.json")}...`);
+  const meticulousConfig = await readConfig();
+  const newConfig: MeticulousCliConfig = {
+    ...meticulousConfig,
+    testCases: [...(meticulousConfig.testCases || [])],
+  };
+  await saveConfig(newConfig);
+
+  logger.info(`Setting up ${chalk.green("test:meticulous")} script...`);
+  await npmSetScript({
+    script: "test:meticulous",
+    command: "meticulous run-all-tests --headless --parallelize --deflake",
+  });
+};
+
+export const bootstrap: CommandModule<unknown, Options> = {
+  command: "bootstrap",
+  describe: "Bootstrap your project to use Meticulous",
+  builder: {},
+  handler: wrapHandler(handler),
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
+export { bootstrap } from "./commands/bootstrap/bootstrap.command";
 export { createTest } from "./commands/create-test/create-test.command";
 export { debugReplay } from "./commands/debug-replay/debug-replay.command";
 export { downloadReplay } from "./commands/download-replay/download-replay.command";

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,5 +1,6 @@
 import { getMeticulousLocalDataDir } from "@alwaysmeticulous/common";
 import yargs from "yargs";
+import { bootstrap } from "./commands/bootstrap/bootstrap.command";
 import { createTest } from "./commands/create-test/create-test.command";
 import { debugReplay } from "./commands/debug-replay/debug-replay.command";
 import { downloadReplay } from "./commands/download-replay/download-replay.command";
@@ -31,6 +32,7 @@ export const main: () => void = () => {
 
       Meticulous CLI`
     )
+    .command(bootstrap)
     .command(createTest)
     .command(debugReplay)
     .command(downloadReplay)

--- a/packages/cli/src/utils/npm-set-script.utils.ts
+++ b/packages/cli/src/utils/npm-set-script.utils.ts
@@ -1,0 +1,20 @@
+import { exec } from "child_process";
+
+export const npmSetScript: (options: {
+  script: string;
+  command: string;
+}) => Promise<string> = ({ script, command }) => {
+  return new Promise((resolve, reject) => {
+    exec(
+      `npm set-script ${script} "${command}"`,
+      { encoding: "utf-8" },
+      (error, output) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(output);
+      }
+    );
+  });
+};


### PR DESCRIPTION
The `bootstrap` commands sets up a npm/yarn project:
* Creates a `meticulous.json` file if one doesn't exist
* Adds a `test:meticulous` script