### PR TITLE
Pass through session start time to virtual event loop

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
           path: |
             node_modules/.cache/turbo
             packages/*/.turbo
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-v2
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/packages/replay-debugger/src/replayer/debugger.utils.ts
+++ b/packages/replay-debugger/src/replayer/debugger.utils.ts
@@ -1,7 +1,7 @@
 import { readFile } from "fs/promises";
 import type { ReplayDebuggerDependencies } from "@alwaysmeticulous/common";
 import { METICULOUS_LOGGER_NAME, SessionData } from "@alwaysmeticulous/common";
-import { patchDate } from "@alwaysmeticulous/replayer";
+import { patchDate, getSessionStartTime } from "@alwaysmeticulous/replayer";
 import log from "loglevel";
 import { BrowserContext, Page, Viewport } from "puppeteer";
 
@@ -50,7 +50,8 @@ export const createDebugReplayPage: (options: {
 
   // Shift simulation time by patching the Date class
   if (shiftTime) {
-    await patchDate({ page, sessionData });
+    const sessionStartTime = getSessionStartTime(sessionData);
+    await patchDate({ page, sessionStartTime });
   }
 
   // Disable the recording snippet

--- a/packages/replayer/src/index.ts
+++ b/packages/replayer/src/index.ts
@@ -2,5 +2,6 @@ export { replayEvents } from "./replayer";
 export {
   getStartUrl,
   getOriginalSessionStartUrl,
+  getSessionStartTime,
   patchDate,
 } from "./replay.utils";

--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -7,6 +7,7 @@ import {
 import {
   OnReplayTimelineEventFn,
   VirtualTimeOptions,
+  InstallVirtualEventLoopOpts,
 } from "@alwaysmeticulous/sdk-bundles-api";
 import log from "loglevel";
 import { DateTime, Duration } from "luxon";
@@ -115,15 +116,19 @@ export const createReplayPage: (options: {
   return page;
 };
 
-const installVirtualEventLoop = (page: Page, sessionStartTime: DateTime) =>
-  page.evaluateOnNewDocument(`
-    const installVirtualEventLoop = window.__meticulous?.replayFunctions?.installVirtualEventLoop;
-    if (installVirtualEventLoop) {
-      installVirtualEventLoop({ sessionStartTime: ${sessionStartTime.toMillis()} });
-    } else {
-      console.error("Could not install virtual event loop since window.__meticulous.replayFunctions.installVirtualEventLoop was null or undefined");
-    }
-`);
+const installVirtualEventLoop = (page: Page, sessionStartTime: DateTime) => {
+  const opts: InstallVirtualEventLoopOpts = {
+    sessionStartTime: sessionStartTime.toMillis(),
+  };
+  return page.evaluateOnNewDocument(`
+      const installVirtualEventLoop = window.__meticulous?.replayFunctions?.installVirtualEventLoop;
+      if (installVirtualEventLoop) {
+        installVirtualEventLoop(${JSON.stringify(opts)});
+      } else {
+        console.error("Could not install virtual event loop since window.__meticulous.replayFunctions.installVirtualEventLoop was null or undefined");
+      }
+  `);
+};
 
 const getMinMaxRrwebTimestamps: (
   sessionData: SessionData

--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -70,7 +70,7 @@ export const createReplayPage: (options: {
   await page.setViewport(defaultViewport);
 
   // Shift simulation time by patching the Date class
-  const [sessionStartTime] = getMinMaxRrwebTimestamps(sessionData);
+  const sessionStartTime = getSessionStartTime(sessionData);
   if (shiftTime) {
     await patchDate({ page, sessionStartTime });
   }
@@ -130,6 +130,18 @@ const installVirtualEventLoop = (page: Page, sessionStartTime: DateTime) => {
   `);
 };
 
+export const getSessionStartTime = (sessionData: SessionData): DateTime =>
+  getMinMaxRrwebTimestamps(sessionData)[0];
+
+export const getRrwebRecordingDuration: (
+  sessionData: SessionData
+) => Duration | null = (sessionData) => {
+  const [minRrwebTimestamp, maxRrwebTimestamp] =
+    getMinMaxRrwebTimestamps(sessionData);
+  const rrwebRecordingDuration = maxRrwebTimestamp.diff(minRrwebTimestamp);
+  return rrwebRecordingDuration.isValid ? rrwebRecordingDuration : null;
+};
+
 const getMinMaxRrwebTimestamps: (
   sessionData: SessionData
 ) => [DateTime, DateTime] = (sessionData) => {
@@ -143,15 +155,6 @@ const getMinMaxRrwebTimestamps: (
     Math.max(...rrwebTimestamps)
   ).toUTC();
   return [minRrwebTimestamp, maxRrwebTimestamp];
-};
-
-export const getRrwebRecordingDuration: (
-  sessionData: SessionData
-) => Duration | null = (sessionData) => {
-  const [minRrwebTimestamp, maxRrwebTimestamp] =
-    getMinMaxRrwebTimestamps(sessionData);
-  const rrwebRecordingDuration = maxRrwebTimestamp.diff(minRrwebTimestamp);
-  return rrwebRecordingDuration.isValid ? rrwebRecordingDuration : null;
 };
 
 export const patchDate: (options: {

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -9,6 +9,7 @@ export {
   ReplayUserInteractionsFn,
   ReplayUserInteractionsOptions,
   VirtualTimeOptions,
+  InstallVirtualEventLoopOpts,
 } from "./replay/sdk-to-bundle";
 export {
   ReplayTimelineData,

--- a/packages/sdk-bundles-api/src/replay/sdk-to-bundle/index.ts
+++ b/packages/sdk-bundles-api/src/replay/sdk-to-bundle/index.ts
@@ -32,3 +32,14 @@ export type StoryboardOptions =
   | { enabled: true; screenshotsDir: string };
 
 export type OnReplayTimelineEventFn = (entry: ReplayTimelineEntry) => void;
+
+export interface InstallVirtualEventLoopOpts {
+  /**
+   * The start time of the original session in ms since unix epoch (Date.now()).
+   *
+   * This is used to ensure that the application code thinks it's running at the same
+   * time as the original session during replay, to minimize differences vs the original
+   * session.
+   */
+  sessionStartTime: number;
+}


### PR DESCRIPTION
This will ensure the values returned by `Date.now()` etc. are always _exactly_ the same on every skip pauses run -- while currently there's non-determinism due the time elapsed from evaluating `patchDate` and evaluating `installVirtualEventLoop` (the later which calls Date.now() on the patched date to work out the start time).

Once this has merged I'll update installVirtualEventLoop to use the passed in timestamp, and to extend from `window.__meticulous.timeshift.OriginalDate` if it exists _and_ if the new sessionStartTime param is being passed through, rather than from `window.Date` (which would shift twice). Since I can do this as a single change there won't be any issues with API breaks (old CLI, new bundle etc.).