### PR TITLE
Update the simulate command to send diff data to Meticulous

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
+    "@alwaysmeticulous/api": "^2.8.0",
     "@types/express": "^4.17.14"
   },
   "peerDependencies": {

--- a/packages/cli/src/api/replay-diff.api.ts
+++ b/packages/cli/src/api/replay-diff.api.ts
@@ -1,0 +1,44 @@
+import { ReplayDiff, ReplayDiffData } from "@alwaysmeticulous/api";
+import axios, { AxiosInstance } from "axios";
+
+export const getReplayDiff = async ({
+  client,
+  replayDiffId,
+}: {
+  client: AxiosInstance;
+  replayDiffId: string;
+}): Promise<ReplayDiff | null> => {
+  const { data } = await client
+    .get(`replay-diffs/${replayDiffId}`)
+    .catch((error) => {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 404) {
+          return { data: null };
+        }
+      }
+      throw error;
+    });
+  return data;
+};
+
+export const createReplayDiff = async ({
+  client,
+  headReplayId,
+  baseReplayId,
+  testRunId,
+  data: replayDiffData,
+}: {
+  client: AxiosInstance;
+  headReplayId: string;
+  baseReplayId: string;
+  testRunId: string | null;
+  data: ReplayDiffData;
+}): Promise<ReplayDiff> => {
+  const { data } = await client.post("replay-diffs", {
+    headReplayId,
+    baseReplayId,
+    ...(testRunId ? { testRunId } : {}),
+    data: replayDiffData,
+  });
+  return data;
+};

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -160,6 +160,7 @@ const handler: (options: Options) => Promise<void> = async ({
         commitSha,
         deflake: deflake ?? false,
         generatedBy: { type: "testRun", runId: testRun.id },
+        testRunId: testRun.id,
       });
       results.push(result);
       await putTestRunResults({

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -163,12 +163,12 @@ export const checkScreenshotDiffResult = ({
 }): void => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const missingHeadImagesResults = results.filter(
-    ({ outcome }) => outcome === "missing-head"
-  ) as ScreenshotDiffResultMissingHead[];
+  const missingHeadImagesResults = results.flatMap((result) =>
+    result.outcome === "missing-head" ? [result] : []
+  );
   if (missingHeadImagesResults.length) {
     const message = `Head replay is missing screenshots: ${missingHeadImagesResults
-      .map(({ baseScreenshotFile }) => baseScreenshotFile)
+      .map(({ baseScreenshotFile }) => basename(baseScreenshotFile))
       .sort()} => FAIL!`;
     logger.info(message);
     throw new ScreenshotDiffError(message, {
@@ -177,9 +177,9 @@ export const checkScreenshotDiffResult = ({
     });
   }
 
-  const missingBaseImagesResults = results.filter(
-    ({ outcome }) => outcome === "missing-base"
-  ) as ScreenshotDiffResultMissingBase[];
+  const missingBaseImagesResults = results.flatMap((result) =>
+    result.outcome === "missing-base" ? [result] : []
+  );
   if (missingHeadImagesResults.length) {
     const message = `Notice: Base replay is missing screenshots: ${missingBaseImagesResults
       .map(({ headScreenshotFile }) => basename(headScreenshotFile))
@@ -202,8 +202,8 @@ export const checkScreenshotDiffResult = ({
     }
 
     if (outcome === "diff" || outcome === "no-diff") {
-      const mismatch = Math.round(result.mismatchFraction * 100);
-      const threshold = Math.round(diffOptions.diffThreshold * 100);
+      const mismatch = (result.mismatchFraction * 100).toFixed(3);
+      const threshold = (diffOptions.diffThreshold * 100).toFixed(3);
       const message = `${mismatch}% pixel mismatch for screenshot ${basename(
         result.headScreenshotFile
       )} (threshold is ${threshold}%) => ${

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -188,16 +188,6 @@ export const checkScreenshotDiffResult = (
       throw new Error(message);
     }
 
-    // logComparisonResultMessage(
-    //   logger,
-    //   `${Math.round(
-    //     result.comparisonResult.mismatchFraction * 100
-    //   )}% pixel mismatch for screenshot ${basename(
-    //     result.headScreenshotFile
-    //   )} (threshold is ${Math.round(diffThreshold * 100)}%)`,
-    //   result.outcome
-    // );
-
     if (outcome === "diff" || outcome === "no-diff") {
       const mismatch = Math.round(result.mismatchFraction * 100);
       const threshold = Math.round(diffOptions.diffThreshold * 100);

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -2,8 +2,6 @@ import { basename, join } from "path";
 import {
   ScreenshotDiffOptions,
   ScreenshotDiffResult,
-  ScreenshotDiffResultMissingBase,
-  ScreenshotDiffResultMissingHead,
   ScreenshotIdentifier,
 } from "@alwaysmeticulous/api";
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -1,13 +1,17 @@
 import { basename, join } from "path";
+import {
+  ScreenshotDiffOptions,
+  ScreenshotDiffResult,
+  ScreenshotDiffResultMissingBase,
+  ScreenshotDiffResultMissingHead,
+  ScreenshotIdentifier,
+} from "@alwaysmeticulous/api";
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import { AxiosInstance } from "axios";
-import log, { Logger } from "loglevel";
+import log from "loglevel";
 import { createClient } from "../../api/client";
-import { getDiffUrl, postScreenshotDiffStats } from "../../api/replay.api";
 import { buildCommand } from "../../command-utils/command-builder";
 import { SCREENSHOT_DIFF_OPTIONS } from "../../command-utils/common-options";
-import { ScreenshotDiffOptions } from "../../command-utils/common-types";
-import { CompareImageResult, compareImages } from "../../image/diff.utils";
+import { compareImages } from "../../image/diff.utils";
 import { readPng } from "../../image/io.utils";
 import {
   getOrFetchReplay,
@@ -18,199 +22,222 @@ import {
 } from "../../local-data/replays";
 import { writeScreenshotDiff } from "../../local-data/screenshot-diffs";
 
-export class DiffError extends Error {
-  constructor(
-    message: string,
-    readonly extras?: {
-      baseReplayId: string;
-      headReplayId: string;
-      threshold: number;
-      value?: number;
-    }
-  ) {
-    super(message);
-  }
-}
-
-type ComparisonOutcome = "pass" | "fail";
-
-export interface ScreenshotDiffResult {
-  baseScreenshotFile: string;
-  headScreenshotFile: string;
-
-  outcome: ComparisonOutcome;
-  comparisonResult: CompareImageResult;
-}
-
-export const diffScreenshots: (options: {
-  client: AxiosInstance;
+export const diffScreenshots = async ({
+  headReplayId,
+  baseReplayId,
+  headScreenshotsDir,
+  baseScreenshotsDir,
+  diffOptions,
+}: {
   baseReplayId: string;
   headReplayId: string;
   baseScreenshotsDir: string;
   headScreenshotsDir: string;
   diffOptions: ScreenshotDiffOptions;
-  exitOnMismatch: boolean;
-}) => Promise<ScreenshotDiffResult[]> = async ({
-  client,
-  baseReplayId,
-  headReplayId,
-  baseScreenshotsDir,
-  headScreenshotsDir,
-  diffOptions,
-  exitOnMismatch,
-}) => {
+}): Promise<ScreenshotDiffResult[]> => {
   const { diffThreshold, diffPixelThreshold } = diffOptions;
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const baseReplayScreenshots = await getScreenshotFiles(baseScreenshotsDir);
   const headReplayScreenshots = await getScreenshotFiles(headScreenshotsDir);
 
-  // Assume base replay screenshots are always a subset of the head replay screenshots.
-  // We report any missing base replay screenshots for visibility but don't count it as a difference.
   const missingHeadImages = new Set(
-    [...baseReplayScreenshots].filter(
+    baseReplayScreenshots.filter(
       (file) => !headReplayScreenshots.includes(file)
     )
   );
 
-  let totalMismatchPixels = 0;
-
-  const comparisonResults: ScreenshotDiffResult[] = [];
-
-  try {
-    if (missingHeadImages.size > 0) {
-      logComparisonResultMessage(
-        logger,
-        `Head replay is missing screenshots: ${[...missingHeadImages].sort()}`,
-        "fail"
-      );
-      throw new DiffError(
-        `Head replay is missing screenshots: ${[...missingHeadImages].sort()}`,
-        {
-          baseReplayId,
-          headReplayId,
-          threshold: diffThreshold,
-        }
-      );
+  const missingHeadImagesResults: ScreenshotDiffResult[] = Array.from(
+    missingHeadImages
+  ).flatMap((screenshotFileName) => {
+    const identifier = getScreenshotIdentifier(screenshotFileName);
+    if (identifier == null) {
+      return [];
     }
-
-    for (const screenshotFileName of headReplayScreenshots) {
-      if (!baseReplayScreenshots.includes(screenshotFileName)) {
-        logger.info(
-          `Screenshot ${screenshotFileName} not present in base replay`
-        );
-        continue;
-      }
-
-      const baseScreenshotFile = join(baseScreenshotsDir, screenshotFileName);
-      const headScreenshotFile = join(headScreenshotsDir, screenshotFileName);
-      const baseScreenshot = await readPng(baseScreenshotFile);
-      const headScreenshot = await readPng(headScreenshotFile);
-
-      const comparisonResult = compareImages({
-        base: baseScreenshot,
-        head: headScreenshot,
-        pixelThreshold: diffPixelThreshold,
-      });
-
-      totalMismatchPixels += comparisonResult.mismatchPixels;
-
-      logger.debug({
-        screenshotFileName,
-        mismatchPixels: comparisonResult.mismatchPixels,
-        mismatchFraction: comparisonResult.mismatchFraction,
-      });
-
-      await writeScreenshotDiff({
-        baseReplayId,
-        headReplayId,
-        screenshotFileName,
-        diff: comparisonResult.diff,
-      });
-
-      comparisonResults.push({
-        baseScreenshotFile,
-        headScreenshotFile,
-        comparisonResult,
-        outcome:
-          comparisonResult.mismatchFraction > diffThreshold ? "fail" : "pass",
-      });
-    }
-
-    await postScreenshotDiffStats(client, {
-      baseReplayId,
-      headReplayId,
-      stats: {
-        width: 0,
-        height: 0,
-        mismatchPixels: totalMismatchPixels,
+    return [
+      {
+        identifier,
+        outcome: "missing-head",
+        baseScreenshotFile: `screenshots/${screenshotFileName}`,
       },
-    });
+    ];
+  });
 
-    const diffUrl = await getDiffUrl(client, baseReplayId, headReplayId);
-    logger.info(`View screenshot diff at ${diffUrl}`);
+  const headDiffResults = (
+    await Promise.all(
+      headReplayScreenshots.map(
+        async (screenshotFileName): Promise<ScreenshotDiffResult[]> => {
+          const identifier = getScreenshotIdentifier(screenshotFileName);
 
-    comparisonResults.forEach((result) => {
-      logComparisonResultMessage(
-        logger,
-        `${Math.round(
-          result.comparisonResult.mismatchFraction * 100
-        )}% pixel mismatch for screenshot ${basename(
-          result.headScreenshotFile
-        )} (threshold is ${Math.round(diffThreshold * 100)}%)`,
-        result.outcome
-      );
-    });
+          if (identifier == null) {
+            return [];
+          }
 
-    // Check if individual screenshot mismatch is higher than the threshold.
-    const mismatchingScreenshots = comparisonResults.filter(
-      (result) => result.outcome == "fail"
-    );
+          if (!baseReplayScreenshots.includes(screenshotFileName)) {
+            return [
+              {
+                identifier,
+                outcome: "missing-base",
+                headScreenshotFile: `screenshots/${screenshotFileName}`,
+              },
+            ];
+          }
 
-    if (mismatchingScreenshots.length) {
-      logger.info(
-        `Screenshots ${mismatchingScreenshots
-          .map((result) => basename(result.headScreenshotFile))
-          .sort()} do not match!`
-      );
-      if (exitOnMismatch) {
-        process.exit(1);
-      }
-      throw new DiffError(
-        `Screenshots ${mismatchingScreenshots.map((result) =>
-          basename(result.headScreenshotFile)
-        )} do not match!`,
-        {
-          baseReplayId,
-          headReplayId,
-          threshold: diffThreshold,
+          const baseScreenshotFile = join(
+            baseScreenshotsDir,
+            screenshotFileName
+          );
+          const headScreenshotFile = join(
+            headScreenshotsDir,
+            screenshotFileName
+          );
+          const baseScreenshot = await readPng(baseScreenshotFile);
+          const headScreenshot = await readPng(headScreenshotFile);
+
+          try {
+            const comparisonResult = compareImages({
+              base: baseScreenshot,
+              head: headScreenshot,
+              pixelThreshold: diffPixelThreshold,
+            });
+
+            await writeScreenshotDiff({
+              baseReplayId,
+              headReplayId,
+              screenshotFileName,
+              diff: comparisonResult.diff,
+            });
+
+            return [
+              {
+                identifier,
+                outcome:
+                  comparisonResult.mismatchFraction > diffThreshold
+                    ? "diff"
+                    : "no-diff",
+                headScreenshotFile: `screenshots/${screenshotFileName}`,
+                baseScreenshotFile: `screenshots/${screenshotFileName}`,
+                width: baseScreenshot.width,
+                height: baseScreenshot.height,
+                mismatchPixels: comparisonResult.mismatchPixels,
+                mismatchFraction: comparisonResult.mismatchFraction,
+              },
+            ];
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              error.message.startsWith("Cannot handle different size")
+            ) {
+              return [
+                {
+                  identifier,
+                  outcome: "different-size",
+                  headScreenshotFile: `screenshots/${screenshotFileName}`,
+                  baseScreenshotFile: `screenshots/${screenshotFileName}`,
+                  baseWidth: baseScreenshot.width,
+                  baseHeight: baseScreenshot.height,
+                  headWidth: headScreenshot.width,
+                  headHeight: headScreenshot.height,
+                },
+              ];
+            }
+            throw error;
+          }
         }
-      );
-    }
-  } catch (error) {
-    if (!(error instanceof DiffError)) {
-      logger.error(error);
-    }
-    if (exitOnMismatch) {
-      process.exit(1);
-    }
-    throw new DiffError(`Error while diffing: ${error}`, {
-      baseReplayId,
-      headReplayId,
-      threshold: diffThreshold,
-      value: 1,
-    });
-  }
+      )
+    )
+  ).flat();
 
-  return comparisonResults;
+  return [...missingHeadImagesResults, ...headDiffResults];
 };
 
-const logComparisonResultMessage: (
-  logger: Logger,
-  message: string,
-  outcome: ComparisonOutcome
-) => void = (logger, message, outcome) => {
-  logger.info(`${message} => ${outcome === "pass" ? "PASS" : "FAIL!"}`);
+export const checkScreenshotDiffResult = (
+  results: ScreenshotDiffResult[],
+  diffOptions: ScreenshotDiffOptions
+): void => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  const missingHeadImagesResults = results.filter(
+    ({ outcome }) => outcome === "missing-head"
+  ) as ScreenshotDiffResultMissingHead[];
+  if (missingHeadImagesResults.length) {
+    const message = `Head replay is missing screenshots: ${missingHeadImagesResults
+      .map(({ baseScreenshotFile }) => baseScreenshotFile)
+      .sort()} => FAIL!`;
+    logger.info(message);
+    throw new Error(message);
+  }
+
+  const missingBaseImagesResults = results.filter(
+    ({ outcome }) => outcome === "missing-base"
+  ) as ScreenshotDiffResultMissingBase[];
+  if (missingHeadImagesResults.length) {
+    const message = `Notice: Base replay is missing screenshots: ${missingBaseImagesResults
+      .map(({ headScreenshotFile }) => basename(headScreenshotFile))
+      .sort()}`;
+    logger.info(message);
+  }
+
+  results.forEach((result) => {
+    const { outcome } = result;
+
+    if (outcome === "different-size") {
+      const message = `Screenshots ${basename(
+        result.headScreenshotFile
+      )} have different sizes => FAIL!`;
+      logger.info(message);
+      throw new Error(message);
+    }
+
+    // logComparisonResultMessage(
+    //   logger,
+    //   `${Math.round(
+    //     result.comparisonResult.mismatchFraction * 100
+    //   )}% pixel mismatch for screenshot ${basename(
+    //     result.headScreenshotFile
+    //   )} (threshold is ${Math.round(diffThreshold * 100)}%)`,
+    //   result.outcome
+    // );
+
+    if (outcome === "diff" || outcome === "no-diff") {
+      const mismatch = Math.round(result.mismatchFraction * 100);
+      const threshold = Math.round(diffOptions.diffThreshold * 100);
+      const message = `${mismatch}% pixel mismatch for screenshot ${basename(
+        result.headScreenshotFile
+      )} (threshold is ${threshold}%) => ${
+        outcome === "no-diff" ? "PASS" : "FAIL!"
+      }`;
+      logger.info(message);
+      if (outcome === "diff") {
+        throw new Error(message);
+      }
+    }
+  });
+};
+
+const getScreenshotIdentifier = (
+  filename: string
+): ScreenshotIdentifier | undefined => {
+  const name = basename(filename);
+
+  if (name === "final-state.png") {
+    return {
+      type: "end-state",
+    };
+  }
+
+  if (name.startsWith("screenshot-after-event")) {
+    const match = name.match(/^(?:.*)-(\d+)[.]png$/);
+    const eventNumber = match ? parseInt(match[1], 10) : undefined;
+
+    if (match && eventNumber != null && !isNaN(eventNumber)) {
+      return {
+        type: "after-event",
+        eventNumber: eventNumber - 1,
+      };
+    }
+  }
+
+  return undefined;
 };
 
 interface Options {
@@ -228,6 +255,8 @@ const handler: (options: Options) => Promise<void> = async ({
   threshold,
   pixelThreshold,
 }) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
   const client = createClient({ apiToken });
 
   await getOrFetchReplay(client, baseReplayId);
@@ -238,8 +267,7 @@ const handler: (options: Options) => Promise<void> = async ({
   const baseScreenshotsDir = getScreenshotsDir(getReplayDir(baseReplayId));
   const headScreenshotsDir = getScreenshotsDir(getReplayDir(headReplayId));
 
-  await diffScreenshots({
-    client,
+  const results = await diffScreenshots({
     baseReplayId,
     headReplayId,
     baseScreenshotsDir,
@@ -248,7 +276,13 @@ const handler: (options: Options) => Promise<void> = async ({
       diffThreshold: threshold,
       diffPixelThreshold: pixelThreshold,
     },
-    exitOnMismatch: true,
+  });
+
+  logger.debug(results);
+
+  checkScreenshotDiffResult(results, {
+    diffThreshold: threshold,
+    diffPixelThreshold: pixelThreshold,
   });
 };
 

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -2,19 +2,19 @@ import {
   GeneratedBy,
   METICULOUS_LOGGER_NAME,
   ReplayExecutionOptions,
-  ReplayTarget
+  ReplayTarget,
 } from "@alwaysmeticulous/common";
 import log from "loglevel";
 import {
   ScreenshotAssertionsEnabledOptions,
-  ScreenshotDiffOptions
+  ScreenshotDiffOptions,
 } from "../command-utils/common-types";
 import { replayCommandHandler } from "../commands/replay/replay.command";
-import { DiffError } from "../commands/screenshot-diff/screenshot-diff.command";
+import { ScreenshotDiffError } from "../commands/screenshot-diff/screenshot-diff.command";
 import {
   TestCase,
   TestCaseReplayOptions,
-  TestCaseResult
+  TestCaseResult,
 } from "../config/config.types";
 
 const handleReplay: (
@@ -27,6 +27,7 @@ const handleReplay: (
   apiToken,
   commitSha,
   generatedBy,
+  testRunId,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -48,6 +49,7 @@ const handleReplay: (
     exitOnMismatch: false,
     cookiesFile: null,
     generatedBy,
+    testRunId,
   });
   const result: TestCaseResult = await replayPromise
     .then(
@@ -59,7 +61,7 @@ const handleReplay: (
         } as TestCaseResult)
     )
     .catch((error) => {
-      if (error instanceof DiffError && error.extras) {
+      if (error instanceof ScreenshotDiffError && error.extras) {
         return {
           ...testCase,
           headReplayId: error.extras.headReplayId,
@@ -85,6 +87,7 @@ interface HandleReplayOptions {
   apiToken: string | null;
   commitSha: string;
   generatedBy: GeneratedBy;
+  testRunId: string | null;
 }
 
 export const deflakeReplayCommandHandler: (

--- a/packages/cli/src/local-data/replays.ts
+++ b/packages/cli/src/local-data/replays.ts
@@ -1,4 +1,4 @@
-import { opendir , access, mkdir, readFile, rm, writeFile } from "fs/promises";
+import { opendir, access, mkdir, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import {
   getMeticulousLocalDataDir,

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -119,6 +119,7 @@ export const runAllTestsInParallel: (
           executionOptions,
           screenshottingOptions,
           generatedBy: { type: "testRun", runId: testRun.id },
+          testRunId: testRun.id,
         },
       },
     };

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -98,6 +98,7 @@ export interface ReplayEventsOptions {
   screenshottingOptions: ScreenshottingOptions;
   cookiesFile: string | null;
   generatedBy: GeneratedBy;
+  testRunId: string | null;
 }
 
 export type ReplayEventsFn = (options: ReplayEventsOptions) => Promise<void>;


### PR DESCRIPTION
Update relevant CLI commands to send screenshot diff data to the Meticulous API.

### Details

* Diffing screenshots now computes the outcome for all screenshots, so that we can persist the diff data
* When `run-all-tests` is run, the `testRunId` is passed around to be tracked when the screenshot diff data is pushed to the Meticulous API

[SIM-334](https://toil.kitemaker.co/qpgVHi-Meticulous/pPGwrM-Engineering/items/334)