### PR TITLE
add support for diffing multiple simulation screenshots

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -24,8 +24,8 @@ import { fetchAsset } from "../../local-data/replay-assets";
 import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
-  readLocalReplayScreenshot,
-  readReplayScreenshot,
+  getReplayDir,
+  getScreenshotsDir,
 } from "../../local-data/replays";
 import {
   getOrFetchRecordedSession,
@@ -270,22 +270,22 @@ export const replayCommandHandler: (
   // 12. Diff against base replay screenshot if one is provided
   const baseReplayId = baseReplayId_ || "";
   if (screenshot && baseReplayId) {
-    logger.info(
-      `Diffing final state screenshot against replay ${baseReplayId}`
-    );
+    logger.info(`Diffing screenshots against replay ${baseReplayId}`);
 
     await getOrFetchReplay(client, baseReplayId);
     await getOrFetchReplayArchive(client, baseReplayId);
 
-    const baseScreenshot = await readReplayScreenshot(baseReplayId);
-    const headScreenshot = await readLocalReplayScreenshot(tempDir);
+    const baseReplayScreenshotsDir = getScreenshotsDir(
+      getReplayDir(baseReplayId)
+    );
+    const headReplayScreenshotsDir = getScreenshotsDir(tempDir);
 
     await diffScreenshots({
       client,
       baseReplayId,
       headReplayId: replay.id,
-      baseScreenshot,
-      headScreenshot,
+      baseScreenshotsDir: baseReplayScreenshotsDir,
+      headScreenshotsDir: headReplayScreenshotsDir,
       threshold: diffThreshold,
       pixelThreshold: diffPixelThreshold,
       exitOnMismatch: !!exitOnMismatch,

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -5,7 +5,7 @@ import { PNG } from "pngjs";
 import { CommandModule } from "yargs";
 import { createClient } from "../../api/client";
 import { getDiffUrl, postScreenshotDiffStats } from "../../api/replay.api";
-import { CompareImageOptions, compareImages } from "../../image/diff.utils";
+import { compareImages } from "../../image/diff.utils";
 import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
@@ -52,14 +52,12 @@ export const diffScreenshots: (options: {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const threshold = threshold_ || DEFAULT_MISMATCH_THRESHOLD;
-  const pixelmatchOptions: CompareImageOptions["pixelmatchOptions"] | null =
-    pixelThreshold ? { threshold: pixelThreshold } : null;
 
   try {
     const { mismatchPixels, mismatchFraction, diff } = compareImages({
       base: baseScreenshot,
       head: headScreenshot,
-      ...(pixelmatchOptions ? pixelmatchOptions : {}),
+      pixelThreshold: pixelThreshold ?? null,
     });
 
     logger.debug({ mismatchPixels, mismatchFraction });

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -242,7 +242,7 @@ const logComparisonResultMessage: (
   message: string,
   outcome: ComparisonOutcome
 ) => void = (logger, message, outcome) => {
-  logger.info(`${message} => ${outcome === "fail" ? "FAIL!" : "PASS"}`);
+  logger.info(`${message} => ${outcome === "pass" ? "PASS" : "FAIL!"}`);
 };
 
 interface Options {

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -1,18 +1,21 @@
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import { AxiosInstance } from "axios";
-import log from "loglevel";
-import { PNG } from "pngjs";
+import log, { Logger } from "loglevel";
 import { CommandModule } from "yargs";
 import { createClient } from "../../api/client";
 import { getDiffUrl, postScreenshotDiffStats } from "../../api/replay.api";
-import { compareImages } from "../../image/diff.utils";
+import { CompareImageResult, compareImages } from "../../image/diff.utils";
 import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
-  readReplayScreenshot,
+  getReplayDir,
+  getScreenshotFiles,
+  getScreenshotsDir,
 } from "../../local-data/replays";
 import { writeScreenshotDiff } from "../../local-data/screenshot-diffs";
 import { wrapHandler } from "../../utils/sentry.utils";
+import { readPng } from "../../image/io.utils";
+import { basename, join } from "path";
 
 const DEFAULT_MISMATCH_THRESHOLD = 0.01;
 
@@ -23,28 +26,38 @@ export class DiffError extends Error {
       baseReplayId: string;
       headReplayId: string;
       threshold: number;
-      value: number;
+      value?: number;
     }
   ) {
     super(message);
   }
 }
 
+type ComparisonOutcome = "pass" | "fail";
+
+export interface ScreenshotDiffResult {
+  baseScreenshotFile: string;
+  headScreenshotFile: string;
+
+  outcome: ComparisonOutcome;
+  comparisonResult: CompareImageResult;
+}
+
 export const diffScreenshots: (options: {
   client: AxiosInstance;
   baseReplayId: string;
   headReplayId: string;
-  baseScreenshot: PNG;
-  headScreenshot: PNG;
+  baseScreenshotsDir: string;
+  headScreenshotsDir: string;
   threshold: number | null | undefined;
   pixelThreshold: number | null | undefined;
   exitOnMismatch: boolean;
-}) => Promise<void> = async ({
+}) => Promise<ScreenshotDiffResult[]> = async ({
   client,
   baseReplayId,
   headReplayId,
-  baseScreenshot,
-  headScreenshot,
+  baseScreenshotsDir,
+  headScreenshotsDir,
   threshold: threshold_,
   pixelThreshold,
   exitOnMismatch,
@@ -53,47 +66,158 @@ export const diffScreenshots: (options: {
 
   const threshold = threshold_ || DEFAULT_MISMATCH_THRESHOLD;
 
+  const baseReplayScreenshots = await getScreenshotFiles(baseScreenshotsDir);
+  const headReplayScreenshots = await getScreenshotFiles(headScreenshotsDir);
+
+  // Assume base replay screenshots are always a subset of the head replay screenshots.
+  // We report any missing base replay screenshots for visibility but don't count it as a difference.
+  const missingHeadImages = new Set(
+    [...baseReplayScreenshots].filter(
+      (file_) => !headReplayScreenshots.includes(file_)
+    )
+  );
+
+  let totalMismatchPixels = 0;
+  let totalComparedPixels = 0;
+
+  const comparisonResults: ScreenshotDiffResult[] = [];
+
   try {
-    const { mismatchPixels, mismatchFraction, diff } = compareImages({
-      base: baseScreenshot,
-      head: headScreenshot,
-      pixelThreshold: pixelThreshold ?? null,
-    });
+    if (missingHeadImages.size > 0) {
+      logComparisonResultMessage(
+        logger,
+        `Head replay is missing screenshots: ${[...missingHeadImages].sort()}`,
+        "fail"
+      );
+      throw new DiffError(
+        `Head replay is missing screenshots: ${[...missingHeadImages].sort()}`,
+        {
+          baseReplayId,
+          headReplayId,
+          threshold,
+        }
+      );
+    }
 
-    logger.debug({ mismatchPixels, mismatchFraction });
-    logger.info(
-      `${Math.round(
-        mismatchFraction * 100
-      )}% pixel mismatch (threshold is ${Math.round(threshold * 100)}%) => ${
-        mismatchFraction > threshold ? "FAIL!" : "PASS"
-      }`
-    );
+    for (const screenshotFileName of headReplayScreenshots) {
+      if (!baseReplayScreenshots.includes(screenshotFileName)) {
+        logger.info(
+          `Screenshot ${screenshotFileName} not present in base replay`
+        );
+        continue;
+      }
 
-    await writeScreenshotDiff({ baseReplayId, headReplayId, diff });
-    const diffUrl = await getDiffUrl(client, baseReplayId, headReplayId);
-    logger.info(`View screenshot diff at ${diffUrl}`);
+      const baseScreenshotFile = join(baseScreenshotsDir, screenshotFileName);
+      const headScreenshotFile = join(headScreenshotsDir, screenshotFileName);
+      const baseScreenshot = await readPng(baseScreenshotFile);
+      const headScreenshot = await readPng(headScreenshotFile);
+
+      const comparisonResult = compareImages({
+        base: baseScreenshot,
+        head: headScreenshot,
+        pixelThreshold: pixelThreshold ?? null,
+      });
+
+      totalMismatchPixels += comparisonResult.mismatchPixels;
+      totalComparedPixels += baseScreenshot.width * baseScreenshot.height;
+
+      logger.debug({
+        screenshotFileName,
+        mismatchPixels: comparisonResult.mismatchPixels,
+        mismatchFraction: comparisonResult.mismatchFraction,
+      });
+
+      await writeScreenshotDiff({
+        baseReplayId,
+        headReplayId,
+        screenshotFileName,
+        diff: comparisonResult.diff,
+      });
+
+      comparisonResults.push({
+        baseScreenshotFile,
+        headScreenshotFile,
+        comparisonResult,
+        outcome:
+          comparisonResult.mismatchFraction > threshold ? "fail" : "pass",
+      });
+    }
 
     await postScreenshotDiffStats(client, {
       baseReplayId,
       headReplayId,
       stats: {
-        width: baseScreenshot.width,
-        height: baseScreenshot.height,
-        mismatchPixels,
+        width: 0,
+        height: 0,
+        mismatchPixels: totalMismatchPixels,
       },
     });
 
-    if (mismatchFraction > threshold) {
-      logger.info("Screenshots do not match!");
+    const diffUrl = await getDiffUrl(client, baseReplayId, headReplayId);
+    logger.info(`View screenshot diff at ${diffUrl}`);
+
+    comparisonResults.forEach((result) => {
+      logComparisonResultMessage(
+        logger,
+        `${Math.round(
+          result.comparisonResult.mismatchFraction * 100
+        )}% pixel mismatch for screenshot ${basename(
+          result.headScreenshotFile
+        )} (threshold is ${Math.round(threshold * 100)}%)`,
+        result.outcome
+      );
+    });
+
+    // Check if individual screenshot mismatch is higher than the threshold.
+    const mismatchingScreenshots = comparisonResults.filter(
+      (result) => result.outcome == "fail"
+    );
+
+    if (mismatchingScreenshots.length) {
+      logger.info(
+        `Screenshots ${mismatchingScreenshots
+          .map((result) => basename(result.headScreenshotFile))
+          .sort()} do not match!`
+      );
       if (exitOnMismatch) {
         process.exit(1);
       }
-      throw new DiffError("Screenshots do not match!", {
-        baseReplayId,
-        headReplayId,
-        threshold,
-        value: mismatchFraction,
-      });
+      throw new DiffError(
+        `Screenshots ${mismatchingScreenshots.map((result) =>
+          basename(result.headScreenshotFile)
+        )} do not match!`,
+        {
+          baseReplayId,
+          headReplayId,
+          threshold,
+        }
+      );
+    }
+
+    const totalMismatchedFraction = totalMismatchPixels / totalComparedPixels;
+    const overallMismatchOutcome: ComparisonOutcome =
+      totalMismatchedFraction > threshold ? "fail" : "pass";
+
+    logComparisonResultMessage(
+      logger,
+      "Mismatch across all screenshots",
+      overallMismatchOutcome
+    );
+
+    if (overallMismatchOutcome === "fail") {
+      if (exitOnMismatch) {
+        process.exit(1);
+      }
+
+      throw new DiffError(
+        `Total mismatch across screenshots above is ${threshold}!`,
+        {
+          baseReplayId,
+          headReplayId,
+          threshold,
+          value: totalMismatchedFraction,
+        }
+      );
     }
   } catch (error) {
     if (!(error instanceof DiffError)) {
@@ -109,6 +233,16 @@ export const diffScreenshots: (options: {
       value: 1,
     });
   }
+
+  return comparisonResults;
+};
+
+const logComparisonResultMessage: (
+  logger: Logger,
+  message: string,
+  outcome: ComparisonOutcome
+) => void = (logger, message, outcome) => {
+  logger.info(`${message} => ${outcome === "fail" ? "FAIL!" : "PASS"}`);
 };
 
 interface Options {
@@ -133,15 +267,15 @@ const handler: (options: Options) => Promise<void> = async ({
   await getOrFetchReplay(client, headReplayId);
   await getOrFetchReplayArchive(client, headReplayId);
 
-  const baseScreenshot = await readReplayScreenshot(baseReplayId);
-  const headScreenshot = await readReplayScreenshot(headReplayId);
+  const baseScreenshotsDir = getScreenshotsDir(getReplayDir(baseReplayId));
+  const headScreenshotsDir = getScreenshotsDir(getReplayDir(headReplayId));
 
   await diffScreenshots({
     client,
     baseReplayId,
     headReplayId,
-    baseScreenshot,
-    headScreenshot,
+    baseScreenshotsDir,
+    headScreenshotsDir,
     threshold,
     pixelThreshold,
     exitOnMismatch: true,

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -73,7 +73,7 @@ export const diffScreenshots: (options: {
   // We report any missing base replay screenshots for visibility but don't count it as a difference.
   const missingHeadImages = new Set(
     [...baseReplayScreenshots].filter(
-      (file_) => !headReplayScreenshots.includes(file_)
+      (file) => !headReplayScreenshots.includes(file)
     )
   );
 

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -1,21 +1,21 @@
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import { AxiosInstance } from "axios";
 import log, { Logger } from "loglevel";
+import { basename, join } from "path";
 import { CommandModule } from "yargs";
 import { createClient } from "../../api/client";
 import { getDiffUrl, postScreenshotDiffStats } from "../../api/replay.api";
 import { CompareImageResult, compareImages } from "../../image/diff.utils";
+import { readPng } from "../../image/io.utils";
 import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
   getReplayDir,
   getScreenshotFiles,
-  getScreenshotsDir,
+  getScreenshotsDir
 } from "../../local-data/replays";
 import { writeScreenshotDiff } from "../../local-data/screenshot-diffs";
 import { wrapHandler } from "../../utils/sentry.utils";
-import { readPng } from "../../image/io.utils";
-import { basename, join } from "path";
 
 const DEFAULT_MISMATCH_THRESHOLD = 0.01;
 

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -64,7 +64,7 @@ export const diffScreenshots: (options: {
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const threshold = threshold_ || DEFAULT_MISMATCH_THRESHOLD;
+  const threshold = threshold_ ?? DEFAULT_MISMATCH_THRESHOLD;
 
   const baseReplayScreenshots = await getScreenshotFiles(baseScreenshotsDir);
   const headReplayScreenshots = await getScreenshotFiles(headScreenshotsDir);

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -193,32 +193,6 @@ export const diffScreenshots: (options: {
         }
       );
     }
-
-    const totalMismatchedFraction = totalMismatchPixels / totalComparedPixels;
-    const overallMismatchOutcome: ComparisonOutcome =
-      totalMismatchedFraction > threshold ? "fail" : "pass";
-
-    logComparisonResultMessage(
-      logger,
-      "Mismatch across all screenshots",
-      overallMismatchOutcome
-    );
-
-    if (overallMismatchOutcome === "fail") {
-      if (exitOnMismatch) {
-        process.exit(1);
-      }
-
-      throw new DiffError(
-        `Total mismatch across screenshots above is ${threshold}!`,
-        {
-          baseReplayId,
-          headReplayId,
-          threshold,
-          value: totalMismatchedFraction,
-        }
-      );
-    }
   } catch (error) {
     if (!(error instanceof DiffError)) {
       logger.error(error);

--- a/packages/cli/src/image/diff.utils.ts
+++ b/packages/cli/src/image/diff.utils.ts
@@ -1,12 +1,10 @@
-import pixelmatch from "pixelmatch";
+import pixelmatch, { PixelmatchOptions } from "pixelmatch";
 import { PNG } from "pngjs";
 
 export interface CompareImageOptions {
   base: PNG;
   head: PNG;
-  pixelmatchOptions?: {
-    threshold: number;
-  };
+  pixelThreshold: number | null;
 }
 
 export interface CompareImageResult {
@@ -17,7 +15,10 @@ export interface CompareImageResult {
 
 export const compareImages: (
   options: CompareImageOptions
-) => CompareImageResult = ({ base, head, pixelmatchOptions }) => {
+) => CompareImageResult = ({ base, head, pixelThreshold }) => {
+  const pixelmatchOptions: PixelmatchOptions | null = pixelThreshold
+    ? { threshold: pixelThreshold }
+    : null;
   if (base.width !== head.width || base.height !== head.height) {
     throw new Error("Cannot handle different size yet");
   }

--- a/packages/cli/src/local-data/replays.ts
+++ b/packages/cli/src/local-data/replays.ts
@@ -84,7 +84,7 @@ export const readReplayScreenshot: (replayId: string) => Promise<PNG> = async (
   replayId
 ) => {
   const replayDir = getReplayDir(replayId);
-  const screenshotFile = join(replayDir, "screenshots", "final-state.png");
+  const screenshotFile = join(getScreenshotsDir(replayDir), "final-state.png");
   const png = await readPng(screenshotFile);
   return png;
 };
@@ -92,7 +92,7 @@ export const readReplayScreenshot: (replayId: string) => Promise<PNG> = async (
 export const readLocalReplayScreenshot: (
   tempDir: string
 ) => Promise<PNG> = async (tempDir) => {
-  const screenshotFile = join(tempDir, "screenshots", "final-state.png");
+  const screenshotFile = join(getScreenshotsDir(tempDir), "final-state.png");
   const png = await readPng(screenshotFile);
   return png;
 };
@@ -100,5 +100,8 @@ export const readLocalReplayScreenshot: (
 export const getSnapshottedAssetsDir = (replayId: string) =>
   join(getReplayDir(replayId), "snapshotted-assets");
 
-const getReplayDir = (replayId: string) =>
+export const getScreenshotsDir = (replayDir: string) =>
+  join(replayDir, "screenshots");
+
+export const getReplayDir = (replayId: string) =>
   join(getMeticulousLocalDataDir(), "replays", replayId);

--- a/packages/cli/src/local-data/screenshot-diffs.ts
+++ b/packages/cli/src/local-data/screenshot-diffs.ts
@@ -11,13 +11,22 @@ import { writePng } from "../image/io.utils";
 export const writeScreenshotDiff: (options: {
   baseReplayId: string;
   headReplayId: string;
+  screenshotFileName: string;
   diff: PNG;
-}) => Promise<void> = async ({ baseReplayId, headReplayId, diff }) => {
+}) => Promise<void> = async ({
+  baseReplayId,
+  headReplayId,
+  screenshotFileName,
+  diff,
+}) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const diffDir = join(getMeticulousLocalDataDir(), "screenshot-diffs");
   await mkdir(diffDir, { recursive: true });
-  const diffFile = join(diffDir, `${baseReplayId}+${headReplayId}.png`);
+  const diffFile = join(
+    diffDir,
+    `${baseReplayId}+${headReplayId}+${screenshotFileName}.png`
+  );
 
   await writePng(diff, diffFile);
   logger.debug(`Screenshot diff written to ${diffFile}`);


### PR DESCRIPTION
### Changes

We're adding the ability to take multiple screenshots during simulations.

This PR extends the existing diffing utilities to handle comparing  simulations with multiple screenshots.

In cases where we have multiple screenshots diffing can "fail" if any of the following is true:
 * for any screenshot pair, the pixel mismatch is above the set threshold
 * overall pixel mismatch across all screenshot pairs is above the set threshold
 * the head simulation is missing a screenshot which is present in the base simulation-- currently we assume the base simulation screenshots are a subset of the the head simulation.

The failing criteria can change in the future but this preserves the current behaviour (as `final-state` screenshots is a special case of the multiple screenshot simulations)