### PR TITLE
Enable rrweb recording only in cli

### DIFF
--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -57,6 +57,7 @@ export async function bootstrapPage({
         window["METICULOUS_ENABLE_RRWEB"] = true;
         window["METICULOUS_ENABLE_RRWEB_PLUGIN_NODE_DATA"] = true;
       `);
+      await frame.evaluate("console.log(document.currentScript);");
         await frame.evaluate(recordingSnippetFile);
         return;
       }

--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -54,6 +54,7 @@ export async function bootstrapPage({
         window["METICULOUS_APP_COMMIT_HASH"] = "${appCommitHash}";
         window["METICULOUS_FORCE_RECORDING"] = true;
         window["METICULOUS_UPLOAD_INTERVAL_MS"] = ${uploadIntervalMs};
+        window["METICULOUS_ENABLE_RRWEB"] = true;
         window["METICULOUS_ENABLE_RRWEB_PLUGIN_NODE_DATA"] = true;
       `);
         await frame.evaluate(recordingSnippetFile);


### PR DESCRIPTION
The CLI code also sets some settings:

```ts
        await frame.evaluate(`
        window["METICULOUS_RECORDING_TOKEN"] = "${recordingToken}";
        window["METICULOUS_APP_COMMIT_HASH"] = "${appCommitHash}";
        window["METICULOUS_FORCE_RECORDING"] = true;
        window["METICULOUS_UPLOAD_INTERVAL_MS"] = ${uploadIntervalMs};
        window["METICULOUS_ENABLE_RRWEB_PLUGIN_NODE_DATA"] = true;
      `);
```

However we can't easily make changes to these, since it'll depend on the customer updating their version of the CLI. This can cause issues when the CLI and passive snippet make assumptions about their configuration options or defaults and get out of sync. Therefore maybe we should move to:

```ts
        await frame.evaluate(`
        window["METICULOUS_MANUAL_RECORDING"] = true;
        window["METICULOUS_RECORDING_TOKEN"] = "${recordingToken}";
        window["METICULOUS_APP_COMMIT_HASH"] = "${appCommitHash}";
        window["METICULOUS_UPLOAD_INTERVAL_MS"] = ${uploadIntervalMs};
      `);
```

And then we set the CLI defaults within the snippet. Eventually we could publish separate snippets for passive vs manual, and so reduce the size of the passive snippet.

This PR moves in this direction (CLI settings for snippet set in snippet not in CLI), and also disables rrweb recording in the passive snippet. This is because rrweb often produces > 2mb of data, which causes the session to be abandoned.