### PR TITLE
Pass original session start URL through to network event stubbing

### DIFF
--- a/packages/replay-debugger/src/replayer/replayer.ts
+++ b/packages/replay-debugger/src/replayer/replayer.ts
@@ -1,8 +1,12 @@
 import {
-  COMMON_CHROMIUM_FLAGS, CreateReplayDebuggerFn,
-  METICULOUS_LOGGER_NAME
+  COMMON_CHROMIUM_FLAGS,
+  CreateReplayDebuggerFn,
+  METICULOUS_LOGGER_NAME,
 } from "@alwaysmeticulous/common";
-import { getStartUrl } from "@alwaysmeticulous/replayer";
+import {
+  getStartUrl,
+  getOriginalSessionStartUrl,
+} from "@alwaysmeticulous/replayer";
 import log from "loglevel";
 import { Browser, launch } from "puppeteer";
 import { bootstrapPage, setupPageCookies } from "./debugger.utils";
@@ -18,7 +22,7 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
   networkStubbing,
   moveBeforeClick,
   cookiesFile,
-  disableRemoteFonts
+  disableRemoteFonts,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -30,7 +34,7 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     args: [
       `--window-size=${width},${height}`,
       ...COMMON_CHROMIUM_FLAGS,
-      ...(disableRemoteFonts ? ["--disable-remote-fonts"] : [])
+      ...(disableRemoteFonts ? ["--disable-remote-fonts"] : []),
     ],
     headless: false,
     devtools: devTools,
@@ -67,7 +71,11 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     await setupPageCookies({ page, cookiesFile });
   }
 
-  const startUrl = getStartUrl({ session, sessionData, appUrl });
+  const originalSessionStartUrl = getOriginalSessionStartUrl({
+    session,
+    sessionData,
+  });
+  const startUrl = getStartUrl({ originalSessionStartUrl, appUrl });
   logger.debug(`Navigating to ${startUrl}...`);
   const res = await page.goto(startUrl, {
     waitUntil: "domcontentloaded",

--- a/packages/replayer/src/index.ts
+++ b/packages/replayer/src/index.ts
@@ -1,2 +1,6 @@
 export { replayEvents } from "./replayer";
-export { getStartUrl, patchDate } from "./replay.utils";
+export {
+  getStartUrl,
+  getOriginalSessionStartUrl,
+  patchDate,
+} from "./replay.utils";

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -17,6 +17,7 @@ import { prepareScreenshotsDir, writeOutput } from "./output.utils";
 import { ReplayMetadata } from "./replay.types";
 import {
   createReplayPage,
+  getOriginalSessionStartUrl,
   getRrwebRecordingDuration,
   getStartingViewport,
   getStartUrl,
@@ -107,7 +108,11 @@ export const replayEvents: ReplayEventsFn = async (options) => {
   });
 
   // Calculate start URL based on the one that the session originated on/from.
-  const startUrl = getStartUrl({ session, sessionData, appUrl });
+  const originalSessionStartUrl = getOriginalSessionStartUrl({
+    session,
+    sessionData,
+  });
+  const startUrl = getStartUrl({ originalSessionStartUrl, appUrl });
 
   const replayData = await initializeReplayData({ page, startUrl });
 
@@ -128,7 +133,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
       page,
       logLevel,
       sessionData,
-      startUrl,
+      startUrl: originalSessionStartUrl.toString(),
       onTimelineEvent,
     });
   }

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -126,14 +126,14 @@ export const replayEvents: ReplayEventsFn = async (options) => {
         page: Page;
         logLevel: LogLevelDesc;
         sessionData: SessionData;
-        startUrl: string;
+        originalSessionStartUrl: string;
         onTimelineEvent: OnReplayTimelineEventFn;
       }) => Promise<void>;
     await setupReplayNetworkStubbing({
       page,
       logLevel,
       sessionData,
-      startUrl: originalSessionStartUrl.toString(),
+      originalSessionStartUrl: originalSessionStartUrl.toString(),
       onTimelineEvent,
     });
   }

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -1,4 +1,3 @@
-import { join } from "path";
 import {
   COMMON_CHROMIUM_FLAGS,
   METICULOUS_LOGGER_NAME,
@@ -107,8 +106,6 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     dependencies,
     onTimelineEvent,
   });
-  await page.tracing.start({ path: join(outputDir, "trace.json") });
-  console.log(`Writing tracing info to ${join(outputDir, "trace.json")}`);
 
   // Calculate start URL based on the one that the session originated on/from.
   const originalSessionStartUrl = getOriginalSessionStartUrl({
@@ -222,10 +219,6 @@ export const replayEvents: ReplayEventsFn = async (options) => {
       }
     }
   }
-
-  logger.debug("Collecting tracing data...");
-  await page.tracing.stop();
-  logger.debug("Collected tracing data");
 
   logger.debug("Collecting coverage data...");
   const coverageData = await page.coverage.stopJSCoverage();

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import {
   COMMON_CHROMIUM_FLAGS,
   METICULOUS_LOGGER_NAME,
@@ -106,6 +107,8 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     dependencies,
     onTimelineEvent,
   });
+  await page.tracing.start({ path: join(outputDir, "trace.json") });
+  console.log(`Writing tracing info to ${join(outputDir, "trace.json")}`);
 
   // Calculate start URL based on the one that the session originated on/from.
   const originalSessionStartUrl = getOriginalSessionStartUrl({
@@ -126,6 +129,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
         page: Page;
         logLevel: LogLevelDesc;
         sessionData: SessionData;
+        startUrl: string;
         originalSessionStartUrl: string;
         onTimelineEvent: OnReplayTimelineEventFn;
       }) => Promise<void>;
@@ -133,6 +137,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
       page,
       logLevel,
       sessionData,
+      startUrl,
       originalSessionStartUrl: originalSessionStartUrl.toString(),
       onTimelineEvent,
     });
@@ -217,6 +222,10 @@ export const replayEvents: ReplayEventsFn = async (options) => {
       }
     }
   }
+
+  logger.debug("Collecting tracing data...");
+  await page.tracing.stop();
+  logger.debug("Collected tracing data");
 
   logger.debug("Collecting coverage data...");
   const coverageData = await page.coverage.stopJSCoverage();


### PR DESCRIPTION
Pass original session start URL through to network event stubbing so that it can swap out the origin correctly with the origin that matches the original recorded requests. Currently the origin swapping is broken, because it swaps out the `--appUrl` origin for the `--appUrl` origin.