### PR TITLE
key assets metadata by file name rather than fetch URL location

### DIFF
--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -10,7 +10,7 @@ import { getSnippetsBaseUrl } from "../config/snippets";
 
 export interface AssetMetadataItem {
   fileName: string;
-  etag: string;
+  etag: string | null;
   fetchUrl: string;
 }
 
@@ -54,7 +54,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const assetFileName = basename(new URL(fetchUrl).pathname);
 
   const assetMetadata = await loadAssetMetadata();
-  const etag = (await axios.head(fetchUrl)).headers["etag"] || "";
+  const etag = (await axios.head(fetchUrl)).headers["etag"] || null;
 
   const entry = assetMetadata.assets.find(
     (item) => item.fileName === assetFileName
@@ -62,7 +62,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const fileName = assetFileName;
   const filePath = join(await getCreateAssetsDir(), fileName);
 
-  if (entry && etag === entry.etag) {
+  if (entry && etag && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);
     return filePath;
   }

--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -18,10 +18,17 @@ export interface AssetMetadata {
   assets: AssetMetadataItem[];
 }
 
-export const loadAssetMetadata: () => Promise<AssetMetadata> = async () => {
-  const assetsDir = join(getMeticulousLocalDataDir(), "assets");
+const ASSETS_FOLDER_NAME = "assets";
+const ASSET_METADATA_FILE_NAME = "assets.json";
+
+export const getCreateAssetsDir: () => Promise<string> = async () => {
+  const assetsDir = join(getMeticulousLocalDataDir(), ASSETS_FOLDER_NAME);
   await mkdir(assetsDir, { recursive: true });
-  const assetsFile = join(assetsDir, `assets.json`);
+  return assetsDir;
+};
+
+export const loadAssetMetadata: () => Promise<AssetMetadata> = async () => {
+  const assetsFile = join(await getCreateAssetsDir(), ASSET_METADATA_FILE_NAME);
 
   const existingMetadata = await readFile(assetsFile)
     .then((data) => JSON.parse(data.toString("utf-8")))
@@ -36,9 +43,7 @@ export const loadAssetMetadata: () => Promise<AssetMetadata> = async () => {
 export const saveAssetMetadata: (
   assetMetadata: AssetMetadata
 ) => Promise<void> = async (assetMetadata) => {
-  const assetsDir = join(getMeticulousLocalDataDir(), "assets");
-  await mkdir(assetsDir, { recursive: true });
-  const assetsFile = join(assetsDir, `assets.json`);
+  const assetsFile = join(await getCreateAssetsDir(), ASSET_METADATA_FILE_NAME);
 
   await writeFile(assetsFile, JSON.stringify(assetMetadata, null, 2));
 };
@@ -47,8 +52,6 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   const fetchUrl = new URL(path, getSnippetsBaseUrl()).href;
 
-  const assetsDir = join(getMeticulousLocalDataDir(), "assets");
-
   const assetMetadata = await loadAssetMetadata();
   const etag = (await axios.head(fetchUrl)).headers["etag"] || "";
 
@@ -56,7 +59,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const fileName = entry
     ? entry.fileName
     : basename(new URL(fetchUrl).pathname);
-  const filePath = join(assetsDir, fileName);
+  const filePath = join(await getCreateAssetsDir(), fileName);
 
   if (entry && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);

--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -51,14 +51,15 @@ export const saveAssetMetadata: (
 export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   const fetchUrl = new URL(path, getSnippetsBaseUrl()).href;
+  const assetFileName = basename(new URL(fetchUrl).pathname);
 
   const assetMetadata = await loadAssetMetadata();
   const etag = (await axios.head(fetchUrl)).headers["etag"] || "";
 
-  const entry = assetMetadata.assets.find((item) => item.fetchUrl === fetchUrl);
-  const fileName = entry
-    ? entry.fileName
-    : basename(new URL(fetchUrl).pathname);
+  const entry = assetMetadata.assets.find(
+    (item) => item.fileName === assetFileName
+  );
+  const fileName = assetFileName;
   const filePath = join(await getCreateAssetsDir(), fileName);
 
   if (entry && etag === entry.etag) {

--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -10,7 +10,7 @@ import { getSnippetsBaseUrl } from "../config/snippets";
 
 export interface AssetMetadataItem {
   fileName: string;
-  etag: string | null;
+  etag: string;
   fetchUrl: string;
 }
 
@@ -60,14 +60,14 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const assetFileName = basename(new URL(fetchUrl).pathname);
 
   const assetMetadata = await loadAssetMetadata();
-  const etag = (await axios.head(fetchUrl)).headers["etag"] || null;
+  const etag = (await axios.head(fetchUrl)).headers["etag"] || "";
 
   const entry = assetMetadata.assets.find(
     (item) => item.fileName === assetFileName
   );
   const filePath = join(await getOrCreateAssetsDir(), assetFileName);
 
-  if (entry && etag && etag === entry.etag) {
+  if (entry && etag !== "" && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);
     return filePath;
   }

--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -21,14 +21,17 @@ export interface AssetMetadata {
 const ASSETS_FOLDER_NAME = "assets";
 const ASSET_METADATA_FILE_NAME = "assets.json";
 
-export const getCreateAssetsDir: () => Promise<string> = async () => {
+export const getOrCreateAssetsDir: () => Promise<string> = async () => {
   const assetsDir = join(getMeticulousLocalDataDir(), ASSETS_FOLDER_NAME);
   await mkdir(assetsDir, { recursive: true });
   return assetsDir;
 };
 
 export const loadAssetMetadata: () => Promise<AssetMetadata> = async () => {
-  const assetsFile = join(await getCreateAssetsDir(), ASSET_METADATA_FILE_NAME);
+  const assetsFile = join(
+    await getOrCreateAssetsDir(),
+    ASSET_METADATA_FILE_NAME
+  );
 
   const existingMetadata = await readFile(assetsFile)
     .then((data) => JSON.parse(data.toString("utf-8")))
@@ -43,7 +46,10 @@ export const loadAssetMetadata: () => Promise<AssetMetadata> = async () => {
 export const saveAssetMetadata: (
   assetMetadata: AssetMetadata
 ) => Promise<void> = async (assetMetadata) => {
-  const assetsFile = join(await getCreateAssetsDir(), ASSET_METADATA_FILE_NAME);
+  const assetsFile = join(
+    await getOrCreateAssetsDir(),
+    ASSET_METADATA_FILE_NAME
+  );
 
   await writeFile(assetsFile, JSON.stringify(assetMetadata, null, 2));
 };
@@ -60,7 +66,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
     (item) => item.fileName === assetFileName
   );
   const fileName = assetFileName;
-  const filePath = join(await getCreateAssetsDir(), fileName);
+  const filePath = join(await getOrCreateAssetsDir(), fileName);
 
   if (entry && etag && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);

--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -65,8 +65,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const entry = assetMetadata.assets.find(
     (item) => item.fileName === assetFileName
   );
-  const fileName = assetFileName;
-  const filePath = join(await getOrCreateAssetsDir(), fileName);
+  const filePath = join(await getOrCreateAssetsDir(), assetFileName);
 
   if (entry && etag && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);
@@ -80,7 +79,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
     entry.etag = etag;
   } else {
     logger.debug(`${fetchUrl} downloaded`);
-    assetMetadata.assets.push({ fileName, etag, fetchUrl });
+    assetMetadata.assets.push({ fileName: assetFileName, etag, fetchUrl });
   }
   await saveAssetMetadata(assetMetadata);
   return filePath;


### PR DESCRIPTION
## Motivation

Assets locations change per environment and we want to re-fetch any
assets which differ in case of an environment change. Keying the
asset metadata by the output file name ensures a correct etag
comparison (comparing etag of the local file vs the remote origin)
in case of an environment change.