### PR TITLE
Update date shifting to not rely on rrweb

### DIFF
--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -157,7 +157,7 @@ export const getSessionStartTime = (sessionData: SessionData): DateTime => {
   // session start time to ensure we fully accuractly recreate the original values returned by the
   // Date.now() calls.
   const minUserEventTimestamp =
-    userEventEventLog[0]?.timeStampRaw - userEventEventLog[0]?.timeStamp;
+    userEventEventLog[0].timeStampRaw - userEventEventLog[0].timeStamp;
   return DateTime.fromMillis(minUserEventTimestamp).toUTC();
 };
 

--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -132,7 +132,7 @@ const installVirtualEventLoop = (page: Page, sessionStartTime: DateTime) => {
 
 export const getSessionStartTime = (sessionData: SessionData): DateTime => {
   const rrWebTimeRange = getMinMaxRrwebTimestamps(sessionData);
-  if (rrWebTimeRange != null) {
+  if (rrWebTimeRange != null && rrWebTimeRange.min.isValid) {
     return rrWebTimeRange.min;
   }
 

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -21,7 +21,7 @@ import { ReplayMetadata } from "./replay.types";
 import {
   createReplayPage,
   getOriginalSessionStartUrl,
-  getRrwebRecordingDuration,
+  getSessionDuration,
   getStartingViewport,
   getStartUrl,
   initializeReplayData,
@@ -195,7 +195,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     screenshottingOptions.storyboardOptions.enabled
       ? { enabled: true, screenshotsDir }
       : { enabled: false };
-  const rrwebRecordingDuration = getRrwebRecordingDuration(sessionData);
+  const sessionDuration = getSessionDuration(sessionData);
   const replayResult = await replayUserInteractions({
     page,
     logLevel,
@@ -204,8 +204,8 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     virtualTime,
     storyboard,
     onTimelineEvent,
-    ...(rrwebRecordingDuration != null
-      ? { sessionDurationMs: rrwebRecordingDuration?.milliseconds }
+    ...(sessionDuration != null
+      ? { sessionDurationMs: sessionDuration?.milliseconds }
       : {}),
     ...(maxDurationMs != null ? { maxDurationMs } : {}),
     ...(maxEventCount != null ? { maxEventCount } : {}),
@@ -217,14 +217,11 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     padTime &&
     !skipPauses &&
     replayResult.length === "full" &&
-    rrwebRecordingDuration != null
+    sessionDuration != null
   ) {
     const now = DateTime.utc();
-    const timeToPad = startTime
-      .plus(rrwebRecordingDuration)
-      .diff(now)
-      .toMillis();
-    logger.debug(`Padtime: ${timeToPad} ${rrwebRecordingDuration.toISOTime()}`);
+    const timeToPad = startTime.plus(sessionDuration).diff(now).toMillis();
+    logger.debug(`Padtime: ${timeToPad} ${sessionDuration.toISOTime()}`);
     if (timeToPad > 0) {
       await new Promise<void>((resolve) => {
         setTimeout(() => {


### PR DESCRIPTION
We automatically abandon recording rrweb data if it's too large since it's generally not essential for replay. However there is one remaining place where it is essential for replay and that's for when we do date shifting. This PR removes that dependency by falling back to using the user events to calculate the session start and session duration.

This will fix the issue for now, and in the meantime we can work on adding a dedicated session start timestamp (that event.timeStamps are relative to) that's measured in Date.now() time rather than performance.timeOrigin time, to ensure we can reproduce the original Date.now() calls exactly.