### PR TITLE
Add baseCommitSha argument

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -52,13 +52,11 @@ const validateConfig: (config: MeticulousCliConfig) => MeticulousCliConfig = (
     .map(({ title, sessionId, baseReplayId, options }) => ({
       title: typeof title === "string" ? title : "",
       sessionId: typeof sessionId === "string" ? sessionId : "",
-      baseReplayId: typeof baseReplayId === "string" ? baseReplayId : "",
+      ...(typeof baseReplayId === "string" ? { baseReplayId } : {}),
       ...(options ? { options: validateReplayOptions(options) } : {}),
     }))
-    .map(({ title, sessionId, baseReplayId, ...rest }) => ({
-      title: title || `${sessionId} | ${baseReplayId}`,
-      sessionId,
-      baseReplayId,
+    .map(({ title, ...rest }) => ({
+      title: title || `${rest.sessionId} | ${rest.baseReplayId}`,
       ...rest,
     }))
     .filter(({ sessionId, baseReplayId }) => sessionId && baseReplayId);

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -59,7 +59,7 @@ const validateConfig: (config: MeticulousCliConfig) => MeticulousCliConfig = (
       title: title || `${rest.sessionId} | ${rest.baseReplayId}`,
       ...rest,
     }))
-    .filter(({ sessionId, baseReplayId }) => sessionId && baseReplayId);
+    .filter(({ sessionId }) => sessionId);
 
   return { ...rest, testCases: nextTestCases };
 };

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -16,7 +16,7 @@ export interface TestCaseReplayOptions extends Partial<ScreenshotDiffOptions> {
 export interface TestCase {
   title: string;
   sessionId: string;
-  baseReplayId: string;
+  baseReplayId?: string;
   options?: TestCaseReplayOptions;
 }
 

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -29,6 +29,12 @@ export interface RunAllTestsInParallelOptions {
   screenshottingOptions: ScreenshotAssertionsEnabledOptions;
   apiToken: string | null;
   commitSha: string;
+
+  /**
+   * The base commit to compare test results against for test cases that don't have a baseReplayId specified.
+   */
+  baseCommitSha: string | null;
+
   appUrl: string | null;
   useAssetsSnapshottedInBaseSimulation: boolean;
   parallelTasks: number | null;
@@ -46,6 +52,7 @@ export const runAllTestsInParallel: (
   testRun,
   apiToken,
   commitSha,
+  baseCommitSha,
   appUrl,
   useAssetsSnapshottedInBaseSimulation,
   executionOptions,
@@ -58,9 +65,11 @@ export const runAllTestsInParallel: (
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const results: TestCaseResult[] = [...cachedTestRunResults];
-  const queue = getTestsToRun({
+  const queue = await getTestsToRun({
+    client,
     testCases: config.testCases || [],
     cachedTestRunResults,
+    baseCommitSha,
   });
 
   const allTasksDone = defer<void>();

--- a/packages/cli/src/utils/config.utils.ts
+++ b/packages/cli/src/utils/config.utils.ts
@@ -29,6 +29,11 @@ export const getReplayTargetForTestCase = ({
     };
   }
   if (useAssetsSnapshottedInBaseSimulation) {
+    if (testCase.baseReplayId == null) {
+      throw new Error(
+        `--useAssetsSnapshottedInBaseSimulation flag set, but test case "${testCase.title}" does not have a baseReplayId.`
+      );
+    }
     return {
       type: "snapshotted-assets",
       simulationIdForAssets: testCase.baseReplayId,

--- a/packages/cli/src/utils/run-all-tests.utils.ts
+++ b/packages/cli/src/utils/run-all-tests.utils.ts
@@ -61,11 +61,7 @@ export const getTestsToRun = async ({
     (testCase) => testCase.baseReplayId == null
   );
   const testCasesWithBaseReplayId = uncachedTestCases.flatMap(
-    (testCase): TestCase[] =>
-      // Note: explictly setting the baseReplayId is required for typescript to be happy with types
-      testCase.baseReplayId == null
-        ? []
-        : [{ ...testCase, baseReplayId: testCase.baseReplayId }]
+    (testCase): TestCase[] => (testCase.baseReplayId == null ? [] : [testCase])
   );
 
   if (testCasesMissingBaseReplayId.length === 0) {
@@ -89,8 +85,7 @@ export const getTestsToRun = async ({
 
   return uncachedTestCases.flatMap((test) => {
     if (test.baseReplayId != null) {
-      // Note: explictly setting the baseReplayId is required for typescript to be happy with types
-      return [{ ...test, baseReplayId: test.baseReplayId }];
+      return [test];
     }
     const baseReplayId = baseReplayIdBySessionId[test.sessionId];
     if (baseReplayId == null) {
@@ -98,7 +93,7 @@ export const getTestsToRun = async ({
       logger.warn(
         `Skipping comparisons for test "${test.title}" since no result to compare against stored for base commit ${baseCommitSha}`
       );
-      return test;
+      return [test];
     }
     return [{ ...test, baseReplayId }];
   });

--- a/packages/cli/src/utils/run-all-tests.utils.ts
+++ b/packages/cli/src/utils/run-all-tests.utils.ts
@@ -115,16 +115,6 @@ const getBaseReplayIdsBySessionId = async ({
     client,
     commitSha: baseCommitSha,
   });
-
-  if (baseTestRun?.status === "Running") {
-    // Note: for now we just ignore results that haven't completed yet, but in future we may want to block
-    // on the test run completely (poll until it's complete, or timed out).
-    const logger = log.getLogger(METICULOUS_LOGGER_NAME);
-    logger.warn(
-      `Test run (${baseTestRun.id}) on base commit (${baseCommitSha}) is still running. This means some comparisons may be skipped.`
-    );
-  }
-
   const baseReplays = baseTestRun?.resultData?.results ?? [];
   const baseReplayIdBySessionId: Record<string, string> = {};
   // If there are multiple replays for a given session we take the last in the list

--- a/packages/cli/src/utils/run-all-tests.utils.ts
+++ b/packages/cli/src/utils/run-all-tests.utils.ts
@@ -1,3 +1,7 @@
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { AxiosInstance } from "axios";
+import log from "loglevel";
+import { getCachedTestRunResults } from "../api/test-run.api";
 import { TestCase, TestCaseResult } from "../config/config.types";
 
 export const sortResults: (options: {
@@ -26,11 +30,24 @@ export const sortResults: (options: {
   return results;
 };
 
-export const getTestsToRun: (options: {
+export interface GetTestsToRunOptions {
+  client: AxiosInstance;
   testCases: TestCase[];
   cachedTestRunResults: TestCaseResult[];
-}) => TestCase[] = ({ testCases, cachedTestRunResults }) =>
-  testCases.filter(
+
+  /**
+   * The base commit to compare test results against for test cases that don't have a baseReplayId specified.
+   */
+  baseCommitSha: string | null;
+}
+
+export const getTestsToRun = async ({
+  testCases,
+  cachedTestRunResults,
+  client,
+  baseCommitSha,
+}: GetTestsToRunOptions): Promise<TestCase[]> => {
+  const uncachedTestCases = testCases.filter(
     ({ sessionId, baseReplayId, title }) =>
       !cachedTestRunResults.find(
         (cached) =>
@@ -39,3 +56,69 @@ export const getTestsToRun: (options: {
           cached.title === title
       )
   );
+
+  const testCasesMissingBaseReplayId = uncachedTestCases.filter(
+    (testCase) => testCase.baseReplayId == null
+  );
+  const testCasesWithBaseReplayId = uncachedTestCases.flatMap(
+    (testCase): TestCase[] =>
+      // Note: explictly setting the baseReplayId is required for typescript to be happy with types
+      testCase.baseReplayId == null
+        ? []
+        : [{ ...testCase, baseReplayId: testCase.baseReplayId }]
+  );
+
+  if (testCasesMissingBaseReplayId.length === 0) {
+    return testCasesWithBaseReplayId;
+  }
+
+  if (baseCommitSha == null) {
+    const namesOfInvalidTests = testCasesMissingBaseReplayId
+      .map((test) => `"${test.title}"`)
+      .join(", ");
+    throw new Error(
+      `The following test cases are missing a baseReplayId: ${namesOfInvalidTests}.` +
+        " Please either run with the --baseCommitSha option, or add a baseReplayId to all test cases."
+    );
+  }
+
+  const baseReplayIdBySessionId = await getBaseReplayIdsBySessionId({
+    client,
+    baseCommitSha,
+  });
+
+  return uncachedTestCases.flatMap((test) => {
+    if (test.baseReplayId != null) {
+      // Note: explictly setting the baseReplayId is required for typescript to be happy with types
+      return [{ ...test, baseReplayId: test.baseReplayId }];
+    }
+    const baseReplayId = baseReplayIdBySessionId[test.sessionId];
+    if (baseReplayId == null) {
+      const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+      logger.warn(
+        `Skipping comparisons for test "${test.title}" since no result to compare against stored for base commit ${baseCommitSha}`
+      );
+      return test;
+    }
+    return [{ ...test, baseReplayId }];
+  });
+};
+
+const getBaseReplayIdsBySessionId = async ({
+  client,
+  baseCommitSha,
+}: {
+  client: AxiosInstance;
+  baseCommitSha: string;
+}): Promise<Record<string, string>> => {
+  const baseReplays = await getCachedTestRunResults({
+    client,
+    commitSha: baseCommitSha,
+  });
+  const baseReplayIdBySessionId: Record<string, string> = {};
+  // If there are multiple replays for a given session we take the last in the list
+  baseReplays.forEach((replay) => {
+    baseReplayIdBySessionId[replay.sessionId] = replay.headReplayId;
+  });
+  return baseReplayIdBySessionId;
+};


### PR DESCRIPTION
This should enable a workflow where the baseReplayIds are not checked into your meticulous.json file. So if the diffs are intended you can just merge the PR, without having to update your meticulous.json file. The intent is that this will be used as the recommended method for both active and passive tests. The --baseCommitSha will be automatically passed in by a github action that wraps the Meticulous CLI.