### PR TITLE
Update replay options to support `baseSimulationId`

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -6,6 +6,7 @@ import {
   METICULOUS_LOGGER_NAME,
   Replay,
   ReplayEventsFn,
+  ReplayEventsOptions,
   ReplayExecutionOptions,
   ReplayTarget,
 } from "@alwaysmeticulous/common";
@@ -68,7 +69,7 @@ export const replayCommandHandler = async ({
   commitSha: commitSha_,
   save,
   exitOnMismatch,
-  baseSimulationId: baseReplayId_,
+  baseSimulationId: baseSimulationId_,
   cookiesFile,
   generatedBy,
 }: ReplayOptions): Promise<Replay> => {
@@ -134,7 +135,8 @@ export const replayCommandHandler = async ({
   );
 
   // 6. Create and save replay parameters
-  const replayEventsParams: Parameters<typeof replayEvents>[0] = {
+  const baseSimulationId = baseSimulationId_ ?? null;
+  const replayEventsParams: ReplayEventsOptions = {
     appUrl: appUrl ?? null,
     replayExecutionOptions: executionOptions,
 
@@ -145,6 +147,7 @@ export const replayCommandHandler = async ({
     recordingId: "manual-replay",
     meticulousSha: "meticulousSha",
     generatedBy,
+    baseSimulationId,
 
     dependencies: {
       browserUserInteractions: {
@@ -243,21 +246,20 @@ export const replayCommandHandler = async ({
   logger.info("=======");
 
   // 12. Diff against base replay screenshot if one is provided
-  const baseReplayId = baseReplayId_ || "";
-  if (screenshottingOptions.enabled && baseReplayId) {
-    logger.info(`Diffing screenshots against replay ${baseReplayId}`);
+  if (screenshottingOptions.enabled && baseSimulationId) {
+    logger.info(`Diffing screenshots against simulation ${baseSimulationId}`);
 
-    await getOrFetchReplay(client, baseReplayId);
-    await getOrFetchReplayArchive(client, baseReplayId);
+    await getOrFetchReplay(client, baseSimulationId);
+    await getOrFetchReplayArchive(client, baseSimulationId);
 
     const baseReplayScreenshotsDir = getScreenshotsDir(
-      getReplayDir(baseReplayId)
+      getReplayDir(baseSimulationId)
     );
     const headReplayScreenshotsDir = getScreenshotsDir(tempDir);
 
     await diffScreenshots({
       client,
-      baseReplayId,
+      baseReplayId: baseSimulationId,
       headReplayId: replay.id,
       baseScreenshotsDir: baseReplayScreenshotsDir,
       headScreenshotsDir: headReplayScreenshotsDir,

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -2,19 +2,19 @@ import {
   GeneratedBy,
   METICULOUS_LOGGER_NAME,
   ReplayExecutionOptions,
-  ReplayTarget
+  ReplayTarget,
 } from "@alwaysmeticulous/common";
 import log from "loglevel";
 import {
   ScreenshotAssertionsEnabledOptions,
-  ScreenshotDiffOptions
+  ScreenshotDiffOptions,
 } from "../command-utils/common-types";
 import { replayCommandHandler } from "../commands/replay/replay.command";
 import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
 import {
   TestCase,
   TestCaseReplayOptions,
-  TestCaseResult
+  TestCaseResult,
 } from "../config/config.types";
 
 const handleReplay: (

--- a/packages/cli/src/local-data/replays.ts
+++ b/packages/cli/src/local-data/replays.ts
@@ -1,4 +1,4 @@
-import { opendir , access, mkdir, readFile, rm, writeFile } from "fs/promises";
+import { opendir, access, mkdir, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import {
   getMeticulousLocalDataDir,

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -98,6 +98,7 @@ export interface ReplayEventsOptions {
   screenshottingOptions: ScreenshottingOptions;
   cookiesFile: string | null;
   generatedBy: GeneratedBy;
+  baseSimulationId: string | null;
 }
 
 export type ReplayEventsFn = (options: ReplayEventsOptions) => Promise<void>;


### PR DESCRIPTION
This PR updates `ReplayEventsOptions` to accept `baseSimulationId` as a parameter.

This will be used to keep track of the base simulation to be used for generating a storyboard.