### PR TITLE
Navigate directly to recording page docs when browser opens

### DIFF
--- a/packages/record/src/record/record.ts
+++ b/packages/record/src/record/record.ts
@@ -6,7 +6,11 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import log from "loglevel";
 import { join } from "path";
 import puppeteer, { Browser, PuppeteerNode } from "puppeteer";
-import { bootstrapPage, defer } from "./record.utils";
+import {
+  bootstrapPage,
+  defer,
+  INITIAL_METICULOUS_DOCS_URL,
+} from "./record.utils";
 
 const DEFAULT_UPLOAD_INTERVAL_MS = 1_000; // 1 second
 const COOKIE_FILENAME = "cookies.json";
@@ -121,6 +125,8 @@ export const recordSession: RecordSessionFn = async ({
     earlyNetworkRecorderSnippet,
     uploadIntervalMs: uploadIntervalMs || DEFAULT_UPLOAD_INTERVAL_MS,
   });
+
+  page.goto(INITIAL_METICULOUS_DOCS_URL);
 
   logger.info("Browser ready");
 

--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -3,6 +3,9 @@ import { readFile } from "fs/promises";
 import log from "loglevel";
 import { Page } from "puppeteer";
 
+export const INITIAL_METICULOUS_DOCS_URL =
+  "https://app.meticulous.ai/docs/recording-a-test";
+
 export interface IDeferred<T = void> {
   resolve: (value: T) => void;
   reject: () => void;
@@ -47,6 +50,9 @@ export async function bootstrapPage({
   await page.evaluateOnNewDocument(earlyNetworkRecorderSnippetFile);
 
   page.on("framenavigated", async (frame) => {
+    if (page.url() === INITIAL_METICULOUS_DOCS_URL) {
+      return;
+    }
     try {
       if (page.mainFrame() === frame) {
         await frame.evaluate(`


### PR DESCRIPTION
This navigates to the recording-a-test docs url as the first page when launching the record command. We do a hard-code check for the recording-a-page doc page, to avoid injecting the snippet on this page and to avoid creating a extra dummy recording