### PR TITLE
Install virtual event loop before rest of page loads

### DIFF
--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -4,7 +4,10 @@ import {
   ReplayEventsDependencies,
   SessionData,
 } from "@alwaysmeticulous/common";
-import { OnReplayTimelineEventFn } from "@alwaysmeticulous/sdk-bundles-api";
+import {
+  OnReplayTimelineEventFn,
+  VirtualTimeOptions,
+} from "@alwaysmeticulous/sdk-bundles-api";
 import log from "loglevel";
 import { DateTime, Duration } from "luxon";
 import { BrowserContext, Page, Viewport } from "puppeteer";
@@ -32,6 +35,7 @@ export const createReplayPage: (options: {
   dependencies: ReplayEventsDependencies;
   onTimelineEvent: OnReplayTimelineEventFn;
   bypassCSP: boolean;
+  virtualTime: VirtualTimeOptions;
 }) => Promise<Page> = async ({
   context,
   defaultViewport,
@@ -40,6 +44,7 @@ export const createReplayPage: (options: {
   dependencies,
   onTimelineEvent,
   bypassCSP,
+  virtualTime,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -92,6 +97,12 @@ export const createReplayPage: (options: {
   );
   await page.evaluateOnNewDocument(userInteractionsFile);
 
+  // If virtual time is enabled then we need to install the virtual event loop before
+  // any customer code runs, since that code may snapshot copies of the setTimeout etc. functions
+  if (virtualTime.enabled) {
+    await installVirtualEventLoop(page);
+  }
+
   // Setup the url-observer snippet
   const urlObserverFile = await readFile(
     dependencies.browserUrlObserver.location,
@@ -104,6 +115,16 @@ export const createReplayPage: (options: {
 
   return page;
 };
+
+const installVirtualEventLoop = (page: Page) =>
+  page.evaluateOnNewDocument(`
+    const installVirtualEventLoop = window.__meticulous?.replayFunctions?.installVirtualEventLoop;
+    if (installVirtualEventLoop) {
+      installVirtualEventLoop();
+    } else {
+      console.error("Could not install virtual event loop since window.__meticulous.replayFunctions.installVirtualEventLoop null or undefined");
+    }
+`);
 
 const getMinMaxRrwebTimestamps: (
   sessionData: SessionData

--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -97,8 +97,6 @@ export const createReplayPage: (options: {
   );
   await page.evaluateOnNewDocument(userInteractionsFile);
 
-  // If virtual time is enabled then we need to install the virtual event loop before
-  // any customer code runs, since that code may snapshot copies of the setTimeout etc. functions
   if (virtualTime.enabled) {
     await installVirtualEventLoop(page);
   }

--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -122,7 +122,7 @@ const installVirtualEventLoop = (page: Page) =>
     if (installVirtualEventLoop) {
       installVirtualEventLoop();
     } else {
-      console.error("Could not install virtual event loop since window.__meticulous.replayFunctions.installVirtualEventLoop null or undefined");
+      console.error("Could not install virtual event loop since window.__meticulous.replayFunctions.installVirtualEventLoop was null or undefined");
     }
 `);
 

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -9,7 +9,10 @@ import {
   ReplayTimelineEntry,
   ReplayUserInteractionsFn,
 } from "@alwaysmeticulous/sdk-bundles-api";
-import { StoryboardOptions } from "@alwaysmeticulous/sdk-bundles-api/dist/replay/sdk-to-bundle";
+import {
+  StoryboardOptions,
+  VirtualTimeOptions,
+} from "@alwaysmeticulous/sdk-bundles-api/dist/replay/sdk-to-bundle";
 import log, { LogLevelDesc } from "loglevel";
 import { DateTime } from "luxon";
 import { Browser, launch, Page } from "puppeteer";
@@ -100,6 +103,9 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     entry: ReplayTimelineEntry
   ) => timelineCollector.addEntry(entry);
 
+  const virtualTime: VirtualTimeOptions = skipPauses
+    ? { enabled: true }
+    : { enabled: false };
   const page = await createReplayPage({
     context,
     defaultViewport,
@@ -108,6 +114,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     dependencies,
     onTimelineEvent,
     bypassCSP,
+    virtualTime,
   });
 
   // Calculate start URL based on the one that the session originated on/from.
@@ -194,7 +201,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     logLevel,
     sessionData,
     moveBeforeClick,
-    virtualTime: skipPauses ? { enabled: true } : { enabled: false },
+    virtualTime,
     storyboard,
     onTimelineEvent,
     ...(rrwebRecordingDuration != null


### PR DESCRIPTION
If virtual time is enabled then we need to install the virtual event loop before any application code runs, since that code may snapshot copies of the setTimeout etc. functions