### PR TITLE
Move sdk-bundles-api to devDependencies

### DIFF
--- a/packages/recorder-loader/package.json
+++ b/packages/recorder-loader/package.json
@@ -18,7 +18,7 @@
     "lint:commit": "eslint --cache $(git diff --relative --name-only --diff-filter=ACMRTUXB master | grep  -E \"(.js$|.ts$|.tsx$)\")",
     "lint:fix": "eslint src --ext=ts,tsx,js --cache --fix"
   },
-  "dependencies": {
+  "devDependencies": {
     "@alwaysmeticulous/sdk-bundles-api": "^2.8.0"
   },
   "author": {

--- a/packages/replay-debugger/package.json
+++ b/packages/replay-debugger/package.json
@@ -21,9 +21,11 @@
     "@alwaysmeticulous/common": "^2.6.2",
     "@alwaysmeticulous/replay-debugger-ui": "^2.5.0",
     "@alwaysmeticulous/replayer": "^2.8.0",
-    "@alwaysmeticulous/sdk-bundles-api": "^2.8.0",
     "puppeteer": "^14.4.1",
     "rrweb": "^1.1.3"
+  },
+  "devDependencies": {
+    "@alwaysmeticulous/sdk-bundles-api": "^2.8.0"
   },
   "author": {
     "name": "The Meticulous Team",

--- a/packages/replayer/package.json
+++ b/packages/replayer/package.json
@@ -19,11 +19,13 @@
   },
   "dependencies": {
     "@alwaysmeticulous/common": "^2.6.2",
-    "@alwaysmeticulous/sdk-bundles-api": "^2.8.0",
     "loglevel": "^1.8.0",
     "luxon": "^2.4.0",
     "puppeteer": "^14.4.1",
     "rrweb": "^1.1.3"
+  },
+  "devDependencies": {
+    "@alwaysmeticulous/sdk-bundles-api": "^2.8.0"
   },
   "author": {
     "name": "The Meticulous Team",


### PR DESCRIPTION
The `sdk-bundles-api` package only contains types and so should not be transitively depended on.