### PR TITLE
fix dist imports

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -4,11 +4,8 @@ import {
   Replay,
   ReplayEventsFn,
 } from "@alwaysmeticulous/common";
-import {
-  ReplayExecutionOptions,
-  ReplayTarget,
-  StoryboardOptions,
-} from "@alwaysmeticulous/common/dist/types/replay.types";
+import { StoryboardOptions } from "@alwaysmeticulous/common/dist/types/replay.types";
+import { ReplayExecutionOptions, ReplayTarget } from "@alwaysmeticulous/common";
 import { AxiosInstance } from "axios";
 import { mkdir, mkdtemp, writeFile } from "fs/promises";
 import log from "loglevel";

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -3,9 +3,10 @@ import {
   METICULOUS_LOGGER_NAME,
   Replay,
   ReplayEventsFn,
+  ReplayExecutionOptions,
+  ReplayTarget,
 } from "@alwaysmeticulous/common";
 import { StoryboardOptions } from "@alwaysmeticulous/common/dist/types/replay.types";
-import { ReplayExecutionOptions, ReplayTarget } from "@alwaysmeticulous/common";
 import { AxiosInstance } from "axios";
 import { mkdir, mkdtemp, writeFile } from "fs/promises";
 import log from "loglevel";

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -4,7 +4,7 @@ import {
   Replay,
   ReplayEventsFn,
   ReplayExecutionOptions,
-  ReplayTarget,
+  ReplayTarget
 } from "@alwaysmeticulous/common";
 import { StoryboardOptions } from "@alwaysmeticulous/common/dist/types/replay.types";
 import { AxiosInstance } from "axios";
@@ -19,18 +19,17 @@ import {
   getReplayCommandId,
   getReplayPushUrl,
   getReplayUrl,
-  putReplayPushedStatus,
+  putReplayPushedStatus
 } from "../../api/replay.api";
 import { uploadArchive } from "../../api/upload";
 import { createReplayArchive, deleteArchive } from "../../archive/archive";
 import {
   COMMON_REPLAY_OPTIONS,
   OPTIONS,
-  SCREENSHOT_DIFF_OPTIONS,
+  SCREENSHOT_DIFF_OPTIONS
 } from "../../command-utils/common-options";
 import {
-  ScreenshotDiffOptions,
-  ScreenshotAssertionsOptions,
+  ScreenshotAssertionsOptions, ScreenshotDiffOptions
 } from "../../command-utils/common-types";
 import { sanitizeFilename } from "../../local-data/local-data.utils";
 import { fetchAsset } from "../../local-data/replay-assets";
@@ -38,12 +37,12 @@ import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
   getReplayDir,
-  getScreenshotsDir,
+  getScreenshotsDir
 } from "../../local-data/replays";
 import { serveAssetsFromSimulation } from "../../local-data/serve-assets-from-simulation";
 import {
   getOrFetchRecordedSession,
-  getOrFetchRecordedSessionData,
+  getOrFetchRecordedSessionData
 } from "../../local-data/sessions";
 import { getCommitSha } from "../../utils/commit-sha.utils";
 import { addTestCase } from "../../utils/config.utils";

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -1,16 +1,15 @@
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import { ReplayExecutionOptions, ReplayTarget } from "@alwaysmeticulous/common";
+import { METICULOUS_LOGGER_NAME, ReplayExecutionOptions, ReplayTarget } from "@alwaysmeticulous/common";
 import log from "loglevel";
 import {
   ScreenshotAssertionsEnabledOptions,
-  ScreenshotDiffOptions,
+  ScreenshotDiffOptions
 } from "../command-utils/common-types";
 import { replayCommandHandler } from "../commands/replay/replay.command";
 import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
 import {
   TestCase,
   TestCaseReplayOptions,
-  TestCaseResult,
+  TestCaseResult
 } from "../config/config.types";
 
 const handleReplay: (

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -1,8 +1,5 @@
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import {
-  ReplayExecutionOptions,
-  ReplayTarget,
-} from "@alwaysmeticulous/common/dist/types/replay.types";
+import { ReplayExecutionOptions, ReplayTarget } from "@alwaysmeticulous/common";
 import log from "loglevel";
 import {
   ScreenshotAssertionsEnabledOptions,


### PR DESCRIPTION
Follow-up to https://github.com/alwaysmeticulous/meticulous-sdk/pull/131/files, we still have two versions of `StoryboardOptions` floating about:

1) https://github.com/alwaysmeticulous/meticulous-sdk/blob/a7333c8e681abd136ca4e1526a24a4f2ae54451a/packages/common/src/types/replay.types.ts#L79

2) https://github.com/alwaysmeticulous/meticulous-sdk/blob/a7333c8e681abd136ca4e1526a24a4f2ae54451a/packages/sdk-bundles-api/src/replay/sdk-to-bundle/index.ts#L30

Will fix that in follow-up PR. 