### PR TITLE
Add serve command

### DIFF
--- a/packages/cli/src/commands/serve/serve.command.ts
+++ b/packages/cli/src/commands/serve/serve.command.ts
@@ -1,0 +1,36 @@
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import log from "loglevel";
+import { CommandModule } from "yargs";
+import { createClient } from "../../api/client";
+import { serveAssetsFromSimulation } from "../../local-data/serve-assets-from-simulation";
+import { wrapHandler } from "../../utils/sentry.utils";
+interface Options {
+  apiToken?: string | null | undefined;
+  replayId: string;
+}
+
+const handler: (options: Options) => Promise<void> = async ({
+  apiToken,
+  replayId,
+}) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const client = createClient({ apiToken });
+  const { url } = await serveAssetsFromSimulation(client, replayId);
+  logger.log(`Serving assets at url ${url}`);
+};
+
+export const serve: CommandModule<unknown, Options> = {
+  command: "serve",
+  describe:
+    "Spin up a localhost server to serve the assets that were snapshotted when running a particular replay",
+  builder: {
+    apiToken: {
+      string: true,
+    },
+    replayId: {
+      string: true,
+      demandOption: true,
+    },
+  },
+  handler: wrapHandler(handler),
+};

--- a/packages/cli/src/commands/serve/serve.command.ts
+++ b/packages/cli/src/commands/serve/serve.command.ts
@@ -4,6 +4,7 @@ import { CommandModule } from "yargs";
 import { createClient } from "../../api/client";
 import { serveAssetsFromSimulation } from "../../local-data/serve-assets-from-simulation";
 import { wrapHandler } from "../../utils/sentry.utils";
+
 interface Options {
   apiToken?: string | null | undefined;
   replayId: string;

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -9,6 +9,7 @@ import { record } from "./commands/record/record.command";
 import { replay } from "./commands/replay/replay.command";
 import { runAllTests } from "./commands/run-all-tests/run-all-tests.command";
 import { screenshotDiff } from "./commands/screenshot-diff/screenshot-diff.command";
+import { serve } from "./commands/serve/serve.command";
 import { showProject } from "./commands/show-project/show-project.command";
 import { updateTests } from "./commands/update-tests/update-tests.command";
 import { uploadBuild } from "./commands/upload-build/upload-build.command";
@@ -44,6 +45,7 @@ export const main: () => void = () => {
     .command(showProject)
     .command(updateTests)
     .command(uploadBuild)
+    .command(serve)
     .help()
     .strict()
     .demandCommand()

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -45,7 +45,7 @@ export const main: () => void = () => {
     .command(showProject)
     .command(updateTests)
     .command(uploadBuild)
-    .command(serve)
+    .command("serve", false, serve) // This is a debugging command, so we hide it to not pollute the main menu
     .help()
     .strict()
     .demandCommand()


### PR DESCRIPTION
Add command to spin up a localhost server to serve the assets that were snapshotted when running a particular replay.

I added this mainly for my own usage in debugging, but I think it's useful and worth merging. What do you think?

Downside would be more commands get listed when you run `npx meticulous`, which could make it more confusing for users to learn how to use the product. (ideal thing would be to start grouping the commands into core and advanced, not sure that's possible)