### PR TITLE
Introduce disable remote fonts as option

### DIFF
--- a/packages/cli/src/command-utils/common-options.ts
+++ b/packages/cli/src/command-utils/common-options.ts
@@ -71,6 +71,11 @@ export const OPTIONS = {
       "A number between 0 and 1. Color/brightness differences in individual pixels will be ignored if the difference is less than this threshold. A value of 1.0 would accept any difference in color, while a value of 0.0 would accept no difference in color.",
     default: 0.01,
   },
+  disableRemoteFonts: {
+    boolean: true,
+    description: "Pass the disable remote fonts flag into chromium",
+    default: false,
+  },
 } as const;
 
 export const SCREENSHOT_DIFF_OPTIONS = {
@@ -89,4 +94,5 @@ export const COMMON_REPLAY_OPTIONS = {
   shiftTime: OPTIONS.shiftTime,
   networkStubbing: OPTIONS.networkStubbing,
   skipPauses: OPTIONS.skipPauses,
+  disableRemoteFonts: OPTIONS.disableRemoteFonts,
 };

--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -110,6 +110,7 @@ const handler: (options: Options) => Promise<void> = async ({
   networkStubbing,
   moveBeforeClick,
   cookiesFile,
+  disableRemoteFonts,
   skipPauses,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
@@ -157,6 +158,7 @@ const handler: (options: Options) => Promise<void> = async ({
     screenshotSelector,
     padTime,
     shiftTime,
+    disableRemoteFonts,
     networkStubbing,
     moveBeforeClick,
     cookiesFile,

--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -117,6 +117,9 @@ export const debugReplay = buildCommand("debug-simulation")
       string: true,
       description: "Path to cookies to inject before replay",
     },
-    ...COMMON_REPLAY_OPTIONS
+    devTools: COMMON_REPLAY_OPTIONS.devTools,
+    shiftTime: COMMON_REPLAY_OPTIONS.shiftTime,
+    networkStubbing: COMMON_REPLAY_OPTIONS.networkStubbing,
+    disableRemoteFonts: COMMON_REPLAY_OPTIONS.disableRemoteFonts,
   })
   .handler(handler);

--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -5,6 +5,7 @@ import {
 import log from "loglevel";
 import { createClient } from "../../api/client";
 import { buildCommand } from "../../command-utils/command-builder";
+import { COMMON_REPLAY_OPTIONS } from "../../command-utils/common-options";
 import { fetchAsset } from "../../local-data/replay-assets";
 import {
   getOrFetchRecordedSession,
@@ -20,6 +21,7 @@ interface Options {
   networkStubbing: boolean;
   moveBeforeClick?: boolean | null | undefined;
   cookiesFile?: string | null | undefined;
+  disableRemoteFonts: boolean;
 }
 
 const handler: (options: Options) => Promise<void> = async ({
@@ -31,6 +33,7 @@ const handler: (options: Options) => Promise<void> = async ({
   networkStubbing,
   moveBeforeClick,
   cookiesFile,
+  disableRemoteFonts,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -83,6 +86,7 @@ const handler: (options: Options) => Promise<void> = async ({
     },
     shiftTime,
     networkStubbing,
+    disableRemoteFonts,
     moveBeforeClick: moveBeforeClick || false,
     cookiesFile: cookiesFile || "",
   };
@@ -105,21 +109,6 @@ export const debugReplay = buildCommand("debug-simulation")
     appUrl: {
       string: true,
     },
-    devTools: {
-      boolean: true,
-      description: "Open Chrome Dev Tools",
-    },
-    shiftTime: {
-      boolean: true,
-      description:
-        "Shift time during simulation to be set as the recording time",
-      default: true,
-    },
-    networkStubbing: {
-      boolean: true,
-      description: "Stub network requests during replay",
-      default: true,
-    },
     moveBeforeClick: {
       boolean: true,
       description: "Simulate mouse movement before clicking",
@@ -128,5 +117,6 @@ export const debugReplay = buildCommand("debug-simulation")
       string: true,
       description: "Path to cookies to inject before replay",
     },
+    ...COMMON_REPLAY_OPTIONS
   })
   .handler(handler);

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -357,6 +357,7 @@ export const rawReplayCommandHandler = ({
   networkStubbing,
   moveBeforeClick,
   cookiesFile,
+  disableRemoteFonts,
   skipPauses,
   maxDurationMs,
   maxEventCount,
@@ -371,6 +372,7 @@ export const rawReplayCommandHandler = ({
     networkStubbing,
     skipPauses,
     moveBeforeClick,
+    disableRemoteFonts,
     maxDurationMs: maxDurationMs ?? null,
     maxEventCount: maxEventCount ?? null,
   };

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -67,6 +67,7 @@ const handler: (options: Options) => Promise<void> = async ({
   deflake,
   useCache,
   testsFile,
+  disableRemoteFonts,
   skipPauses,
 }) => {
   if (appUrl != null && useAssetsSnapshottedInBaseSimulation) {
@@ -82,6 +83,7 @@ const handler: (options: Options) => Promise<void> = async ({
     padTime,
     shiftTime,
     networkStubbing,
+    disableRemoteFonts,
     skipPauses,
     moveBeforeClick: false, // moveBeforeClick isn't exposed as an option for run-all-tests
     maxDurationMs: null, // we don't expose this option

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -16,5 +16,4 @@ export const COMMON_CHROMIUM_FLAGS = [
     "--disable-prompt-on-repost",
     "--disable-sync",
     "--no-first-run",
-    "--disable-remote-fonts"
-]
+];

--- a/packages/common/src/types/replay-debugger.types.ts
+++ b/packages/common/src/types/replay-debugger.types.ts
@@ -20,6 +20,7 @@ export interface ReplayDebuggerOptions {
   shiftTime: boolean;
   networkStubbing: boolean;
   moveBeforeClick: boolean;
+  disableRemoteFonts: boolean;
   cookiesFile: string;
 }
 

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -58,6 +58,7 @@ export interface ReplayExecutionOptions {
   networkStubbing: boolean;
   skipPauses: boolean;
   moveBeforeClick: boolean;
+  disableRemoteFonts: boolean;
   maxDurationMs: number | null;
   maxEventCount: number | null;
 }

--- a/packages/replay-debugger/src/replayer/replayer.ts
+++ b/packages/replay-debugger/src/replayer/replayer.ts
@@ -18,6 +18,7 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
   networkStubbing,
   moveBeforeClick,
   cookiesFile,
+  disableRemoteFonts
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -28,7 +29,8 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     defaultViewport,
     args: [
       `--window-size=${width},${height}`,
-      ...COMMON_CHROMIUM_FLAGS
+      ...COMMON_CHROMIUM_FLAGS,
+      ...(disableRemoteFonts ? ["--disable-remote-fonts"] : [])
     ],
     headless: false,
     devtools: devTools,

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -1,6 +1,8 @@
 import {
-  COMMON_CHROMIUM_FLAGS, METICULOUS_LOGGER_NAME, ReplayEventsFn,
-  SessionData
+  COMMON_CHROMIUM_FLAGS,
+  METICULOUS_LOGGER_NAME,
+  ReplayEventsFn,
+  SessionData,
 } from "@alwaysmeticulous/common";
 import {
   OnReplayTimelineEventFn,
@@ -51,6 +53,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     padTime,
     maxDurationMs,
     maxEventCount,
+    disableRemoteFonts,
   } = replayExecutionOptions;
   const metadata: ReplayMetadata = {
     session,
@@ -75,7 +78,8 @@ export const replayEvents: ReplayEventsFn = async (options) => {
         // This disables cross-origin security. We need this in order to disable CORS for replayed network requests,
         // including the respective Preflgiht CORS requests which are not handled by the network stubbing layer.
         "--disable-web-security",
-        ...COMMON_CHROMIUM_FLAGS
+        ...COMMON_CHROMIUM_FLAGS,
+        ...(disableRemoteFonts ? ["--disable-remote-fonts"] : []),
       ],
       headless: headless,
       devtools: devTools,


### PR DESCRIPTION
This change also changes the replay-debugger command to use `COMMON_REPLAY_OPTIONS`.