### PR TITLE
Wire through csp bypassing for replay

### DIFF
--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -31,6 +31,7 @@ export const createReplayPage: (options: {
   shiftTime: boolean;
   dependencies: ReplayEventsDependencies;
   onTimelineEvent: OnReplayTimelineEventFn;
+  bypassCSP: boolean;
 }) => Promise<Page> = async ({
   context,
   defaultViewport,
@@ -38,12 +39,16 @@ export const createReplayPage: (options: {
   shiftTime,
   dependencies,
   onTimelineEvent,
+  bypassCSP,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const page = await context.newPage();
   logger.debug("Created page");
   page.setDefaultNavigationTimeout(120000); // 2 minutes
+  if (bypassCSP) {
+    await page.setBypassCSP(true);
+  }
 
   // Set viewport
   await page.setViewport(defaultViewport);

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -55,6 +55,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     maxDurationMs,
     maxEventCount,
     disableRemoteFonts,
+    bypassCSP,
   } = replayExecutionOptions;
   const metadata: ReplayMetadata = {
     session,
@@ -105,6 +106,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     shiftTime,
     dependencies,
     onTimelineEvent,
+    bypassCSP,
   });
 
   // Calculate start URL based on the one that the session originated on/from.


### PR DESCRIPTION
This has always been a CLI option, but previously wasn't wired through.

This is useful for websites which disable unsafe-eval (since we rely on that for Puppeteer injecting code). Ideally we'd still fail any requests that look like they could have side-effects (e.g. XHR, Fetch, navigations with post data/forms etc.) to external URLs for safety, in a way that's robust even if polly errors during initialisation or something. Or at least only allow external URLs to be hit if method is GET and we don't send any cookies with it.