### PR TITLE
Wire through sessionDurationMs

### DIFF
--- a/packages/sdk-bundles-api/src/replay/sdk-to-bundle/index.ts
+++ b/packages/sdk-bundles-api/src/replay/sdk-to-bundle/index.ts
@@ -12,6 +12,7 @@ export interface ReplayUserInteractionsOptions {
   storyboard?: StoryboardOptions;
   maxDurationMs?: number;
   maxEventCount?: number;
+  sessionDurationMs?: number;
   onTimelineEvent: OnReplayTimelineEventFn;
   logLevel: LogLevelDesc;
 }


### PR DESCRIPTION
This passes the calculated sessionDurationMs through to replayEvents (currently based on rrweb events, though we may want to change this in future if we're not always recording rrweb events -- e.g. snapshot a start and end timestamp ourselves; which is why I haven't named it rrWebSessionDurationMs -- replayUserInteractions doesn't need to know the details of how it's been calculated). 

### Why pass this through?

When running with --skipPauses it needs to know how much virtual time to fast-forward through after the last user event, and really this should be consistent with how much time we pad by when using padTime. So want one piece of logic used by both.

Note that pushing padTime down into the meticulous repo side would be slightly nicer, however that would create a hard API break, which I want to avoid right now (will become irrelevant if/when we merge).