### PR TITLE
Add error case to replay results

### DIFF
--- a/packages/sdk-bundles-api/src/replay/bundle-to-sdk/index.ts
+++ b/packages/sdk-bundles-api/src/replay/bundle-to-sdk/index.ts
@@ -16,7 +16,7 @@ export interface ReplayUserInteractionsResultShort {
 }
 
 /**
- * Returned when a fatal error was thrown during replay, that cut the replay short
+ * Returned when a fatal error was thrown during replay that cut the replay short
  * (for example the page was navigated while trying to evaluate javascript).
  */
 export interface ReplayUserInteractionsResultError {

--- a/packages/sdk-bundles-api/src/replay/bundle-to-sdk/index.ts
+++ b/packages/sdk-bundles-api/src/replay/bundle-to-sdk/index.ts
@@ -1,7 +1,8 @@
 /** Result of replaying user interactions */
 export type ReplayUserInteractionsResult =
   | ReplayUserInteractionsResultFull
-  | ReplayUserInteractionsResultShort;
+  | ReplayUserInteractionsResultShort
+  | ReplayUserInteractionsResultError;
 
 /** Returned when the recorded session has been fully replayed */
 export interface ReplayUserInteractionsResultFull {
@@ -12,4 +13,14 @@ export interface ReplayUserInteractionsResultFull {
 export interface ReplayUserInteractionsResultShort {
   length: "short";
   reason: "max events" | "max duration";
+}
+
+/**
+ * Returned when a fatal error was thrown during replay, that cut the replay short
+ * (for example the page was navigated while trying to evaluate javascript).
+ */
+export interface ReplayUserInteractionsResultError {
+  length: "short";
+  reason: "error";
+  error: unknown;
 }

--- a/packages/sdk-bundles-api/src/replay/bundle-to-sdk/index.ts
+++ b/packages/sdk-bundles-api/src/replay/bundle-to-sdk/index.ts
@@ -1,8 +1,7 @@
 /** Result of replaying user interactions */
 export type ReplayUserInteractionsResult =
   | ReplayUserInteractionsResultFull
-  | ReplayUserInteractionsResultShort
-  | ReplayUserInteractionsResultError;
+  | ReplayUserInteractionsResultShort;
 
 /** Returned when the recorded session has been fully replayed */
 export interface ReplayUserInteractionsResultFull {
@@ -13,14 +12,4 @@ export interface ReplayUserInteractionsResultFull {
 export interface ReplayUserInteractionsResultShort {
   length: "short";
   reason: "max events" | "max duration";
-}
-
-/**
- * Returned when a fatal error was thrown during replay that cut the replay short
- * (for example the page was navigated while trying to evaluate javascript).
- */
-export interface ReplayUserInteractionsResultError {
-  length: "short";
-  reason: "error";
-  error: unknown;
 }

--- a/packages/sdk-bundles-api/src/replay/bundle-to-sdk/timeline.types.ts
+++ b/packages/sdk-bundles-api/src/replay/bundle-to-sdk/timeline.types.ts
@@ -29,6 +29,17 @@ export interface ErrorTimelineEntry extends GenericReplayTimelineEntry {
   };
 }
 
+/**
+ * An error that cut the replay short.
+ */
+export interface FatalErrorTimelineEntry extends GenericReplayTimelineEntry {
+  kind: "fatalError";
+  data: {
+    message: string | null;
+    stack: string | null;
+  };
+}
+
 export interface UrlChangeTimelineEntry extends GenericReplayTimelineEntry {
   kind: "urlChange";
   data: {
@@ -74,6 +85,7 @@ export interface JsReplaySimulateEvent {
 
 export type ReplayTimelineEntry =
   | ErrorTimelineEntry
+  | FatalErrorTimelineEntry
   | UrlChangeTimelineEntry
   | PollyTimelineEntry
   | JsReplayTimelineEntry;


### PR DESCRIPTION
This should make debugging easier, because it means that if an error is thrown it still writes and updates the output. Presumably the end state screenshot will still differ, so we'll still get a failed comparison. If it's a passive session, and the storyboard screenshots are all there and all identical then it may not be important to the user that the replay failed after the last storyboard screenshot (depending on why it failed), though I expect at some point we will want to surface this.