### PR TITLE
bubble up error when rejecting promise in recorder loader

### DIFF
--- a/packages/recorder-loader/src/loader.ts
+++ b/packages/recorder-loader/src/loader.ts
@@ -54,8 +54,8 @@ export const loadAndStartRecorder: (options: LoaderOptions) => Promise<void> = (
 
       try {
         window.__meticulous?.initialiseRecorder();
-      } catch (Error) {
-        reject("Meticulous recorder failed to initialise.");
+      } catch (error) {
+        reject(error);
       }
 
       resolve();


### PR DESCRIPTION
Addressing the comment here: https://github.com/alwaysmeticulous/meticulous-sdk/pull/112#discussion_r992261384

Looks like the isn't much useful contextual information from the script `error` event so I've kept the `script.onerror` `reject()` as is.