### PR TITLE
Log any console messages -> debug as soon as page is created

### DIFF
--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -45,6 +45,16 @@ export const createReplayPage: (options: {
   logger.debug("Created page");
   page.setDefaultNavigationTimeout(120000); // 2 minutes
 
+  // Log any errors/console messages
+  page.on("console", (message) => {
+    logger.debug(
+      "Console message",
+      message.type(),
+      message.text(),
+      ...message.args()
+    );
+  });
+
   // Set viewport
   await page.setViewport(defaultViewport);
 


### PR DESCRIPTION
Currently we do this on the replay-next-node side, but that initializes the console logging too late -- after scripts may have already been evaluated, so it's possible we may miss some errors getting logged out. I'll open a seperate PR to remove it from there.