### PR TITLE
Use replay v2 snippets in simulation debugger

### DIFF
--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -47,7 +47,9 @@ const handler: (options: Options) => Promise<void> = async ({
   const browserUserInteractions = await fetchAsset(
     "replay/v2/snippet-user-interactions.bundle.js"
   );
-  const reanimator = await fetchAsset("replay/v1/reanimator.bundle.js");
+  const nodeBrowserContext = await fetchAsset(
+    "replay/v2/node-browser-context.bundle.js"
+  );
   const nodeNetworkStubbing = await fetchAsset(
     "replay/v2/node-network-stubbing.bundle.js"
   );
@@ -75,9 +77,9 @@ const handler: (options: Options) => Promise<void> = async ({
         key: "browserUserInteractions",
         location: browserUserInteractions,
       },
-      reanimator: {
-        key: "reanimator",
-        location: reanimator,
+      nodeBrowserContext: {
+        key: "nodeBrowserContext",
+        location: nodeBrowserContext,
       },
       nodeNetworkStubbing: {
         key: "nodeNetworkStubbing",

--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -48,8 +48,8 @@ const handler: (options: Options) => Promise<void> = async ({
     "replay/v2/snippet-user-interactions.bundle.js"
   );
   const reanimator = await fetchAsset("replay/v1/reanimator.bundle.js");
-  const replayNetworkFile = await fetchAsset(
-    "replay/v1/replay-network-events.bundle.js"
+  const nodeNetworkStubbing = await fetchAsset(
+    "replay/v2/node-network-stubbing.bundle.js"
   );
 
   // 4. Load replay-debugger package
@@ -79,9 +79,9 @@ const handler: (options: Options) => Promise<void> = async ({
         key: "reanimator",
         location: reanimator,
       },
-      replayNetworkFile: {
-        key: "replayNetworkFile",
-        location: replayNetworkFile,
+      nodeNetworkStubbing: {
+        key: "nodeNetworkStubbing",
+        location: nodeNetworkStubbing,
       },
     },
     shiftTime,

--- a/packages/cli/src/commands/debug-replay/debug-replay.command.ts
+++ b/packages/cli/src/commands/debug-replay/debug-replay.command.ts
@@ -44,8 +44,8 @@ const handler: (options: Options) => Promise<void> = async ({
   const sessionData = await getOrFetchRecordedSessionData(client, sessionId);
 
   // 3. Load replay assets
-  const replayDebugger = await fetchAsset(
-    "replay/v1/replay-debugger.bundle.js"
+  const browserUserInteractions = await fetchAsset(
+    "replay/v2/snippet-user-interactions.bundle.js"
   );
   const reanimator = await fetchAsset("replay/v1/reanimator.bundle.js");
   const replayNetworkFile = await fetchAsset(
@@ -71,9 +71,9 @@ const handler: (options: Options) => Promise<void> = async ({
     appUrl: appUrl || "",
     devTools: devTools || false,
     dependencies: {
-      replayDebugger: {
-        key: "replayDebugger",
-        location: replayDebugger,
+      browserUserInteractions: {
+        key: "browserUserInteractions",
+        location: browserUserInteractions,
       },
       reanimator: {
         key: "reanimator",

--- a/packages/common/src/types/replay-debugger.types.ts
+++ b/packages/common/src/types/replay-debugger.types.ts
@@ -7,7 +7,7 @@ import { RecordedSession, SessionData } from "./session.types";
 export interface ReplayDebuggerDependencies
   extends BaseReplayEventsDependencies {
   browserUserInteractions: ReplayEventsDependency<"browserUserInteractions">;
-  reanimator: ReplayEventsDependency<"reanimator">;
+  nodeBrowserContext: ReplayEventsDependency<"nodeBrowserContext">;
   nodeNetworkStubbing: ReplayEventsDependency<"nodeNetworkStubbing">;
 }
 

--- a/packages/common/src/types/replay-debugger.types.ts
+++ b/packages/common/src/types/replay-debugger.types.ts
@@ -6,7 +6,7 @@ import { RecordedSession, SessionData } from "./session.types";
 
 export interface ReplayDebuggerDependencies
   extends BaseReplayEventsDependencies {
-  replayDebugger: ReplayEventsDependency<"replayDebugger">;
+  browserUserInteractions: ReplayEventsDependency<"browserUserInteractions">;
   reanimator: ReplayEventsDependency<"reanimator">;
   replayNetworkFile: ReplayEventsDependency<"replayNetworkFile">;
 }

--- a/packages/common/src/types/replay-debugger.types.ts
+++ b/packages/common/src/types/replay-debugger.types.ts
@@ -8,7 +8,7 @@ export interface ReplayDebuggerDependencies
   extends BaseReplayEventsDependencies {
   browserUserInteractions: ReplayEventsDependency<"browserUserInteractions">;
   reanimator: ReplayEventsDependency<"reanimator">;
-  replayNetworkFile: ReplayEventsDependency<"replayNetworkFile">;
+  nodeNetworkStubbing: ReplayEventsDependency<"nodeNetworkStubbing">;
 }
 
 export interface ReplayDebuggerOptions {

--- a/packages/replay-debugger/package.json
+++ b/packages/replay-debugger/package.json
@@ -21,6 +21,7 @@
     "@alwaysmeticulous/common": "^2.5.7",
     "@alwaysmeticulous/replay-debugger-ui": "^2.5.0",
     "@alwaysmeticulous/replayer": "^2.6.0",
+    "@alwaysmeticulous/sdk-bundles-api": "^2.5.0",
     "puppeteer": "^14.4.1",
     "rrweb": "^1.1.3"
   },

--- a/packages/replay-debugger/src/replayer/debugger.utils.ts
+++ b/packages/replay-debugger/src/replayer/debugger.utils.ts
@@ -1,8 +1,5 @@
 import { readFile } from "fs/promises";
-import type {
-  BaseReplayEventsDependencies,
-  ReplayEventsDependency,
-} from "@alwaysmeticulous/common";
+import type { ReplayDebuggerDependencies } from "@alwaysmeticulous/common";
 import { patchDate } from "@alwaysmeticulous/replayer";
 import { Page } from "puppeteer";
 
@@ -18,13 +15,6 @@ export const setupPageCookies: (
   const cookies = JSON.parse(cookiesStr) as any[];
   await page.setCookie(...cookies);
 };
-
-export interface ReplayDebuggerDependencies
-  extends BaseReplayEventsDependencies {
-  browserUserInteractions: ReplayEventsDependency<"browserUserInteractions">;
-  reanimator: ReplayEventsDependency<"reanimator">;
-  replayNetworkFile: ReplayEventsDependency<"replayNetworkFile">;
-}
 
 export interface BootstrapPageOptions {
   page: Page;

--- a/packages/replay-debugger/src/replayer/debugger.utils.ts
+++ b/packages/replay-debugger/src/replayer/debugger.utils.ts
@@ -21,7 +21,7 @@ export const setupPageCookies: (
 
 export interface ReplayDebuggerDependencies
   extends BaseReplayEventsDependencies {
-  replayDebugger: ReplayEventsDependency<"replayDebugger">;
+  browserUserInteractions: ReplayEventsDependency<"browserUserInteractions">;
   reanimator: ReplayEventsDependency<"reanimator">;
   replayNetworkFile: ReplayEventsDependency<"replayNetworkFile">;
 }
@@ -87,6 +87,6 @@ export const bootstrapPage: (
 
   // Inject replay debug snippet
   await page.evaluateOnNewDocument(
-    await readFile(dependencies.replayDebugger.location, "utf-8")
+    await readFile(dependencies.browserUserInteractions.location, "utf-8")
   );
 };

--- a/packages/replay-debugger/src/replayer/debugger.utils.ts
+++ b/packages/replay-debugger/src/replayer/debugger.utils.ts
@@ -1,7 +1,9 @@
 import { readFile } from "fs/promises";
 import type { ReplayDebuggerDependencies } from "@alwaysmeticulous/common";
+import { METICULOUS_LOGGER_NAME, SessionData } from "@alwaysmeticulous/common";
 import { patchDate } from "@alwaysmeticulous/replayer";
-import { Page } from "puppeteer";
+import log from "loglevel";
+import { BrowserContext, Page, Viewport } from "puppeteer";
 
 export interface SetupPageCookiesOptions {
   page: Page;
@@ -24,15 +26,28 @@ export interface BootstrapPageOptions {
   networkStubbing: boolean;
 }
 
-export const bootstrapPage: (
-  options: BootstrapPageOptions
-) => Promise<void> = async ({
-  page,
+export const createDebugReplayPage: (options: {
+  context: BrowserContext;
+  defaultViewport: Viewport;
+  sessionData: SessionData;
+  shiftTime: boolean;
+  dependencies: ReplayDebuggerDependencies;
+}) => Promise<Page> = async ({
+  context,
+  defaultViewport,
   sessionData,
-  dependencies,
   shiftTime,
-  networkStubbing,
+  dependencies,
 }) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  const page = await context.newPage();
+  logger.debug("Created page");
+  page.setDefaultNavigationTimeout(120000); // 2 minutes
+
+  // Set viewport
+  await page.setViewport(defaultViewport);
+
   // Shift simulation time by patching the Date class
   if (shiftTime) {
     await patchDate({ page, sessionData });
@@ -44,39 +59,12 @@ export const bootstrapPage: (
     window.__meticulous = window.__meticulous || {};
   `);
 
-  await page.evaluateOnNewDocument(
-    `window.sessionData = ${JSON.stringify(sessionData)}`
+  // Setup the user-interactions snippet
+  const userInteractionsFile = await readFile(
+    dependencies.browserUserInteractions.location,
+    "utf-8"
   );
-  try {
-    const { startUrl, startURL } = sessionData.userEvents.window;
-    await page.evaluateOnNewDocument(
-      `window.__meticulousStartURL = "${startUrl || startURL}"`
-    );
-    // TODO: fix this
-    // eslint-disable-next-line no-empty
-  } catch {}
+  await page.evaluateOnNewDocument(userInteractionsFile);
 
-  const reanimatorFile = await readFile(
-    dependencies.reanimator.location,
-    "utf8"
-  );
-  await page.evaluateOnNewDocument(reanimatorFile);
-
-  await page.evaluateOnNewDocument(
-    `window.Reanimator.replay(window['sessionData']['randomEvents'])`
-  );
-
-  if (networkStubbing) {
-    const replayNetworkFile = await readFile(
-      dependencies.replayNetworkFile.location,
-      "utf-8"
-    ); // Bundles PollyJS and supports the replay of network responses
-    await page.evaluateOnNewDocument(replayNetworkFile);
-    await page.evaluateOnNewDocument(`window.setUpPolly()`);
-  }
-
-  // Inject replay debug snippet
-  await page.evaluateOnNewDocument(
-    await readFile(dependencies.browserUserInteractions.location, "utf-8")
-  );
+  return page;
 };

--- a/packages/replay-debugger/src/replayer/replayer.ts
+++ b/packages/replay-debugger/src/replayer/replayer.ts
@@ -2,14 +2,16 @@ import {
   COMMON_CHROMIUM_FLAGS,
   CreateReplayDebuggerFn,
   METICULOUS_LOGGER_NAME,
+  SessionData,
 } from "@alwaysmeticulous/common";
 import {
   getStartUrl,
   getOriginalSessionStartUrl,
 } from "@alwaysmeticulous/replayer";
-import log from "loglevel";
-import { Browser, launch } from "puppeteer";
-import { bootstrapPage, setupPageCookies } from "./debugger.utils";
+import { OnReplayTimelineEventFn } from "@alwaysmeticulous/sdk-bundles-api";
+import log, { LogLevelDesc } from "loglevel";
+import { Browser, launch, Page } from "puppeteer";
+import { createDebugReplayPage, setupPageCookies } from "./debugger.utils";
 import { createReplayDebuggerUI } from "./replay-debugger.ui";
 
 export const createReplayer: CreateReplayDebuggerFn = async ({
@@ -25,6 +27,7 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
   disableRemoteFonts,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logLevel: LogLevelDesc = logger.getLevel();
 
   const { width, height } = sessionData.userEvents.window;
   const defaultViewport = { width, height };
@@ -33,6 +36,9 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     defaultViewport,
     args: [
       `--window-size=${width},${height}`,
+      // This disables cross-origin security. We need this in order to disable CORS for replayed network requests,
+      // including the respective Preflgiht CORS requests which are not handled by the network stubbing layer.
+      "--disable-web-security",
       ...COMMON_CHROMIUM_FLAGS,
       ...(disableRemoteFonts ? ["--disable-remote-fonts"] : []),
     ],
@@ -48,23 +54,12 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     })
   );
 
-  const page = await replayContext.newPage();
-  logger.debug("Created page");
-  page.setDefaultNavigationTimeout(120000); // 2 minutes
-
-  // Set viewport
-  await page.setViewport({
-    width: width,
-    height: height,
-  });
-
-  // Bootstrap page
-  await bootstrapPage({
-    page,
+  const page = await createDebugReplayPage({
+    context: replayContext,
+    defaultViewport,
     sessionData,
-    dependencies,
     shiftTime,
-    networkStubbing,
+    dependencies,
   });
 
   if (cookiesFile) {
@@ -76,6 +71,32 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     sessionData,
   });
   const startUrl = getStartUrl({ originalSessionStartUrl, appUrl });
+
+  // Set-up network stubbing if required
+  if (networkStubbing) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const networkStubbingModule = require(dependencies.nodeNetworkStubbing
+      .location);
+    const setupReplayNetworkStubbing =
+      networkStubbingModule.setupReplayNetworkStubbing as (options: {
+        page: Page;
+        logLevel: LogLevelDesc;
+        sessionData: SessionData;
+        startUrl: string;
+        originalSessionStartUrl: string;
+        onTimelineEvent: OnReplayTimelineEventFn;
+      }) => Promise<void>;
+    await setupReplayNetworkStubbing({
+      page,
+      logLevel,
+      sessionData,
+      startUrl,
+      originalSessionStartUrl: originalSessionStartUrl.toString(),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onTimelineEvent: () => {},
+    });
+  }
+
   logger.debug(`Navigating to ${startUrl}...`);
   const res = await page.goto(startUrl, {
     waitUntil: "domcontentloaded",

--- a/packages/replay-debugger/src/replayer/replayer.ts
+++ b/packages/replay-debugger/src/replayer/replayer.ts
@@ -97,6 +97,21 @@ export const createReplayer: CreateReplayDebuggerFn = async ({
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const browserContextModule = require(dependencies.nodeBrowserContext
+    .location);
+  const setupBrowserContextSeeding =
+    browserContextModule.setupBrowserContextSeeding as (options: {
+      page: Page;
+      sessionData: SessionData;
+      startUrl: string;
+    }) => Promise<void>;
+  await setupBrowserContextSeeding({
+    page,
+    sessionData,
+    startUrl,
+  });
+
   logger.debug(`Navigating to ${startUrl}...`);
   const res = await page.goto(startUrl, {
     waitUntil: "domcontentloaded",


### PR DESCRIPTION
### Changes

This PR updates the `replay-debugger` to use replay v2 snippets, following similar logic to the standard replayer. The control plane in the debugger was already within the node process, so not much of a change in terms of user interaction. The browser context seeding and network stubbing logic is moved to the node process.

Fixes SIM-322