### PR TITLE
Deduplicate replay interfaces

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,15 +34,13 @@
     "express": "^4.18.1",
     "find-free-port": "^2.0.0",
     "inquirer": "^8.2.4",
-    "lodash": "^4.17.21",
     "luxon": "^2.4.0",
     "pixelmatch": "^5.3.0",
     "pngjs": "^6.0.0",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@types/express": "^4.17.14",
-    "@types/lodash": "^4.14.186"
+    "@types/express": "^4.17.14"
   },
   "peerDependencies": {
     "@alwaysmeticulous/record": "^2.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,13 +34,15 @@
     "express": "^4.18.1",
     "find-free-port": "^2.0.0",
     "inquirer": "^8.2.4",
+    "lodash": "^4.17.21",
     "luxon": "^2.4.0",
     "pixelmatch": "^5.3.0",
     "pngjs": "^6.0.0",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@types/express": "^4.17.14"
+    "@types/express": "^4.17.14",
+    "@types/lodash": "^4.14.186"
   },
   "peerDependencies": {
     "@alwaysmeticulous/record": "^1.7.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,9 +45,9 @@
     "@types/lodash": "^4.14.186"
   },
   "peerDependencies": {
-    "@alwaysmeticulous/record": "^1.7.6",
-    "@alwaysmeticulous/replay-debugger": "^1.7.6",
-    "@alwaysmeticulous/replayer": "^1.7.6"
+    "@alwaysmeticulous/record": "^2.2.1",
+    "@alwaysmeticulous/replay-debugger": "^2.2.1",
+    "@alwaysmeticulous/replayer": "^2.2.1"
   },
   "peerDependenciesMeta": {
     "@alwaysmeticulous/record": {

--- a/packages/cli/src/command-utils/command-utils.ts
+++ b/packages/cli/src/command-utils/command-utils.ts
@@ -6,7 +6,7 @@ type UndefinedToNullOrUndefined<T extends object> = {
  * yargs normally passes through undefineds, but passes through nulls for
  * numbers which fail to parse. We convert everything to undefined to standardize.
  */
-export const convertNullsToUndefineds = <T extends object>(
+export const handleNulls = <T extends object>(
   handler: (args: T) => Promise<void>
 ): ((args: UndefinedToNullOrUndefined<T>) => Promise<void>) => {
   return (args: UndefinedToNullOrUndefined<T>) => {

--- a/packages/cli/src/command-utils/command-utils.ts
+++ b/packages/cli/src/command-utils/command-utils.ts
@@ -1,0 +1,23 @@
+type UndefinedToNullOrUndefined<T extends object> = {
+  [K in keyof T]: undefined extends T[K] ? T[K] | null : T[K];
+};
+
+/**
+ * yargs normally passes through undefineds, but passes through nulls for
+ * numbers which fail to parse. We convert everything to undefined to standardize.
+ */
+export const convertNullsToUndefineds = <T extends object>(
+  handler: (args: T) => Promise<void>
+): ((args: UndefinedToNullOrUndefined<T>) => Promise<void>) => {
+  return (args: UndefinedToNullOrUndefined<T>) => {
+    const keys = Object.keys(args) as Array<keyof T>;
+    const newArgs = keys.reduce(
+      (partialArgs: Partial<T>, key: keyof T): Partial<T> => ({
+        ...partialArgs,
+        [key]: args[key] === null ? undefined : args[key],
+      }),
+      {}
+    ) as T;
+    return handler(newArgs);
+  };
+};

--- a/packages/cli/src/command-utils/common-options.ts
+++ b/packages/cli/src/command-utils/common-options.ts
@@ -1,0 +1,65 @@
+export const DEFAULT_MISMATCH_THRESHOLD = 0.01;
+
+// Matches https://github.com/mapbox/pixelmatch/blob/master/index.js#L6
+export const DEFAULT_DIFF_PIXEL_THRESHOLD = 0.1;
+
+export const SCREENSHOT_DIFF_OPTIONS = {
+  diffThreshold: {
+    number: true,
+    description:
+      "Acceptable maximum proportion of changed pixels, between 0 and 1. If this proportion is exceeded then the test will fail.",
+    default: DEFAULT_MISMATCH_THRESHOLD,
+  },
+  diffPixelThreshold: {
+    number: true,
+    description:
+      "A number between 0 and 1. Color/brightness differences in individual pixels will be ignored if the difference is less than this threshold. A value of 1.0 would accept any difference in color, while a value of 0.0 would accept no difference in color.",
+    default: DEFAULT_DIFF_PIXEL_THRESHOLD,
+  },
+};
+
+export const PRIMARY_COMMON_REPLAY_OPTIONS = {
+  apiToken: {
+    string: true,
+  },
+  commitSha: {
+    string: true,
+  },
+};
+
+export const SECONDARY_COMMON_REPLAY_OPTIONS = {
+  headless: {
+    boolean: true,
+    description: "Start browser in headless mode",
+  },
+  devTools: {
+    boolean: true,
+    description: "Open Chrome Dev Tools",
+  },
+  bypassCSP: {
+    boolean: true,
+    description: "Enables bypass CSP in the browser",
+  },
+  padTime: {
+    boolean: true,
+    description:
+      "Pad replay time according to recording duration. Please note this option will be ignored if running with the '--accelerate' option.",
+    default: true,
+  },
+  shiftTime: {
+    boolean: true,
+    description: "Shift time during simulation to be set as the recording time",
+    default: true,
+  },
+  networkStubbing: {
+    boolean: true,
+    description: "Stub network requests during replay",
+    default: true,
+  },
+  accelerate: {
+    boolean: true,
+    description:
+      "Fast forward through any pauses to replay as fast as possible. Warning: this option is experimental and may be deprecated",
+    default: false,
+  },
+};

--- a/packages/cli/src/command-utils/common-options.ts
+++ b/packages/cli/src/command-utils/common-options.ts
@@ -1,20 +1,13 @@
-export const DEFAULT_MISMATCH_THRESHOLD = 0.01;
-
-// Matches https://github.com/mapbox/pixelmatch/blob/master/index.js#L6
-export const DEFAULT_DIFF_PIXEL_THRESHOLD = 0.1;
-
 export const SCREENSHOT_DIFF_OPTIONS = {
   diffThreshold: {
     number: true,
     description:
       "Acceptable maximum proportion of changed pixels, between 0 and 1. If this proportion is exceeded then the test will fail.",
-    default: DEFAULT_MISMATCH_THRESHOLD,
   },
   diffPixelThreshold: {
     number: true,
     description:
       "A number between 0 and 1. Color/brightness differences in individual pixels will be ignored if the difference is less than this threshold. A value of 1.0 would accept any difference in color, while a value of 0.0 would accept no difference in color.",
-    default: DEFAULT_DIFF_PIXEL_THRESHOLD,
   },
 };
 

--- a/packages/cli/src/command-utils/common-options.ts
+++ b/packages/cli/src/command-utils/common-options.ts
@@ -1,37 +1,36 @@
-export const SCREENSHOT_DIFF_OPTIONS = {
-  diffThreshold: {
-    number: true,
-    description:
-      "Acceptable maximum proportion of changed pixels, between 0 and 1. If this proportion is exceeded then the test will fail.",
-  },
-  diffPixelThreshold: {
-    number: true,
-    description:
-      "A number between 0 and 1. Color/brightness differences in individual pixels will be ignored if the difference is less than this threshold. A value of 1.0 would accept any difference in color, while a value of 0.0 would accept no difference in color.",
-  },
-};
+// We keep all options that are used by multiple commands in one file.
+// This ensures the defaults and descriptions stay in sync. Where we do want
+// a different default or description we override it, like:
+//
+//  headless: {
+//    ...COMMON_REPLAY_OPTIONS.headless,
+//    default: true,
+//  },
+//
+// This then makes the difference in behaviour explicit
 
-export const PRIMARY_COMMON_REPLAY_OPTIONS = {
+export const OPTIONS = {
   apiToken: {
     string: true,
   },
   commitSha: {
     string: true,
   },
-};
-
-export const SECONDARY_COMMON_REPLAY_OPTIONS = {
   headless: {
     boolean: true,
     description: "Start browser in headless mode",
+    default: false,
   },
   devTools: {
     boolean: true,
     description: "Open Chrome Dev Tools",
+    default: false,
   },
   bypassCSP: {
     boolean: true,
-    description: "Enables bypass CSP in the browser",
+    description:
+      "Enables bypass CSP in the browser (danger: this could mean you tests hit your production backend)",
+    default: false,
   },
   padTime: {
     boolean: true,
@@ -55,4 +54,39 @@ export const SECONDARY_COMMON_REPLAY_OPTIONS = {
       "Fast forward through any pauses to replay as fast as possible. Warning: this option is experimental and may be deprecated",
     default: false,
   },
+  moveBeforeClick: {
+    boolean: true,
+    description: "Simulate mouse movement before clicking",
+    default: false,
+  },
+  diffThreshold: {
+    number: true,
+    description:
+      "Acceptable maximum proportion of changed pixels, between 0 and 1. If this proportion is exceeded then the test will fail.",
+    default: 0.01,
+  },
+  diffPixelThreshold: {
+    number: true,
+    description:
+      "A number between 0 and 1. Color/brightness differences in individual pixels will be ignored if the difference is less than this threshold. A value of 1.0 would accept any difference in color, while a value of 0.0 would accept no difference in color.",
+    default: 0.1, // matches https://github.com/mapbox/pixelmatch/blob/master/index.js#L6
+  },
+};
+
+export const SCREENSHOT_DIFF_OPTIONS = {
+  diffThreshold: OPTIONS.diffThreshold,
+  diffPixelThreshold: OPTIONS.diffPixelThreshold,
+};
+
+/**
+ * Options that are passed onto replayEvents, that are shared by the replay, run-all-tests, and create-test commands
+ */
+export const COMMON_REPLAY_OPTIONS = {
+  headless: OPTIONS.headless,
+  devTools: OPTIONS.devTools,
+  bypassCSP: OPTIONS.bypassCSP,
+  padTime: OPTIONS.padTime,
+  shiftTime: OPTIONS.shiftTime,
+  networkStubbing: OPTIONS.networkStubbing,
+  accelerate: OPTIONS.accelerate,
 };

--- a/packages/cli/src/command-utils/common-types.ts
+++ b/packages/cli/src/command-utils/common-types.ts
@@ -1,0 +1,37 @@
+export interface ScreenshotDiffOptions {
+  diffThreshold?: number | undefined;
+  diffPixelThreshold?: number | undefined;
+}
+
+/**
+ * Replay options that are re-used by all commands that run a replay,
+ * including both commands that run all tests and the replay command
+ */
+export interface CommonReplayOptions {
+  apiToken?: string | null | undefined;
+  commitSha?: string | null | undefined;
+  headless?: boolean | null | undefined;
+  devTools?: boolean | null | undefined;
+  bypassCSP?: boolean | null | undefined;
+  padTime: boolean;
+  shiftTime: boolean;
+  networkStubbing: boolean;
+  accelerate: boolean;
+}
+
+/**
+ * Replay options that are re-used by all commands that run a replay,
+ * including both commands that run all tests and the replay command
+ */
+export interface PerReplayOptions {
+  appUrl?: string | null | undefined;
+
+  /**
+   * If present will run the session against a local server serving up previously snapshotted assets (HTML, JS, CSS etc.) from the specified prior replay, instead of against a URL.
+   */
+  simulationIdForAssets?: string | undefined;
+
+  screenshotSelector?: string;
+
+  cookies?: Record<string, any>[];
+}

--- a/packages/cli/src/command-utils/common-types.ts
+++ b/packages/cli/src/command-utils/common-types.ts
@@ -12,15 +12,6 @@ export interface ScreenshotDiffOptions {
 }
 
 /**
- * Replay options that are re-used by all commands that run a replay,
- * including both commands that run all tests and the replay command
- */
-export interface CommonReplayOptions {
-  apiToken: string | undefined;
-  commitSha: string | undefined;
-}
-
-/**
  * Options for taking a screenshot and comparing it against a previous screenshot
  */
 export type ScreenshotAssertionsOptions =

--- a/packages/cli/src/command-utils/common-types.ts
+++ b/packages/cli/src/command-utils/common-types.ts
@@ -1,6 +1,13 @@
+import { TestCaseReplayOptions } from "../config/config.types";
+import {
+  ReplayExecutionOptions,
+  ResolvedReplayExecutionOptions,
+} from "@alwaysmeticulous/common";
+import defaults from "lodash/defaults";
+
 export interface ScreenshotDiffOptions {
-  diffThreshold?: number | undefined;
-  diffPixelThreshold?: number | undefined;
+  diffThreshold: number;
+  diffPixelThreshold: number;
 }
 
 /**
@@ -10,28 +17,76 @@ export interface ScreenshotDiffOptions {
 export interface CommonReplayOptions {
   apiToken?: string | null | undefined;
   commitSha?: string | null | undefined;
-  headless?: boolean | null | undefined;
-  devTools?: boolean | null | undefined;
-  bypassCSP?: boolean | null | undefined;
-  padTime: boolean;
-  shiftTime: boolean;
-  networkStubbing: boolean;
-  accelerate: boolean;
 }
 
 /**
- * Replay options that are re-used by all commands that run a replay,
- * including both commands that run all tests and the replay command
+ * Options that affect how test expectations are evaluated
  */
-export interface PerReplayOptions {
-  appUrl?: string | null | undefined;
-
-  /**
-   * If present will run the session against a local server serving up previously snapshotted assets (HTML, JS, CSS etc.) from the specified prior replay, instead of against a URL.
-   */
-  simulationIdForAssets?: string | undefined;
-
-  screenshotSelector?: string;
-
-  cookies?: Record<string, any>[];
+export interface TestExpectationOptions {
+  screenshotDiffs: Partial<ScreenshotDiffOptions>;
+  screenshotSelector: string | undefined;
 }
+
+export interface ResolvedExpectationOptions {
+  screenshotDiffs: ScreenshotDiffOptions;
+  screenshotSelector: string | undefined;
+}
+
+export const DEFAULT_REPLAY_EXECUTION_OPTIONS: ResolvedReplayExecutionOptions =
+  {
+    headless: false,
+    devTools: false,
+    bypassCSP: false,
+    padTime: true,
+    shiftTime: true,
+    networkStubbing: true,
+    accelerate: false,
+    moveBeforeClick: false,
+  };
+
+export const getResolvedExecutionOptions = (
+  optionsFromTestCase: TestCaseReplayOptions,
+  executionOptionsFromCliFlags: ReplayExecutionOptions
+) => {
+  const testCaseExecutionOptions = {
+    moveBeforeClick: optionsFromTestCase.moveBeforeClick,
+    simulationIdForAssets: optionsFromTestCase.simulationIdForAssets,
+  };
+
+  // Options specified in the test case override those passed as CLI flags
+  // (CLI flags set the defaults)
+  return defaults(
+    {},
+    testCaseExecutionOptions,
+    executionOptionsFromCliFlags,
+    DEFAULT_REPLAY_EXECUTION_OPTIONS
+  );
+};
+
+export const DEFAULT_SCREENSHOT_DIFF_OPTIONS: ScreenshotDiffOptions = {
+  diffThreshold: 0.01,
+  diffPixelThreshold: 0.1, // matches https://github.com/mapbox/pixelmatch/blob/master/index.js#L6
+};
+
+export const getResolvedExpectationOptions = (
+  optionsFromTestCase: TestCaseReplayOptions,
+  expectationOptionsFromCliFlags: TestExpectationOptions
+): ResolvedExpectationOptions => {
+  // Options specified in the test case override those passed as CLI flags
+  // (CLI flags set the defaults)
+  const screenshotDiffs: ScreenshotDiffOptions = defaults(
+    {},
+    {
+      diffThreshold: optionsFromTestCase.diffThreshold,
+      diffPixelThreshold: optionsFromTestCase.diffPixelThreshold,
+    },
+    expectationOptionsFromCliFlags.screenshotDiffs,
+    DEFAULT_SCREENSHOT_DIFF_OPTIONS
+  );
+  return {
+    screenshotDiffs,
+    screenshotSelector:
+      expectationOptionsFromCliFlags.screenshotSelector ??
+      optionsFromTestCase.screenshotSelector,
+  };
+};

--- a/packages/cli/src/command-utils/common-types.ts
+++ b/packages/cli/src/command-utils/common-types.ts
@@ -1,15 +1,4 @@
-import {
-  ReplayExecutionOptions,
-  ReplayTarget,
-  ScreenshottingEnabledOptions,
-} from "@alwaysmeticulous/common";
-import defaults from "lodash/defaults";
-import { TestCaseReplayOptions } from "../config/config.types";
-
-export interface ScreenshotDiffOptions {
-  diffThreshold: number;
-  diffPixelThreshold: number;
-}
+import { ScreenshottingEnabledOptions } from "@alwaysmeticulous/common";
 
 /**
  * Options for taking a screenshot and comparing it against a previous screenshot
@@ -23,57 +12,7 @@ export interface ScreenshotAssertionsEnabledOptions
   diffOptions: ScreenshotDiffOptions;
 }
 
-export const getReplayTarget = ({
-  appUrl,
-  simulationIdForAssets,
-}: {
-  appUrl?: string | undefined;
-  simulationIdForAssets?: string | undefined;
-}): ReplayTarget => {
-  if (simulationIdForAssets) {
-    return { type: "snapshotted-assets", simulationIdForAssets };
-  }
-  if (appUrl) {
-    return { type: "url", appUrl };
-  }
-  return { type: "original-recorded-url" };
-};
-
-export const applyTestCaseExecutionOptionOverrides = (
-  executionOptionsFromCliFlags: ReplayExecutionOptions,
-  overridesFromTestCase: TestCaseReplayOptions
-) => {
-  // Options specified in the test case override those passed as CLI flags
-  // (CLI flags set the defaults)
-  return defaults(
-    {},
-    {
-      moveBeforeClick: overridesFromTestCase.moveBeforeClick,
-      simulationIdForAssets: overridesFromTestCase.simulationIdForAssets,
-    },
-    executionOptionsFromCliFlags
-  );
-};
-
-export const applyTestCaseScreenshottingOptionsOverrides = (
-  screenshottingOptionsFromCliFlags: ScreenshotAssertionsEnabledOptions,
-  overridesFromTestCase: TestCaseReplayOptions
-): ScreenshotAssertionsEnabledOptions => {
-  // Options specified in the test case override those passed as CLI flags
-  // (CLI flags set the defaults)
-  const diffOptions: ScreenshotDiffOptions = defaults(
-    {},
-    {
-      diffThreshold: overridesFromTestCase.diffThreshold,
-      diffPixelThreshold: overridesFromTestCase.diffPixelThreshold,
-    },
-    screenshottingOptionsFromCliFlags.diffOptions
-  );
-  return {
-    enabled: true,
-    screenshotSelector:
-      overridesFromTestCase.screenshotSelector ??
-      screenshottingOptionsFromCliFlags.screenshotSelector,
-    diffOptions,
-  };
-};
+export interface ScreenshotDiffOptions {
+  diffThreshold: number;
+  diffPixelThreshold: number;
+}

--- a/packages/cli/src/command-utils/common-types.ts
+++ b/packages/cli/src/command-utils/common-types.ts
@@ -38,7 +38,7 @@ export const getReplayTarget = ({
   if (appUrl) {
     return { type: "url", appUrl };
   }
-  return { type: "url" };
+  return { type: "original-recorded-url" };
 };
 
 export const applyTestCaseExecutionOptionOverrides = (

--- a/packages/cli/src/command-utils/common-types.ts
+++ b/packages/cli/src/command-utils/common-types.ts
@@ -1,7 +1,10 @@
-import { TestCaseReplayOptions } from "../config/config.types";
-import { ReplayExecutionOptions } from "@alwaysmeticulous/common";
+import {
+  ReplayExecutionOptions,
+  ReplayTarget,
+  ScreenshottingEnabledOptions,
+} from "@alwaysmeticulous/common";
 import defaults from "lodash/defaults";
-import { ReplayTarget } from "@alwaysmeticulous/common/dist/types/replay.types";
+import { TestCaseReplayOptions } from "../config/config.types";
 
 export interface ScreenshotDiffOptions {
   diffThreshold: number;
@@ -18,11 +21,15 @@ export interface CommonReplayOptions {
 }
 
 /**
- * Options that affect how test expectations are evaluated
+ * Options for taking a screenshot and comparing it against a previous screenshot
  */
-export interface TestExpectationOptions {
-  screenshotDiffs: ScreenshotDiffOptions;
-  screenshotSelector: string | undefined;
+export type ScreenshotAssertionsOptions =
+  | { enabled: false }
+  | ScreenshotAssertionsEnabledOptions;
+
+export interface ScreenshotAssertionsEnabledOptions
+  extends ScreenshottingEnabledOptions {
+  diffOptions: ScreenshotDiffOptions;
 }
 
 export const getReplayTarget = ({
@@ -57,24 +64,25 @@ export const applyTestCaseExecutionOptionOverrides = (
   );
 };
 
-export const applyTestCaseExpectationOptionsOverrides = (
-  expectationOptionsFromCliFlags: TestExpectationOptions,
+export const applyTestCaseScreenshottingOptionsOverrides = (
+  screenshottingOptionsFromCliFlags: ScreenshotAssertionsEnabledOptions,
   overridesFromTestCase: TestCaseReplayOptions
-): TestExpectationOptions => {
+): ScreenshotAssertionsEnabledOptions => {
   // Options specified in the test case override those passed as CLI flags
   // (CLI flags set the defaults)
-  const screenshotDiffs: ScreenshotDiffOptions = defaults(
+  const diffOptions: ScreenshotDiffOptions = defaults(
     {},
     {
       diffThreshold: overridesFromTestCase.diffThreshold,
       diffPixelThreshold: overridesFromTestCase.diffPixelThreshold,
     },
-    expectationOptionsFromCliFlags.screenshotDiffs
+    screenshottingOptionsFromCliFlags.diffOptions
   );
   return {
-    screenshotDiffs,
+    enabled: true,
     screenshotSelector:
       overridesFromTestCase.screenshotSelector ??
-      expectationOptionsFromCliFlags.screenshotSelector,
+      screenshottingOptionsFromCliFlags.screenshotSelector,
+    diffOptions,
   };
 };

--- a/packages/cli/src/command-utils/common-types.ts
+++ b/packages/cli/src/command-utils/common-types.ts
@@ -13,6 +13,13 @@ export interface ScreenshotAssertionsEnabledOptions
 }
 
 export interface ScreenshotDiffOptions {
+  /**
+   * Acceptable maximum proportion of changed pixels, between 0 and 1.
+   */
   diffThreshold: number;
+
+  /**
+   * A number between 0 and 1. Color/brightness differences in individual pixels will be ignored if the difference is less than this threshold. A value of 1.0 would accept any difference in color, while a value of 0.0 would accept no difference in color.
+   */
   diffPixelThreshold: number;
 }

--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -160,6 +160,10 @@ const handler: (options: Options) => Promise<void> = async ({
     baseSimulationId: undefined,
     diffThreshold: OPTIONS.diffThreshold.default,
     diffPixelThreshold: OPTIONS.diffPixelThreshold.default,
+
+    // We don't expose these options
+    maxDurationMs: undefined,
+    maxEventCount: undefined,
   };
   const replay = await rawReplayCommandHandler(replayOptions);
 

--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -149,11 +149,15 @@ const handler: (options: Options) => Promise<void> = async ({
     moveBeforeClick,
     cookiesFile,
     accelerate,
-    appUrl: undefined, // we replay against the original recorded URL (TODO: add type: original-recorded-url)
-    save: false, // we handle the saving to meticulous.json ourselves below
-    baseSimulationId: undefined,
 
-    // We haven't yet added command line flags for the below, so we just pass through the defaults
+    save: false, // we handle the saving to meticulous.json ourselves below
+
+    // We replay against the original recorded URL
+    appUrl: undefined,
+    simulationIdForAssets: undefined,
+
+    // We don't try comparing to the original screenshot, so just set these to their defaults
+    baseSimulationId: undefined,
     diffThreshold: OPTIONS.diffThreshold.default,
     diffPixelThreshold: OPTIONS.diffPixelThreshold.default,
   };

--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -1,22 +1,26 @@
 import { METICULOUS_LOGGER_NAME, Replay } from "@alwaysmeticulous/common";
-import log from "loglevel";
-import { CommandModule } from "yargs";
 import chalk from "chalk";
 import inquirer from "inquirer";
+import log from "loglevel";
+import { CommandModule } from "yargs";
+import {
+  COMMON_REPLAY_OPTIONS,
+  OPTIONS,
+} from "../../command-utils/common-options";
+import { addTestCase } from "../../utils/config.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import {
   recordCommandHandler,
   RecordCommandHandlerOptions,
 } from "../record/record.command";
 import {
-  replayCommandHandler,
-  ReplayCommandHandlerOptions,
+  rawReplayCommandHandler,
+  RawReplayCommandHandlerOptions,
 } from "../replay/replay.command";
-import { addTestCase } from "../../utils/config.utils";
 
 interface Options
-  extends RecordCommandHandlerOptions,
-    ReplayCommandHandlerOptions {}
+  extends Omit<RecordCommandHandlerOptions, "devTools" | "bypassCSP">,
+    RawReplayCommandHandlerOptions {}
 
 const handleTestCreation: (
   replay: Replay,
@@ -130,7 +134,7 @@ const handler: (options: Options) => Promise<void> = async ({
 
   logger.info("Step 2: validating the new test...");
 
-  const replayOptions: ReplayCommandHandlerOptions = {
+  const replayOptions: RawReplayCommandHandlerOptions = {
     apiToken,
     commitSha,
     sessionId: lastSessionId,
@@ -145,8 +149,16 @@ const handler: (options: Options) => Promise<void> = async ({
     moveBeforeClick,
     cookiesFile,
     accelerate,
+    appUrl: undefined, // we replay against the original recorded URL (TODO: add type: original-recorded-url)
+    save: false, // we handle the saving to meticulous.json ourselves below
+    baseSimulationId: undefined,
+
+    // We haven't yet added command line flags for the below, so we just pass through the defaults
+    cookies: undefined,
+    diffThreshold: OPTIONS.diffThreshold.default,
+    diffPixelThreshold: OPTIONS.diffPixelThreshold.default,
   };
-  const replay = await replayCommandHandler(replayOptions);
+  const replay = await rawReplayCommandHandler(replayOptions);
 
   await handleTestCreation(replay, lastSessionId);
 };
@@ -156,21 +168,8 @@ export const createTest: CommandModule<unknown, Options> = {
   describe: "Create a new test",
   builder: {
     // Common options
-    apiToken: {
-      string: true,
-      demandOption: true,
-    },
-    commitSha: {
-      string: true,
-    },
-    devTools: {
-      boolean: true,
-      description: "Open Chrome Dev Tools",
-    },
-    bypassCSP: {
-      boolean: true,
-      description: "Enables bypass CSP in the browser",
-    },
+    apiToken: OPTIONS.apiToken,
+    commitSha: OPTIONS.commitSha,
     // Record options
     width: {
       number: true,
@@ -192,31 +191,10 @@ export const createTest: CommandModule<unknown, Options> = {
       description: "Enable verbose logging",
     },
     // Replay options
-    headless: {
-      boolean: true,
-      description: "Start browser in headless mode",
-      default: true,
-    },
     screenshotSelector: {
       string: true,
       description:
         "Query selector to screenshot a specific DOM element instead of the whole page",
-    },
-    padTime: {
-      boolean: true,
-      description: "Pad simulation time according to recording duration",
-      default: true,
-    },
-    shiftTime: {
-      boolean: true,
-      description:
-        "Shift time during simulation to be set as the recording time",
-      default: true,
-    },
-    networkStubbing: {
-      boolean: true,
-      description: "Stub network requests during simulation",
-      default: true,
     },
     moveBeforeClick: {
       boolean: true,
@@ -226,11 +204,15 @@ export const createTest: CommandModule<unknown, Options> = {
       string: true,
       description: "Path to cookies to inject before simulation",
     },
+    ...COMMON_REPLAY_OPTIONS,
+    headless: {
+      ...COMMON_REPLAY_OPTIONS.headless,
+      default: true,
+    },
     accelerate: {
-      boolean: true,
+      ...COMMON_REPLAY_OPTIONS.accelerate,
       description:
         "Fast forward through any pauses to replay as fast as possible when replaying for the first time to create the test. Warning: this option is experimental and may be deprecated",
-      default: false,
     },
   },
   handler: wrapHandler(handler),

--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -154,7 +154,6 @@ const handler: (options: Options) => Promise<void> = async ({
     baseSimulationId: undefined,
 
     // We haven't yet added command line flags for the below, so we just pass through the defaults
-    cookies: undefined,
     diffThreshold: OPTIONS.diffThreshold.default,
     diffPixelThreshold: OPTIONS.diffPixelThreshold.default,
   };

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -18,15 +18,15 @@ import { getCommitSha } from "../../utils/commit-sha.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 
 export interface RecordCommandHandlerOptions {
-  apiToken?: string | null | undefined;
-  commitSha?: string | null | undefined;
-  devTools?: boolean | null | undefined;
-  bypassCSP?: boolean | null | undefined;
-  width?: number | null | undefined;
-  height?: number | null | undefined;
-  uploadIntervalMs?: number | null | undefined;
-  incognito?: boolean | null | undefined;
-  trace?: boolean | null | undefined;
+  apiToken: string | undefined;
+  commitSha: string | undefined;
+  devTools: boolean | undefined;
+  bypassCSP: boolean | undefined;
+  width: number | undefined;
+  height: number | undefined;
+  uploadIntervalMs: number | undefined;
+  incognito: boolean | undefined;
+  trace: boolean | undefined;
   onDetectedSession?: (sessionId: string) => void;
 }
 

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -17,6 +17,9 @@ import { fetchAsset } from "../../local-data/replay-assets";
 import { getCommitSha } from "../../utils/commit-sha.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 
+// Note: We use `| undefined` instead of `?` here, despite yargs passing through absent keys for
+// unspecified options. We do this because recordCommandHandler is re-used by create-test
+// and we want to enforce that create-test passes through the full set of options, and does not forget any.
 export interface RecordCommandHandlerOptions {
   apiToken: string | undefined;
   commitSha: string | undefined;

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -13,14 +13,11 @@ import {
   getRecordingCommandId,
   postSessionIdNotification,
 } from "../../api/session.api";
-import { convertNullsToUndefineds } from "../../command-utils/command-utils";
+import { handleNulls } from "../../command-utils/command-utils";
 import { fetchAsset } from "../../local-data/replay-assets";
 import { getCommitSha } from "../../utils/commit-sha.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 
-// Note: We use `| undefined` instead of `?` here, despite yargs passing through absent keys for
-// unspecified options. We do this because recordCommandHandler is re-used by create-test
-// and we want to enforce that create-test passes through the full set of options, and does not forget any.
 export interface RecordCommandHandlerOptions {
   apiToken: string | undefined;
   commitSha: string | undefined;
@@ -193,5 +190,5 @@ export const record: CommandModule<unknown, RecordCommandHandlerOptions> = {
       description: "Enable verbose logging",
     },
   },
-  handler: wrapHandler(convertNullsToUndefineds(recordCommandHandler)),
+  handler: wrapHandler(handleNulls(recordCommandHandler)),
 };

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -13,6 +13,7 @@ import {
   getRecordingCommandId,
   postSessionIdNotification,
 } from "../../api/session.api";
+import { convertNullsToUndefineds } from "../../command-utils/command-utils";
 import { fetchAsset } from "../../local-data/replay-assets";
 import { getCommitSha } from "../../utils/commit-sha.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
@@ -25,9 +26,9 @@ export interface RecordCommandHandlerOptions {
   commitSha: string | undefined;
   devTools: boolean | undefined;
   bypassCSP: boolean | undefined;
-  width: number | undefined | null;
-  height: number | undefined | null;
-  uploadIntervalMs: number | undefined | null;
+  width: number | undefined;
+  height: number | undefined;
+  uploadIntervalMs: number | undefined;
   incognito: boolean | undefined;
   trace: boolean | undefined;
   onDetectedSession?: (sessionId: string) => void;
@@ -192,5 +193,5 @@ export const record: CommandModule<unknown, RecordCommandHandlerOptions> = {
       description: "Enable verbose logging",
     },
   },
-  handler: wrapHandler(recordCommandHandler),
+  handler: wrapHandler(convertNullsToUndefineds(recordCommandHandler)),
 };

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -22,9 +22,9 @@ export interface RecordCommandHandlerOptions {
   commitSha: string | undefined;
   devTools: boolean | undefined;
   bypassCSP: boolean | undefined;
-  width: number | undefined;
-  height: number | undefined;
-  uploadIntervalMs: number | undefined;
+  width: number | undefined | null;
+  height: number | undefined | null;
+  uploadIntervalMs: number | undefined | null;
   incognito: boolean | undefined;
   trace: boolean | undefined;
   onDetectedSession?: (sessionId: string) => void;

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -51,7 +51,7 @@ import { addTestCase } from "../../utils/config.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 import { diffScreenshots } from "../screenshot-diff/screenshot-diff.command";
-import { convertNullsToUndefineds } from "../../command-utils/command-utils";
+import { handleNulls } from "../../command-utils/command-utils";
 
 export interface ReplayOptions extends AdditionalReplayOptions {
   replayTarget: ReplayTarget;
@@ -320,10 +320,6 @@ const unknownReplayTargetType = (replayTarget: never): never => {
   );
 };
 
-// Note: We use `| undefined` instead of `?` here, despite yargs passing through absent keys for
-// unspecified options. We do this because rawReplayCommandHandler and replayCommandHandler,
-// which use these typings, are re-used by create-test and other methods and we want to enforce
-// that these methods pass through the full set of options, and do not forget any.
 export interface RawReplayCommandHandlerOptions
   extends ScreenshotDiffOptions,
     ReplayExecutionOptions,
@@ -476,7 +472,7 @@ export const replay: CommandModule<unknown, RawReplayCommandHandlerOptions> = {
     },
   },
   handler: wrapHandler(
-    convertNullsToUndefineds(async (options) => {
+    handleNulls(async (options) => {
       await rawReplayCommandHandler(options);
     })
   ),

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -30,7 +30,6 @@ import {
   SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
 import {
-  getReplayTarget,
   ScreenshotDiffOptions,
   ScreenshotAssertionsOptions,
 } from "../../command-utils/common-types";
@@ -308,7 +307,7 @@ const serveOrGetAppUrl = async (
   return assertNever(replayTarget);
 };
 
-const assertNever = (value: never): any => {
+const assertNever = (value: never): never => {
   throw new Error(
     `Unhandled discriminated union member: ${JSON.stringify(value)}`
   );
@@ -388,6 +387,22 @@ export const rawReplayCommandHandler = ({
     save,
     exitOnMismatch: true,
   });
+};
+
+const getReplayTarget = ({
+  appUrl,
+  simulationIdForAssets,
+}: {
+  appUrl?: string | undefined;
+  simulationIdForAssets?: string | undefined;
+}): ReplayTarget => {
+  if (simulationIdForAssets) {
+    return { type: "snapshotted-assets", simulationIdForAssets };
+  }
+  if (appUrl) {
+    return { type: "url", appUrl };
+  }
+  return { type: "original-recorded-url" };
 };
 
 export const replay: CommandModule<unknown, RawReplayCommandHandlerOptions> = {

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -30,7 +30,6 @@ import {
   SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
 import {
-  CommonReplayOptions,
   getReplayTarget,
   ScreenshotDiffOptions,
   ScreenshotAssertionsOptions,
@@ -54,9 +53,7 @@ import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 import { diffScreenshots } from "../screenshot-diff/screenshot-diff.command";
 
-export interface ReplayOptions
-  extends CommonReplayOptions,
-    AdditionalReplayOptions {
+export interface ReplayOptions extends AdditionalReplayOptions {
   replayTarget: ReplayTarget;
   executionOptions: ReplayExecutionOptions;
   screenshottingOptions: ScreenshotAssertionsOptions;
@@ -73,7 +70,6 @@ export const replayCommandHandler = async ({
   save,
   exitOnMismatch,
   baseSimulationId: baseReplayId_,
-  cookies,
   cookiesFile,
 }: ReplayOptions): Promise<Replay> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
@@ -176,7 +172,6 @@ export const replayCommandHandler = async ({
       },
     },
     screenshottingOptions,
-    cookies: cookies,
     cookiesFile: cookiesFile,
   };
   await writeFile(
@@ -320,8 +315,7 @@ const assertNever = (value: never): any => {
 };
 
 export interface RawReplayCommandHandlerOptions
-  extends CommonReplayOptions,
-    ScreenshotDiffOptions,
+  extends ScreenshotDiffOptions,
     ReplayExecutionOptions,
     AdditionalReplayOptions {
   screenshot: boolean;
@@ -331,13 +325,15 @@ export interface RawReplayCommandHandlerOptions
 }
 
 interface AdditionalReplayOptions {
+  apiToken: string | undefined;
+  commitSha: string | undefined;
+
   sessionId: string;
 
   save: boolean | undefined;
 
   baseSimulationId: string | undefined;
 
-  cookies: Record<string, any>[] | undefined;
   cookiesFile: string | undefined;
 }
 
@@ -360,7 +356,6 @@ export const rawReplayCommandHandler = ({
   shiftTime,
   networkStubbing,
   moveBeforeClick,
-  cookies,
   cookiesFile,
   accelerate,
 }: RawReplayCommandHandlerOptions): Promise<Replay> => {
@@ -387,7 +382,6 @@ export const rawReplayCommandHandler = ({
     screenshottingOptions,
     apiToken,
     commitSha,
-    cookies,
     cookiesFile,
     sessionId,
     baseSimulationId,

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -58,8 +58,6 @@ export interface ReplayOptions extends AdditionalReplayOptions {
   executionOptions: ReplayExecutionOptions;
   screenshottingOptions: ScreenshotAssertionsOptions;
   exitOnMismatch: boolean;
-  maxDurationMs?: number | null | undefined;
-  maxEventCount?: number | null | undefined;
 }
 
 export const replayCommandHandler = async ({
@@ -73,8 +71,6 @@ export const replayCommandHandler = async ({
   exitOnMismatch,
   baseSimulationId: baseReplayId_,
   cookiesFile,
-  maxDurationMs,
-  maxEventCount,
 }: ReplayOptions): Promise<Replay> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -177,8 +173,6 @@ export const replayCommandHandler = async ({
     },
     screenshottingOptions,
     cookiesFile: cookiesFile,
-    ...(maxDurationMs != null ? { maxDurationMs } : {}),
-    ...(maxEventCount != null ? { maxEventCount } : {}),
   };
   await writeFile(
     join(tempDir, "replayEventsParams.json"),
@@ -360,6 +354,8 @@ export const rawReplayCommandHandler = ({
   moveBeforeClick,
   cookiesFile,
   accelerate,
+  maxDurationMs,
+  maxEventCount,
 }: RawReplayCommandHandlerOptions): Promise<Replay> => {
   const executionOptions: ReplayExecutionOptions = {
     headless,
@@ -370,6 +366,8 @@ export const rawReplayCommandHandler = ({
     networkStubbing,
     accelerate,
     moveBeforeClick,
+    maxDurationMs: maxDurationMs ?? undefined,
+    maxEventCount: maxEventCount ?? undefined,
   };
   const screenshottingOptions: ScreenshotAssertionsOptions = screenshot
     ? {

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -314,26 +314,26 @@ const assertNever = (value: never): any => {
   );
 };
 
+// Note: We use `| undefined` instead of `?` here, despite yargs passing through absent keys for
+// unspecified options. We do this because rawReplayCommandHandler and replayCommandHandler,
+// which use these typings, are re-used by create-test and other methods and we want to enforce
+// that these methods pass through the full set of options, and do not forget any.
 export interface RawReplayCommandHandlerOptions
   extends ScreenshotDiffOptions,
     ReplayExecutionOptions,
     AdditionalReplayOptions {
   screenshot: boolean;
   appUrl: string | undefined;
-  simulationIdForAssets?: string;
+  simulationIdForAssets: string | undefined;
   screenshotSelector: string | undefined;
 }
 
 interface AdditionalReplayOptions {
   apiToken: string | undefined;
   commitSha: string | undefined;
-
   sessionId: string;
-
   save: boolean | undefined;
-
   baseSimulationId: string | undefined;
-
   cookiesFile: string | undefined;
 }
 

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -304,12 +304,12 @@ const serveOrGetAppUrl = async (
   if (replayTarget.type === "original-recorded-url") {
     return {};
   }
-  return assertNever(replayTarget);
+  return unknownReplayTargetType(replayTarget);
 };
 
-const assertNever = (value: never): never => {
+const unknownReplayTargetType = (replayTarget: never): never => {
   throw new Error(
-    `Unhandled discriminated union member: ${JSON.stringify(value)}`
+    `Unknown type of replay target: ${JSON.stringify(replayTarget)}`
   );
 };
 

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -51,6 +51,7 @@ import { addTestCase } from "../../utils/config.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 import { diffScreenshots } from "../screenshot-diff/screenshot-diff.command";
+import { convertNullsToUndefineds } from "../../command-utils/command-utils";
 
 export interface ReplayOptions extends AdditionalReplayOptions {
   replayTarget: ReplayTarget;
@@ -460,7 +461,9 @@ export const replay: CommandModule<unknown, RawReplayCommandHandlerOptions> = {
     ...COMMON_REPLAY_OPTIONS,
     ...SCREENSHOT_DIFF_OPTIONS,
   },
-  handler: wrapHandler(async (options) => {
-    await rawReplayCommandHandler(options);
-  }),
+  handler: wrapHandler(
+    convertNullsToUndefineds(async (options) => {
+      await rawReplayCommandHandler(options);
+    })
+  ),
 };

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -8,7 +8,6 @@ import {
   ReplayExecutionOptions,
   ReplayTarget,
 } from "@alwaysmeticulous/common/dist/types/replay.types";
-import { throws } from "assert";
 import { AxiosInstance } from "axios";
 import { mkdir, mkdtemp, writeFile } from "fs/promises";
 import log from "loglevel";
@@ -26,9 +25,9 @@ import {
 import { uploadArchive } from "../../api/upload";
 import { createReplayArchive, deleteArchive } from "../../archive/archive";
 import {
-  SCREENSHOT_DIFF_OPTIONS,
   COMMON_REPLAY_OPTIONS,
   OPTIONS,
+  SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
 import {
   CommonReplayOptions,

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -30,6 +30,7 @@ import { writeGitHubSummary } from "../../utils/github-summary.utils";
 import { getTestsToRun, sortResults } from "../../utils/run-all-tests.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
+import { convertNullsToUndefineds } from "../../command-utils/command-utils";
 
 interface Options extends ScreenshotDiffOptions, ReplayExecutionOptions {
   apiToken?: string;
@@ -243,5 +244,5 @@ export const runAllTests: CommandModule<unknown, Options> = {
     ...COMMON_REPLAY_OPTIONS,
     ...SCREENSHOT_DIFF_OPTIONS,
   },
-  handler: wrapHandler(handler),
+  handler: wrapHandler(convertNullsToUndefineds(handler)),
 };

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -18,6 +18,8 @@ import {
 } from "../../command-utils/common-options";
 import {
   CommonReplayOptions,
+  TestExpectationOptions,
+  ReplayExecutionOptions,
   ScreenshotDiffOptions,
 } from "../../command-utils/common-types";
 import { readConfig } from "../../config/config";
@@ -31,7 +33,11 @@ import { getTestsToRun, sortResults } from "../../utils/run-all-tests.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 
-interface Options extends CommonReplayOptions, ScreenshotDiffOptions {
+// TODO: Types
+interface Options
+  extends CommonReplayOptions,
+    Partial<ScreenshotDiffOptions>,
+    ReplayExecutionOptions {
   appUrl?: string | null | undefined;
   useAssetsSnapshottedInBaseSimulation?: boolean | null | undefined;
   githubSummary?: boolean | null | undefined;
@@ -63,6 +69,21 @@ const handler: (options: Options) => Promise<void> = async ({
   testsFile,
   accelerate,
 }) => {
+  const replayExecutionOptions: ReplayExecutionOptions = {
+    appUrl,
+    headless,
+    devTools,
+    bypassCSP,
+    padTime,
+    shiftTime,
+    networkStubbing,
+    accelerate,
+  };
+  const testExpectationOptions: TestExpectationOptions = {
+    screenshotDiffs: { diffPixelThreshold, diffThreshold },
+    screenshotSelector: undefined,
+  };
+
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const client = createClient({ apiToken });
@@ -100,22 +121,14 @@ const handler: (options: Options) => Promise<void> = async ({
         config,
         client,
         testRun,
+        replayExecutionOptions,
+        testExpectationOptions,
         apiToken,
         commitSha,
-        appUrl,
         useAssetsSnapshottedInBaseSimulation,
-        headless,
-        devTools,
-        bypassCSP,
-        diffThreshold,
-        diffPixelThreshold,
-        padTime,
-        shiftTime,
-        networkStubbing,
         parallelTasks,
         deflake,
         cachedTestRunResults,
-        accelerate,
       });
       return results;
     }

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -139,7 +139,7 @@ const handler: (options: Options) => Promise<void> = async ({
         replayTarget: getReplayTargetForTestCase({
           useAssetsSnapshottedInBaseSimulation,
           appUrl,
-          baseReplayId: testCase.baseReplayId,
+          testCase,
         }),
         executionOptions,
         screenshottingOptions,

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -32,9 +32,9 @@ import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 
 interface Options extends ScreenshotDiffOptions, ReplayExecutionOptions {
-  apiToken: string | undefined;
-  commitSha: string | undefined;
-  appUrl: string | undefined;
+  apiToken?: string;
+  commitSha?: string;
+  appUrl?: string;
   useAssetsSnapshottedInBaseSimulation: boolean;
   githubSummary?: boolean;
   parallelize?: boolean;

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -194,6 +194,8 @@ export const runAllTests: CommandModule<unknown, Options> = {
     commitSha: OPTIONS.commitSha,
     appUrl: {
       string: true,
+      description:
+        "The URL to execute the tests against. If left absent here and in the test cases file, then will use the URL the test was originally recorded against.",
     },
     useAssetsSnapshottedInBaseSimulation: {
       boolean: true,

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -12,14 +12,13 @@ import {
   putTestRunResults,
 } from "../../api/test-run.api";
 import {
-  SCREENSHOT_DIFF_OPTIONS,
   COMMON_REPLAY_OPTIONS,
   OPTIONS,
+  SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
 import {
-  CommonReplayOptions,
-  ScreenshotDiffOptions,
   ScreenshotAssertionsOptions,
+  ScreenshotDiffOptions,
 } from "../../command-utils/common-types";
 import { readConfig } from "../../config/config";
 import { TestCaseResult } from "../../config/config.types";
@@ -32,10 +31,9 @@ import { getTestsToRun, sortResults } from "../../utils/run-all-tests.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 
-interface Options
-  extends CommonReplayOptions,
-    ScreenshotDiffOptions,
-    ReplayExecutionOptions {
+interface Options extends ScreenshotDiffOptions, ReplayExecutionOptions {
+  apiToken: string | undefined;
+  commitSha: string | undefined;
   appUrl: string | undefined;
   useAssetsSnapshottedInBaseSimulation: boolean;
   githubSummary?: boolean;

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -19,7 +19,7 @@ import {
 import {
   CommonReplayOptions,
   ScreenshotDiffOptions,
-  TestExpectationOptions,
+  ScreenshotAssertionsOptions,
 } from "../../command-utils/common-types";
 import { readConfig } from "../../config/config";
 import { TestCaseResult } from "../../config/config.types";
@@ -32,7 +32,6 @@ import { getTestsToRun, sortResults } from "../../utils/run-all-tests.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 
-// TODO: Types
 interface Options
   extends CommonReplayOptions,
     ScreenshotDiffOptions,
@@ -78,9 +77,10 @@ const handler: (options: Options) => Promise<void> = async ({
     accelerate,
     moveBeforeClick: false, // moveBeforeClick isn't exposed as an option for run-all-tests
   };
-  const expectationOptions: TestExpectationOptions = {
-    screenshotDiffs: { diffPixelThreshold, diffThreshold },
+  const screenshottingOptions: ScreenshotAssertionsOptions = {
+    enabled: true,
     screenshotSelector: undefined, // this is only specified on a test case level
+    diffOptions: { diffPixelThreshold, diffThreshold },
   };
 
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
@@ -121,7 +121,7 @@ const handler: (options: Options) => Promise<void> = async ({
         client,
         testRun,
         executionOptions,
-        expectationOptions,
+        screenshottingOptions,
         apiToken,
         commitSha,
         appUrl,
@@ -143,7 +143,7 @@ const handler: (options: Options) => Promise<void> = async ({
           baseReplayId: testCase.baseReplayId,
         }),
         executionOptions,
-        expectationOptions,
+        screenshottingOptions,
         testCase,
         apiToken,
         commitSha,

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -30,7 +30,7 @@ import { writeGitHubSummary } from "../../utils/github-summary.utils";
 import { getTestsToRun, sortResults } from "../../utils/run-all-tests.utils";
 import { wrapHandler } from "../../utils/sentry.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
-import { convertNullsToUndefineds } from "../../command-utils/command-utils";
+import { handleNulls } from "../../command-utils/command-utils";
 
 interface Options extends ScreenshotDiffOptions, ReplayExecutionOptions {
   apiToken?: string;
@@ -244,5 +244,5 @@ export const runAllTests: CommandModule<unknown, Options> = {
     ...COMMON_REPLAY_OPTIONS,
     ...SCREENSHOT_DIFF_OPTIONS,
   },
-  handler: wrapHandler(convertNullsToUndefineds(handler)),
+  handler: wrapHandler(handleNulls(handler)),
 };

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -41,7 +41,7 @@ interface Options
   useAssetsSnapshottedInBaseSimulation: boolean;
   githubSummary?: boolean;
   parallelize?: boolean;
-  parallelTasks?: number;
+  parallelTasks?: number | null;
   deflake: boolean;
   useCache: boolean;
   testsFile?: string;
@@ -126,7 +126,7 @@ const handler: (options: Options) => Promise<void> = async ({
         commitSha,
         appUrl,
         useAssetsSnapshottedInBaseSimulation,
-        parallelTasks,
+        parallelTasks: parallelTasks ?? undefined,
         deflake,
         cachedTestRunResults,
       });

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -75,6 +75,8 @@ const handler: (options: Options) => Promise<void> = async ({
     networkStubbing,
     accelerate,
     moveBeforeClick: false, // moveBeforeClick isn't exposed as an option for run-all-tests
+    maxDurationMs: undefined, // we don't expose this option
+    maxEventCount: undefined, // we don't expose this option
   };
   const screenshottingOptions: ScreenshotAssertionsOptions = {
     enabled: true,

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -111,7 +111,7 @@ export const diffScreenshots: (options: {
       const comparisonResult = compareImages({
         base: baseScreenshot,
         head: headScreenshot,
-        pixelThreshold: diffPixelThreshold ?? null,
+        pixelThreshold: diffPixelThreshold,
       });
 
       totalMismatchPixels += comparisonResult.mismatchPixels;

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -50,8 +50,9 @@ export const diffScreenshots: (options: {
   const { diffThreshold, diffPixelThreshold } = diffOptions;
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const pixelmatchOptions: CompareImageOptions["pixelmatchOptions"] | null =
-    diffPixelThreshold ? { threshold: diffPixelThreshold } : null;
+  const pixelmatchOptions: CompareImageOptions["pixelmatchOptions"] = {
+    threshold: diffPixelThreshold,
+  };
 
   try {
     const { mismatchPixels, mismatchFraction, diff } = compareImages({

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -5,6 +5,7 @@ import { PNG } from "pngjs";
 import { CommandModule } from "yargs";
 import { createClient } from "../../api/client";
 import { getDiffUrl, postScreenshotDiffStats } from "../../api/replay.api";
+import { SCREENSHOT_DIFF_OPTIONS } from "../../command-utils/common-options";
 import { CompareImageOptions, compareImages } from "../../image/diff.utils";
 import {
   getOrFetchReplay,
@@ -13,8 +14,6 @@ import {
 } from "../../local-data/replays";
 import { writeScreenshotDiff } from "../../local-data/screenshot-diffs";
 import { wrapHandler } from "../../utils/sentry.utils";
-
-const DEFAULT_MISMATCH_THRESHOLD = 0.01;
 
 export class DiffError extends Error {
   constructor(
@@ -36,8 +35,8 @@ export const diffScreenshots: (options: {
   headReplayId: string;
   baseScreenshot: PNG;
   headScreenshot: PNG;
-  threshold: number | null | undefined;
-  pixelThreshold: number | null | undefined;
+  threshold: number;
+  pixelThreshold: number;
   exitOnMismatch: boolean;
 }) => Promise<void> = async ({
   client,
@@ -45,13 +44,12 @@ export const diffScreenshots: (options: {
   headReplayId,
   baseScreenshot,
   headScreenshot,
-  threshold: threshold_,
+  threshold,
   pixelThreshold,
   exitOnMismatch,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const threshold = threshold_ || DEFAULT_MISMATCH_THRESHOLD;
   const pixelmatchOptions: CompareImageOptions["pixelmatchOptions"] | null =
     pixelThreshold ? { threshold: pixelThreshold } : null;
 
@@ -117,8 +115,8 @@ interface Options {
   apiToken?: string | null | undefined;
   baseSimulationId: string;
   headSimulationId: string;
-  threshold?: number | null | undefined;
-  pixelThreshold?: number | null | undefined;
+  threshold: number;
+  pixelThreshold: number;
 }
 
 const handler: (options: Options) => Promise<void> = async ({
@@ -167,12 +165,8 @@ export const screenshotDiff: CommandModule<unknown, Options> = {
       demandOption: true,
       alias: "headReplayId",
     },
-    threshold: {
-      number: true,
-    },
-    pixelThreshold: {
-      number: true,
-    },
+    threshold: SCREENSHOT_DIFF_OPTIONS.diffThreshold,
+    pixelThreshold: SCREENSHOT_DIFF_OPTIONS.diffPixelThreshold,
   },
   handler: wrapHandler(handler),
 };

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2,7 +2,7 @@ import { cosmiconfig } from "cosmiconfig";
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { cwd } from "process";
-import { MeticulousCliConfig, ReplayOptions } from "./config.types";
+import { MeticulousCliConfig, TestCaseReplayOptions } from "./config.types";
 
 const METICULOUS_CONFIG_FILE = "meticulous.json";
 
@@ -24,16 +24,16 @@ const getConfigFilePath: () => Promise<string> = async () => {
   return configFilePath;
 };
 
-const validateReplayOptions: (options: ReplayOptions) => ReplayOptions = (
-  prevOptions
-) => {
+const validateReplayOptions: (
+  options: TestCaseReplayOptions
+) => TestCaseReplayOptions = (prevOptions) => {
   const {
     screenshotSelector,
     diffThreshold,
     diffPixelThreshold,
     cookies,
     moveBeforeClick,
-    useAssetsFromReplayId,
+    simulationIdForAssets,
   } = prevOptions;
   return {
     ...(screenshotSelector ? { screenshotSelector } : {}),
@@ -41,7 +41,7 @@ const validateReplayOptions: (options: ReplayOptions) => ReplayOptions = (
     ...(diffPixelThreshold ? { diffPixelThreshold } : {}),
     ...(cookies ? { cookies } : {}),
     ...(moveBeforeClick ? { moveBeforeClick } : {}),
-    ...(useAssetsFromReplayId ? { useAssetsFromReplayId } : {}),
+    ...(simulationIdForAssets ? { simulationIdForAssets } : {}),
   };
 };
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -31,7 +31,6 @@ const validateReplayOptions: (
     screenshotSelector,
     diffThreshold,
     diffPixelThreshold,
-    cookies,
     moveBeforeClick,
     simulationIdForAssets,
   } = prevOptions;
@@ -39,7 +38,6 @@ const validateReplayOptions: (
     ...(screenshotSelector ? { screenshotSelector } : {}),
     ...(diffThreshold ? { diffThreshold } : {}),
     ...(diffPixelThreshold ? { diffPixelThreshold } : {}),
-    ...(cookies ? { cookies } : {}),
     ...(moveBeforeClick ? { moveBeforeClick } : {}),
     ...(simulationIdForAssets ? { simulationIdForAssets } : {}),
   };

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -10,7 +10,6 @@ export interface TestCaseReplayOptions extends Partial<ScreenshotDiffOptions> {
 
   screenshotSelector?: string;
 
-  cookies?: Record<string, any>[];
   moveBeforeClick?: boolean;
 }
 

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -1,11 +1,16 @@
-import {
-  PerReplayOptions,
-  ScreenshotDiffOptions,
-} from "../command-utils/common-types";
+import { ScreenshotDiffOptions } from "../command-utils/common-types";
 
-export interface TestCaseReplayOptions
-  extends Partial<PerReplayOptions>,
-    ScreenshotDiffOptions {
+export interface TestCaseReplayOptions extends Partial<ScreenshotDiffOptions> {
+  appUrl?: string | null | undefined;
+
+  /**
+   * If present will run the session against a local server serving up previously snapshotted assets (HTML, JS, CSS etc.) from the specified prior replay, instead of against a URL.
+   */
+  simulationIdForAssets?: string | undefined;
+
+  screenshotSelector?: string;
+
+  cookies?: Record<string, any>[];
   moveBeforeClick?: boolean;
 }
 

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -1,21 +1,19 @@
-export interface ReplayOptions {
-  screenshotSelector?: string;
-  diffThreshold?: number;
-  diffPixelThreshold?: number;
-  cookies?: Record<string, any>[];
-  moveBeforeClick?: boolean;
+import {
+  PerReplayOptions,
+  ScreenshotDiffOptions,
+} from "../command-utils/common-types";
 
-  /**
-   * If present will run the session against a local server serving up previously snapshotted assets (HTML, JS, CSS etc.) from the specified prior replay, instead of against a URL.
-   */
-  useAssetsFromReplayId?: string;
+export interface TestCaseReplayOptions
+  extends Partial<PerReplayOptions>,
+    ScreenshotDiffOptions {
+  moveBeforeClick?: boolean;
 }
 
 export interface TestCase {
   title: string;
   sessionId: string;
   baseReplayId: string;
-  options?: ReplayOptions;
+  options?: TestCaseReplayOptions;
 }
 
 export interface MeticulousCliConfig {

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -6,8 +6,8 @@ import {
 import log from "loglevel";
 import {
   applyTestCaseExecutionOptionOverrides,
-  applyTestCaseExpectationOptionsOverrides,
-  TestExpectationOptions,
+  applyTestCaseScreenshottingOptionsOverrides,
+  ScreenshotAssertionsEnabledOptions,
 } from "../command-utils/common-types";
 import { replayCommandHandler } from "../commands/replay/replay.command";
 import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
@@ -19,7 +19,7 @@ const handleReplay: (
   testCase,
   replayTarget,
   executionOptions,
-  expectationOptions,
+  screenshottingOptions,
   apiToken,
   commitSha,
 }) => {
@@ -31,15 +31,14 @@ const handleReplay: (
       executionOptions,
       testCase.options ?? {}
     ),
-    expectationOptions: applyTestCaseExpectationOptionsOverrides(
-      expectationOptions,
+    screenshottingOptions: applyTestCaseScreenshottingOptionsOverrides(
+      screenshottingOptions,
       testCase.options ?? {}
     ),
     apiToken,
     commitSha,
     sessionId: testCase.sessionId,
     baseSimulationId: testCase.baseReplayId,
-    screenshot: true,
     save: false,
     exitOnMismatch: false,
     cookies: undefined,
@@ -76,7 +75,7 @@ export interface DeflakeReplayCommandHandlerOptions
 interface HandleReplayOptions {
   replayTarget: ReplayTarget;
   executionOptions: ReplayExecutionOptions;
-  expectationOptions: TestExpectationOptions;
+  screenshottingOptions: ScreenshotAssertionsEnabledOptions;
   testCase: TestCase;
   apiToken: string | undefined;
   commitSha: string;

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -1,27 +1,49 @@
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import {
+  ReplayExecutionOptions,
+  ReplayTarget,
+} from "@alwaysmeticulous/common/dist/types/replay.types";
 import log from "loglevel";
 import {
-  CommonReplayOptions,
-  ScreenshotDiffOptions,
+  applyTestCaseExecutionOptionOverrides,
+  applyTestCaseExpectationOptionsOverrides,
+  TestExpectationOptions,
 } from "../command-utils/common-types";
 import { replayCommandHandler } from "../commands/replay/replay.command";
 import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
 import { TestCase, TestCaseResult } from "../config/config.types";
 
-const handleReplay: (options: {
-  testCase: TestCase;
-  options: HandleReplayOptions;
-}) => Promise<TestCaseResult> = async ({ testCase, options }) => {
+const handleReplay: (
+  options: HandleReplayOptions
+) => Promise<TestCaseResult> = async ({
+  testCase,
+  replayTarget,
+  executionOptions,
+  expectationOptions,
+  apiToken,
+  commitSha,
+}) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const replayPromise = replayCommandHandler({
+    replayTarget,
+    executionOptions: applyTestCaseExecutionOptionOverrides(
+      executionOptions,
+      testCase.options ?? {}
+    ),
+    expectationOptions: applyTestCaseExpectationOptionsOverrides(
+      expectationOptions,
+      testCase.options ?? {}
+    ),
+    apiToken,
+    commitSha,
     sessionId: testCase.sessionId,
     baseSimulationId: testCase.baseReplayId,
     screenshot: true,
     save: false,
     exitOnMismatch: false,
-    ...testCase.options,
-    ...options, // CLI options override testCase options
+    cookies: undefined,
+    cookiesFile: undefined,
   });
   const result: TestCaseResult = await replayPromise
     .then(
@@ -48,30 +70,34 @@ const handleReplay: (options: {
 
 export interface DeflakeReplayCommandHandlerOptions
   extends HandleReplayOptions {
-  testCase: TestCase;
   deflake: boolean;
 }
 
-interface HandleReplayOptions
-  extends CommonReplayOptions,
-    ScreenshotDiffOptions {}
+interface HandleReplayOptions {
+  replayTarget: ReplayTarget;
+  executionOptions: ReplayExecutionOptions;
+  expectationOptions: TestExpectationOptions;
+  testCase: TestCase;
+  apiToken: string | undefined;
+  commitSha: string;
+}
 
 export const deflakeReplayCommandHandler: (
   options: DeflakeReplayCommandHandlerOptions
-) => Promise<TestCaseResult> = async ({ testCase, deflake, ...options }) => {
+) => Promise<TestCaseResult> = async ({ deflake, ...otherOptions }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const firstResult = await handleReplay({ testCase, options });
+  const firstResult = await handleReplay(otherOptions);
   if (firstResult.result === "pass" || !deflake) {
     return firstResult;
   }
 
-  const secondResult = await handleReplay({ testCase, options });
+  const secondResult = await handleReplay(otherOptions);
   if (secondResult.result === "fail") {
     return secondResult;
   }
 
-  const thirdResult = await handleReplay({ testCase, options });
+  const thirdResult = await handleReplay(otherOptions);
   logger.info(`FLAKE: ${thirdResult.title} => ${thirdResult.result}`);
   return thirdResult;
 };

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -1,19 +1,28 @@
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import log from "loglevel";
 import {
-  replayCommandHandler,
-  ReplayCommandHandlerOptions,
-} from "../commands/replay/replay.command";
+  CommonReplayOptions,
+  ScreenshotDiffOptions,
+} from "../command-utils/common-types";
+import { replayCommandHandler } from "../commands/replay/replay.command";
 import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
 import { TestCase, TestCaseResult } from "../config/config.types";
 
 const handleReplay: (options: {
   testCase: TestCase;
-  options: ReplayCommandHandlerOptions;
+  options: HandleReplayOptions;
 }) => Promise<TestCaseResult> = async ({ testCase, options }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const replayPromise = replayCommandHandler(options);
+  const replayPromise = replayCommandHandler({
+    sessionId: testCase.sessionId,
+    baseSimulationId: testCase.baseReplayId,
+    screenshot: true,
+    save: false,
+    exitOnMismatch: false,
+    ...testCase.options,
+    ...options, // CLI options override testCase options
+  });
   const result: TestCaseResult = await replayPromise
     .then(
       (replay) =>
@@ -38,10 +47,14 @@ const handleReplay: (options: {
 };
 
 export interface DeflakeReplayCommandHandlerOptions
-  extends ReplayCommandHandlerOptions {
+  extends HandleReplayOptions {
   testCase: TestCase;
   deflake: boolean;
 }
+
+interface HandleReplayOptions
+  extends CommonReplayOptions,
+    ScreenshotDiffOptions {}
 
 export const deflakeReplayCommandHandler: (
   options: DeflakeReplayCommandHandlerOptions

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -41,7 +41,6 @@ const handleReplay: (
     baseSimulationId: testCase.baseReplayId,
     save: false,
     exitOnMismatch: false,
-    cookies: undefined,
     cookiesFile: undefined,
   });
   const result: TestCaseResult = await replayPromise

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -3,7 +3,6 @@ import {
   ReplayExecutionOptions,
   ReplayTarget,
 } from "@alwaysmeticulous/common/dist/types/replay.types";
-import defaults from "lodash/defaults";
 import log from "loglevel";
 import {
   ScreenshotAssertionsEnabledOptions,
@@ -110,14 +109,15 @@ const applyTestCaseExecutionOptionOverrides = (
 ) => {
   // Options specified in the test case override those passed as CLI flags
   // (CLI flags set the defaults)
-  return defaults(
-    {},
-    {
-      moveBeforeClick: overridesFromTestCase.moveBeforeClick,
-      simulationIdForAssets: overridesFromTestCase.simulationIdForAssets,
-    },
-    executionOptionsFromCliFlags
-  );
+  return {
+    ...executionOptionsFromCliFlags,
+    moveBeforeClick:
+      overridesFromTestCase.moveBeforeClick ??
+      executionOptionsFromCliFlags.moveBeforeClick,
+    simulationIdForAssets:
+      overridesFromTestCase.simulationIdForAssets ??
+      executionOptionsFromCliFlags.simulationIdForAssets,
+  };
 };
 
 const applyTestCaseScreenshottingOptionsOverrides = (

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -106,7 +106,7 @@ export const deflakeReplayCommandHandler: (
 const applyTestCaseExecutionOptionOverrides = (
   executionOptionsFromCliFlags: ReplayExecutionOptions,
   overridesFromTestCase: TestCaseReplayOptions
-) => {
+): ReplayExecutionOptions => {
   // Options specified in the test case override those passed as CLI flags
   // (CLI flags set the defaults)
   return {
@@ -114,9 +114,6 @@ const applyTestCaseExecutionOptionOverrides = (
     moveBeforeClick:
       overridesFromTestCase.moveBeforeClick ??
       executionOptionsFromCliFlags.moveBeforeClick,
-    simulationIdForAssets:
-      overridesFromTestCase.simulationIdForAssets ??
-      executionOptionsFromCliFlags.simulationIdForAssets,
   };
 };
 
@@ -126,14 +123,14 @@ const applyTestCaseScreenshottingOptionsOverrides = (
 ): ScreenshotAssertionsEnabledOptions => {
   // Options specified in the test case override those passed as CLI flags
   // (CLI flags set the defaults)
-  const diffOptions: ScreenshotDiffOptions = defaults(
-    {},
-    {
-      diffThreshold: overridesFromTestCase.diffThreshold,
-      diffPixelThreshold: overridesFromTestCase.diffPixelThreshold,
-    },
-    screenshottingOptionsFromCliFlags.diffOptions
-  );
+  const diffOptions: ScreenshotDiffOptions = {
+    diffThreshold:
+      overridesFromTestCase.diffThreshold ??
+      screenshottingOptionsFromCliFlags.diffOptions.diffThreshold,
+    diffPixelThreshold:
+      overridesFromTestCase.diffPixelThreshold ??
+      screenshottingOptionsFromCliFlags.diffOptions.diffPixelThreshold,
+  };
   return {
     enabled: true,
     screenshotSelector:

--- a/packages/cli/src/image/diff.utils.ts
+++ b/packages/cli/src/image/diff.utils.ts
@@ -4,7 +4,15 @@ import { PNG } from "pngjs";
 export interface CompareImageOptions {
   base: PNG;
   head: PNG;
-  pixelThreshold: number | null;
+
+  /**
+   * Maximum colour distance a given pixel is allowed to differ before counting two
+   * pixels as different.
+   *
+   * Measure is based on "Measuring perceived color difference using YIQ NTSC transmission color space
+   * in mobile applications" by Y. Kotsarenko and F. Ramos
+   */
+  pixelThreshold: number;
 }
 
 export interface CompareImageResult {
@@ -30,7 +38,7 @@ export const compareImages: (
     width,
     height,
     {
-      threshold: pixelThreshold ?? undefined,
+      threshold: pixelThreshold,
     }
   );
   const mismatchFraction = mismatchPixels / (width * height);

--- a/packages/cli/src/parallel-tests/messages.types.ts
+++ b/packages/cli/src/parallel-tests/messages.types.ts
@@ -1,22 +1,13 @@
 import log from "loglevel";
-import {
-  CommonReplayOptions,
-  ReplayExecutionOptions,
-  TestExpectationOptions,
-} from "../command-utils/common-types";
-import { TestCase, TestCaseResult } from "../config/config.types";
+import { TestCaseResult } from "../config/config.types";
+import { DeflakeReplayCommandHandlerOptions } from "../deflake-tests/deflake-tests.handler";
 
 export interface InitMessage {
   kind: "init";
   data: {
     logLevel: log.LogLevel[keyof log.LogLevel];
     dataDir: string;
-    runAllOptions: {
-      replayExecution: ReplayExecutionOptions;
-      testExpectations: TestExpectationOptions;
-    } & CommonReplayOptions;
-    testCase: TestCase;
-    deflake: boolean;
+    replayOptions: DeflakeReplayCommandHandlerOptions;
   };
 }
 

--- a/packages/cli/src/parallel-tests/messages.types.ts
+++ b/packages/cli/src/parallel-tests/messages.types.ts
@@ -1,6 +1,9 @@
 import log from "loglevel";
-import { ScreenshotDiffOptions } from "../command-utils/common-types";
-import { CLIOnlyReplayOptions } from "../commands/replay/replay.command";
+import {
+  CommonReplayOptions,
+  ReplayExecutionOptions,
+  TestExpectationOptions,
+} from "../command-utils/common-types";
 import { TestCase, TestCaseResult } from "../config/config.types";
 
 export interface InitMessage {
@@ -8,7 +11,10 @@ export interface InitMessage {
   data: {
     logLevel: log.LogLevel[keyof log.LogLevel];
     dataDir: string;
-    runAllOptions: CLIOnlyReplayOptions & ScreenshotDiffOptions;
+    runAllOptions: {
+      replayExecution: ReplayExecutionOptions;
+      testExpectations: TestExpectationOptions;
+    } & CommonReplayOptions;
     testCase: TestCase;
     deflake: boolean;
   };

--- a/packages/cli/src/parallel-tests/messages.types.ts
+++ b/packages/cli/src/parallel-tests/messages.types.ts
@@ -1,4 +1,6 @@
 import log from "loglevel";
+import { ScreenshotDiffOptions } from "../command-utils/common-types";
+import { CLIOnlyReplayOptions } from "../commands/replay/replay.command";
 import { TestCase, TestCaseResult } from "../config/config.types";
 
 export interface InitMessage {
@@ -6,21 +8,7 @@ export interface InitMessage {
   data: {
     logLevel: log.LogLevel[keyof log.LogLevel];
     dataDir: string;
-    runAllOptions: {
-      apiToken: string | null | undefined;
-      commitSha: string | null | undefined;
-      appUrl: string | null | undefined;
-      simulationIdForAssets?: string | null | undefined;
-      headless: boolean | null | undefined;
-      devTools: boolean | null | undefined;
-      bypassCSP: boolean | null | undefined;
-      diffThreshold: number | null | undefined;
-      diffPixelThreshold: number | null | undefined;
-      padTime: boolean;
-      shiftTime: boolean;
-      networkStubbing: boolean;
-      accelerate: boolean;
-    };
+    runAllOptions: CLIOnlyReplayOptions & ScreenshotDiffOptions;
     testCase: TestCase;
     deflake: boolean;
   };

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -30,7 +30,7 @@ export interface RunAllTestsInParallelOptions {
   devTools: boolean | null | undefined;
   bypassCSP: boolean | null | undefined;
   diffThreshold: number | null | undefined;
-  diffPixelThreshold: number | null | undefined;
+  diffPixelThreshold: number;
   padTime: boolean;
   shiftTime: boolean;
   networkStubbing: boolean;
@@ -113,6 +113,18 @@ export const runAllTestsInParallel: (
     child.on("message", messageHandler);
 
     // Send test case and arguments to child process
+    const simulationIdForAssets = getSimulationIdForAssets(
+      testCase,
+      useAssetsSnapshottedInBaseSimulation
+    );
+    const testCaseWithOverridesApplied = {
+      ...testCase,
+      options: {
+        ...(testCase.options ?? {}),
+        appUrl,
+        simulationIdForAssets,
+      },
+    };
     const initMessage: InitMessage = {
       kind: "init",
       data: {
@@ -121,22 +133,18 @@ export const runAllTestsInParallel: (
         runAllOptions: {
           apiToken,
           commitSha,
-          appUrl,
           headless,
           devTools,
           bypassCSP,
-          diffThreshold,
+          diffThreshold: diffThreshold ?? undefined,
           diffPixelThreshold,
           padTime,
           shiftTime,
           networkStubbing,
-          simulationIdForAssets: getSimulationIdForAssets(
-            testCase,
-            useAssetsSnapshottedInBaseSimulation
-          ),
           accelerate,
+          screenshot: true,
         },
-        testCase,
+        testCaseWithOverridesApplied,
         deflake,
       },
     };

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -10,6 +10,10 @@ import { cpus } from "os";
 import { join } from "path";
 import { putTestRunResults, TestRun } from "../api/test-run.api";
 import {
+  ReplayExecutionOptions,
+  TestExpectationOptions,
+} from "../command-utils/common-types";
+import {
   MeticulousCliConfig,
   TestCase,
   TestCaseResult,
@@ -22,22 +26,14 @@ export interface RunAllTestsInParallelOptions {
   config: MeticulousCliConfig;
   client: AxiosInstance;
   testRun: TestRun;
+  replayExecutionOptions: ReplayExecutionOptions;
+  testExpectationOptions: TestExpectationOptions;
   apiToken: string | null | undefined;
   commitSha: string | null | undefined;
-  appUrl: string | null | undefined;
   useAssetsSnapshottedInBaseSimulation?: boolean | null | undefined;
-  headless: boolean | null | undefined;
-  devTools: boolean | null | undefined;
-  bypassCSP: boolean | null | undefined;
-  diffThreshold: number | null | undefined;
-  diffPixelThreshold: number;
-  padTime: boolean;
-  shiftTime: boolean;
-  networkStubbing: boolean;
   parallelTasks: number | null | undefined;
   deflake: boolean;
   cachedTestRunResults: TestCaseResult[];
-  accelerate: boolean;
 }
 
 /** Handler for running Meticulous tests in parallel using child processes */
@@ -49,20 +45,12 @@ export const runAllTestsInParallel: (
   testRun,
   apiToken,
   commitSha,
-  appUrl,
   useAssetsSnapshottedInBaseSimulation,
-  headless,
-  devTools,
-  bypassCSP,
-  diffThreshold,
-  diffPixelThreshold,
-  padTime,
-  shiftTime,
-  networkStubbing,
+  replayExecutionOptions,
+  testExpectationOptions,
   parallelTasks,
   deflake,
   cachedTestRunResults,
-  accelerate,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -133,16 +121,8 @@ export const runAllTestsInParallel: (
         runAllOptions: {
           apiToken,
           commitSha,
-          headless,
-          devTools,
-          bypassCSP,
-          diffThreshold: diffThreshold ?? undefined,
-          diffPixelThreshold,
-          padTime,
-          shiftTime,
-          networkStubbing,
-          accelerate,
-          screenshot: true,
+          replayExecution: replayExecutionOptions,
+          testExpectations: testExpectationOptions,
         },
         testCaseWithOverridesApplied,
         deflake,

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -10,7 +10,7 @@ import log from "loglevel";
 import { cpus } from "os";
 import { join } from "path";
 import { putTestRunResults, TestRun } from "../api/test-run.api";
-import { TestExpectationOptions } from "../command-utils/common-types";
+import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-types";
 import {
   MeticulousCliConfig,
   TestCase,
@@ -25,7 +25,7 @@ export interface RunAllTestsInParallelOptions {
   client: AxiosInstance;
   testRun: TestRun;
   executionOptions: ReplayExecutionOptions;
-  expectationOptions: TestExpectationOptions;
+  screenshottingOptions: ScreenshotAssertionsEnabledOptions;
   apiToken: string | undefined;
   commitSha: string;
   appUrl: string | undefined;
@@ -47,7 +47,7 @@ export const runAllTestsInParallel: (
   appUrl,
   useAssetsSnapshottedInBaseSimulation,
   executionOptions,
-  expectationOptions,
+  screenshottingOptions,
   parallelTasks,
   deflake,
   cachedTestRunResults,
@@ -117,7 +117,7 @@ export const runAllTestsInParallel: (
             baseReplayId: testCase.baseReplayId,
           }),
           executionOptions,
-          expectationOptions,
+          screenshottingOptions,
         },
       },
     };

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -114,7 +114,7 @@ export const runAllTestsInParallel: (
           replayTarget: getReplayTargetForTestCase({
             useAssetsSnapshottedInBaseSimulation,
             appUrl,
-            baseReplayId: testCase.baseReplayId,
+            testCase,
           }),
           executionOptions,
           screenshottingOptions,

--- a/packages/cli/src/parallel-tests/task.handler.ts
+++ b/packages/cli/src/parallel-tests/task.handler.ts
@@ -51,45 +51,10 @@ const main = async () => {
   logger.setLevel(logLevel);
   getMeticulousLocalDataDir(dataDir);
 
-  const {
-    apiToken,
-    commitSha,
-    appUrl,
-    simulationIdForAssets,
-    headless,
-    devTools,
-    bypassCSP,
-    diffThreshold,
-    diffPixelThreshold,
-    padTime,
-    shiftTime,
-    networkStubbing,
-    accelerate,
-  } = runAllOptions;
-  const { sessionId, baseReplayId, options } = testCase;
-
   const result = await deflakeReplayCommandHandler({
+    ...runAllOptions,
     testCase,
     deflake,
-    apiToken,
-    commitSha,
-    sessionId,
-    appUrl,
-    simulationIdForAssets,
-    headless,
-    devTools,
-    bypassCSP,
-    screenshot: true,
-    baseSimulationId: baseReplayId,
-    diffThreshold,
-    diffPixelThreshold,
-    save: false,
-    exitOnMismatch: false,
-    padTime,
-    shiftTime,
-    networkStubbing,
-    accelerate,
-    ...options,
   });
   const resultMessage: ResultMessage = {
     kind: "result",

--- a/packages/cli/src/parallel-tests/task.handler.ts
+++ b/packages/cli/src/parallel-tests/task.handler.ts
@@ -46,16 +46,11 @@ const main = async () => {
 
   const initMessage = await waitForInitMessage();
 
-  const { logLevel, dataDir, runAllOptions, testCase, deflake } =
-    initMessage.data;
+  const { logLevel, dataDir, replayOptions } = initMessage.data;
   logger.setLevel(logLevel);
   getMeticulousLocalDataDir(dataDir);
 
-  const result = await deflakeReplayCommandHandler({
-    ...runAllOptions,
-    testCase,
-    deflake,
-  });
+  const result = await deflakeReplayCommandHandler(replayOptions);
   const resultMessage: ResultMessage = {
     kind: "result",
     data: {

--- a/packages/cli/src/utils/config.utils.ts
+++ b/packages/cli/src/utils/config.utils.ts
@@ -1,3 +1,4 @@
+import { ReplayTarget } from "@alwaysmeticulous/common/dist/types/replay.types";
 import { readConfig, saveConfig } from "../config/config";
 import { MeticulousCliConfig, TestCase } from "../config/config.types";
 
@@ -12,17 +13,20 @@ export const addTestCase: (testCase: TestCase) => Promise<void> = async (
   await saveConfig(newConfig);
 };
 
-export const getSimulationIdForAssets = (
-  testCase: TestCase,
-  useAssetsSnapshottedInBaseSimulation: boolean | null | undefined
-): string | undefined => {
-  if (testCase.options?.simulationIdForAssets) {
-    return testCase.options.simulationIdForAssets;
-  }
-
+export const getReplayTargetForTestCase = ({
+  useAssetsSnapshottedInBaseSimulation,
+  appUrl,
+  baseReplayId,
+}: {
+  useAssetsSnapshottedInBaseSimulation: boolean;
+  appUrl: string | undefined;
+  baseReplayId: string;
+}): ReplayTarget => {
   if (useAssetsSnapshottedInBaseSimulation) {
-    return testCase.baseReplayId;
+    return { type: "snapshotted-assets", simulationIdForAssets: baseReplayId };
   }
-
-  return undefined;
+  if (appUrl) {
+    return { type: "url", appUrl };
+  }
+  return { type: "url" };
 };

--- a/packages/cli/src/utils/config.utils.ts
+++ b/packages/cli/src/utils/config.utils.ts
@@ -28,5 +28,5 @@ export const getReplayTargetForTestCase = ({
   if (appUrl) {
     return { type: "url", appUrl };
   }
-  return { type: "url" };
+  return { type: "original-recorded-url" };
 };

--- a/packages/cli/src/utils/config.utils.ts
+++ b/packages/cli/src/utils/config.utils.ts
@@ -16,14 +16,23 @@ export const addTestCase: (testCase: TestCase) => Promise<void> = async (
 export const getReplayTargetForTestCase = ({
   useAssetsSnapshottedInBaseSimulation,
   appUrl,
-  baseReplayId,
+  testCase,
 }: {
   useAssetsSnapshottedInBaseSimulation: boolean;
   appUrl: string | undefined;
-  baseReplayId: string;
+  testCase: TestCase;
 }): ReplayTarget => {
+  if (testCase.options?.simulationIdForAssets != null) {
+    return {
+      type: "snapshotted-assets",
+      simulationIdForAssets: testCase.options?.simulationIdForAssets,
+    };
+  }
   if (useAssetsSnapshottedInBaseSimulation) {
-    return { type: "snapshotted-assets", simulationIdForAssets: baseReplayId };
+    return {
+      type: "snapshotted-assets",
+      simulationIdForAssets: testCase.baseReplayId,
+    };
   }
   if (appUrl) {
     return { type: "url", appUrl };

--- a/packages/cli/src/utils/config.utils.ts
+++ b/packages/cli/src/utils/config.utils.ts
@@ -16,8 +16,8 @@ export const getSimulationIdForAssets = (
   testCase: TestCase,
   useAssetsSnapshottedInBaseSimulation: boolean | null | undefined
 ): string | undefined => {
-  if (testCase.options?.useAssetsFromReplayId) {
-    return testCase.options.useAssetsFromReplayId;
+  if (testCase.options?.simulationIdForAssets) {
+    return testCase.options.simulationIdForAssets;
   }
 
   if (useAssetsSnapshottedInBaseSimulation) {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -18,5 +18,7 @@ export type {
   ReplayEventsDependency,
   ReplayEventsFn,
   ReplayEventsOptions,
+  ResolvedReplayExecutionOptions,
+  ReplayExecutionOptions,
 } from "./types/replay.types";
 export type { RecordedSession, SessionData } from "./types/session.types";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,5 +19,8 @@ export type {
   ReplayEventsFn,
   ReplayEventsOptions,
   ReplayExecutionOptions,
+  ScreenshottingOptions,
+  ScreenshottingEnabledOptions,
+  ReplayTarget,
 } from "./types/replay.types";
 export type { RecordedSession, SessionData } from "./types/session.types";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -18,7 +18,6 @@ export type {
   ReplayEventsDependency,
   ReplayEventsFn,
   ReplayEventsOptions,
-  ResolvedReplayExecutionOptions,
   ReplayExecutionOptions,
 } from "./types/replay.types";
 export type { RecordedSession, SessionData } from "./types/session.types";

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -18,28 +18,60 @@ export interface ReplayEventsDependencies extends BaseReplayEventsDependencies {
   nodeUserInteractions: ReplayEventsDependency<"nodeUserInteractions">;
 }
 
+export type ReplayTarget = SnapshottedAssetsReplayTarget | URLReplayTarget;
+
+export interface SnapshottedAssetsReplayTarget {
+  type: "snapshotted-assets";
+
+  /**
+   * If present will run the session against a local server serving up previously snapshotted assets (HTML, JS, CSS etc.) from the specified prior replay, instead of against a URL.
+   */
+  simulationIdForAssets?: string | undefined;
+}
+
+export interface URLReplayTarget {
+  type: "url";
+
+  /**
+   * If absent, and no URL provided in test case either, then will use the URL the session was recorded against.
+   */
+  appUrl?: string | null | undefined;
+}
+
+/**
+ * Options that control how a replay is executed.
+ */
+export interface ReplayExecutionOptions {
+  headless?: boolean;
+  devTools?: boolean;
+  bypassCSP?: boolean;
+  padTime?: boolean;
+  shiftTime?: boolean;
+  networkStubbing?: boolean;
+  accelerate?: boolean;
+  moveBeforeClick?: boolean;
+}
+
+export type ResolvedReplayExecutionOptions = Required<ReplayExecutionOptions>;
 export interface ReplayEventsOptions {
-  appUrl: string;
+  /**
+   * If undefined then will use the URL the session was recorded against.
+   */
+  appUrl: string | undefined;
+  replayExecutionOptions: ResolvedReplayExecutionOptions;
+
   browser: any;
   outputDir: string;
   session: RecordedSession;
   sessionData: SessionData;
   recordingId: string;
   meticulousSha: string;
-  headless?: boolean;
-  devTools?: boolean;
-  bypassCSP?: boolean;
   verbose?: boolean;
   dependencies: ReplayEventsDependencies;
   screenshot?: boolean;
   screenshotSelector?: string;
-  padTime: boolean;
-  shiftTime: boolean;
-  networkStubbing: boolean;
-  moveBeforeClick: boolean;
-  cookies: Record<string, any>[] | null;
+  cookies?: Record<string, any>[];
   cookiesFile: string;
-  accelerate: boolean;
 }
 
 export type ReplayEventsFn = (options: ReplayEventsOptions) => Promise<void>;

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -88,7 +88,6 @@ export interface ReplayEventsOptions {
   verbose?: boolean;
   dependencies: ReplayEventsDependencies;
   screenshottingOptions: ScreenshottingOptions;
-  cookies: Record<string, any>[] | undefined;
   cookiesFile: string | undefined;
 }
 

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -26,7 +26,7 @@ export interface SnapshottedAssetsReplayTarget {
   /**
    * If present will run the session against a local server serving up previously snapshotted assets (HTML, JS, CSS etc.) from the specified prior replay, instead of against a URL.
    */
-  simulationIdForAssets?: string | undefined;
+  simulationIdForAssets: string;
 }
 
 export interface URLReplayTarget {
@@ -35,30 +35,28 @@ export interface URLReplayTarget {
   /**
    * If absent, and no URL provided in test case either, then will use the URL the session was recorded against.
    */
-  appUrl?: string | null | undefined;
+  appUrl?: string;
 }
 
 /**
  * Options that control how a replay is executed.
  */
 export interface ReplayExecutionOptions {
-  headless?: boolean;
-  devTools?: boolean;
-  bypassCSP?: boolean;
-  padTime?: boolean;
-  shiftTime?: boolean;
-  networkStubbing?: boolean;
-  accelerate?: boolean;
-  moveBeforeClick?: boolean;
+  headless: boolean;
+  devTools: boolean;
+  bypassCSP: boolean;
+  padTime: boolean;
+  shiftTime: boolean;
+  networkStubbing: boolean;
+  accelerate: boolean;
+  moveBeforeClick: boolean;
 }
-
-export type ResolvedReplayExecutionOptions = Required<ReplayExecutionOptions>;
 export interface ReplayEventsOptions {
   /**
    * If undefined then will use the URL the session was recorded against.
    */
   appUrl: string | undefined;
-  replayExecutionOptions: ResolvedReplayExecutionOptions;
+  replayExecutionOptions: ReplayExecutionOptions;
 
   browser: any;
   outputDir: string;
@@ -68,10 +66,10 @@ export interface ReplayEventsOptions {
   meticulousSha: string;
   verbose?: boolean;
   dependencies: ReplayEventsDependencies;
-  screenshot?: boolean;
-  screenshotSelector?: string;
-  cookies?: Record<string, any>[];
-  cookiesFile: string;
+  screenshot: boolean;
+  screenshotSelector: string | undefined;
+  cookies: Record<string, any>[] | undefined;
+  cookiesFile: string | undefined;
 }
 
 export type ReplayEventsFn = (options: ReplayEventsOptions) => Promise<void>;

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -58,6 +58,20 @@ export interface ReplayExecutionOptions {
   accelerate: boolean;
   moveBeforeClick: boolean;
 }
+
+export type ScreenshottingOptions =
+  | { enabled: false }
+  | ScreenshottingEnabledOptions;
+
+export interface ScreenshottingEnabledOptions {
+  enabled: true;
+
+  /**
+   * If undefined will screenshot whole window
+   */
+  screenshotSelector: string | undefined;
+}
+
 export interface ReplayEventsOptions {
   /**
    * If undefined then will use the URL the session was recorded against.
@@ -73,8 +87,7 @@ export interface ReplayEventsOptions {
   meticulousSha: string;
   verbose?: boolean;
   dependencies: ReplayEventsDependencies;
-  screenshot: boolean;
-  screenshotSelector: string | undefined;
+  screenshottingOptions: ScreenshottingOptions;
   cookies: Record<string, any>[] | undefined;
   cookiesFile: string | undefined;
 }

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -57,6 +57,8 @@ export interface ReplayExecutionOptions {
   networkStubbing: boolean;
   accelerate: boolean;
   moveBeforeClick: boolean;
+  maxDurationMs: number | undefined;
+  maxEventCount: number | undefined;
 }
 
 export type ScreenshottingOptions =
@@ -89,8 +91,6 @@ export interface ReplayEventsOptions {
   dependencies: ReplayEventsDependencies;
   screenshottingOptions: ScreenshottingOptions;
   cookiesFile: string | undefined;
-  maxDurationMs?: number;
-  maxEventCount?: number;
 }
 
 export type ReplayEventsFn = (options: ReplayEventsOptions) => Promise<void>;

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -18,7 +18,10 @@ export interface ReplayEventsDependencies extends BaseReplayEventsDependencies {
   nodeUserInteractions: ReplayEventsDependency<"nodeUserInteractions">;
 }
 
-export type ReplayTarget = SnapshottedAssetsReplayTarget | URLReplayTarget;
+export type ReplayTarget =
+  | SnapshottedAssetsReplayTarget
+  | URLReplayTarget
+  | OriginalRecordedURLReplayTarget;
 
 export interface SnapshottedAssetsReplayTarget {
   type: "snapshotted-assets";
@@ -35,7 +38,11 @@ export interface URLReplayTarget {
   /**
    * If absent, and no URL provided in test case either, then will use the URL the session was recorded against.
    */
-  appUrl?: string;
+  appUrl: string;
+}
+
+export interface OriginalRecordedURLReplayTarget {
+  type: "original-recorded-url";
 }
 
 /**

--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -148,10 +148,10 @@ export const patchDate: (options: {
   `);
 };
 
-const getAppUrl: (options: { sessionData: any; appUrl: string }) => string = ({
-  sessionData,
-  appUrl,
-}) => {
+const getAppUrl: (options: {
+  sessionData: any;
+  appUrl: string | undefined;
+}) => string = ({ sessionData, appUrl }) => {
   if (!appUrl) {
     const { startUrl, startURL } = sessionData.userEvents.window;
     return startUrl || startURL;
@@ -171,7 +171,7 @@ const getAppUrl: (options: { sessionData: any; appUrl: string }) => string = ({
 export const getStartUrl: (options: {
   session: any;
   sessionData: any;
-  appUrl: string;
+  appUrl: string | undefined;
 }) => string = ({ session, sessionData, appUrl }) => {
   // We prefer to use the start URL from the session metadata but default to
   // startURLs present within the events data for backwards-compatibility.

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -201,11 +201,11 @@ export const replayEvents: ReplayEventsFn = async (options) => {
 
   logger.info("Simulation done!");
 
-  if (options.screenshot) {
+  if (options.screenshottingOptions.enabled) {
     await takeScreenshot({
       page,
       outputDir,
-      screenshotSelector: options.screenshotSelector || "",
+      screenshotSelector: options.screenshottingOptions.screenshotSelector,
     });
   }
 

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -37,8 +37,6 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     sessionData,
     replayExecutionOptions,
     dependencies,
-    maxDurationMs,
-    maxEventCount,
   } = options;
 
   // Extract replay metadata
@@ -49,6 +47,8 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     networkStubbing,
     accelerate,
     padTime,
+    maxDurationMs,
+    maxEventCount,
   } = replayExecutionOptions;
   const metadata: ReplayMetadata = {
     session,

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -31,27 +31,26 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     outputDir,
     session,
     sessionData,
-    headless,
-    devTools,
+    replayExecutionOptions,
     dependencies,
-    padTime,
-    shiftTime,
-    networkStubbing,
-    accelerate,
   } = options;
 
   // Extract replay metadata
+  const {
+    headless,
+    devTools,
+    shiftTime,
+    networkStubbing,
+    accelerate,
+    padTime,
+  } = replayExecutionOptions;
   const metadata: ReplayMetadata = {
     session,
     options: {
       appUrl,
       outputDir,
-      headless,
-      devTools,
       dependencies,
-      padTime,
-      shiftTime,
-      networkStubbing,
+      ...replayExecutionOptions,
     },
   };
 
@@ -68,8 +67,8 @@ export const replayEvents: ReplayEventsFn = async (options) => {
         // including the respective Preflgiht CORS requests which are not handled by the network stubbing layer.
         "--disable-web-security",
       ],
-      headless: headless || false,
-      devtools: devTools || false,
+      headless: headless,
+      devtools: devTools,
     }));
 
   const context = await browser.createIncognitoBrowserContext();

--- a/packages/replayer/src/screenshot.utils.ts
+++ b/packages/replayer/src/screenshot.utils.ts
@@ -7,13 +7,13 @@ import { prepareScreenshotsDir } from "./output.utils";
 export interface TakeScreenshotOptions {
   page: Page;
   outputDir: string;
-  screenshotSelector: string;
+  screenshotSelector: string | undefined;
 }
 
 const screenshotPageOrElement: (options: {
   page: Page;
   path: string;
-  screenshotSelector: string;
+  screenshotSelector: string | undefined;
 }) => Promise<void> = async ({ page, path, screenshotSelector }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   const toScreenshot = screenshotSelector

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,6 +1395,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.186":
+  version "4.14.186"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
+  integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
+
 "@types/luxon@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.3.2.tgz#8a3f2cdd4858ce698b56cd8597d9243b8e9d3c65"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,11 +1395,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.186":
-  version "4.14.186"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
-  integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
-
 "@types/luxon@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.3.2.tgz#8a3f2cdd4858ce698b56cd8597d9243b8e9d3c65"


### PR DESCRIPTION
Cleans up our replay options interfaces (now that I added some extra options here it was getting a bit verbose).

## Main changes in this PR

### 1. Grouping options together

<img width="629" alt="image" src="https://user-images.githubusercontent.com/793481/197587813-a06a8df1-8d7d-4963-819e-a5aff4fc9f52.png">

For example ReplayExecutionOptions and ScreenshottingOptions. This hopefully makes the code easier to follow, because it reduces the number of options and so makes it easier for readers to see which options are different vs which options are the same between the different interfaces. It should hopefully make it less verbose to pass things around (e.g. often the ReplayExecutionOptions were just getting passed from one method to the next without getting changed).

### Centralizing defaults at the command level

We try to centralize all defaults at the command level, since then yargs prints out the default value to the user on the help screen, which can be useful for the user. This also means that we can keep the descriptions, defaults etc. for the command in sync; and it's very explicit/clear whenever they do differ from one command vs another.

## Notes

 - The intent here is that bundling into the ReplayExecutionOptions and ScreenshottingOptions is done as soon as possible, right at the start of the command handler. And then the rest of the program mainly just passes around the bundled types.
 - I've tried to use `| undefined` when we want to force the caller to think about what value they want to pass for the args, and only use `?` forgetting the value is unlikely to cause issues & always supplying an undefined value would be annoying/verbose.
 - I haven't updated the other commands or all the other options to match this pattern. Can do so in future PRs, or whenever we next edit those commands.
 - Tried to ensure the types can only represent valid combinations (e.g. see ScreenshottingOptions and ReplayTarget), so that it's easier for readers to understand the options & how they relate; and harder to introduce bugs.