### PR TITLE
Save bundle files with the .cjs extension

### DIFF
--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -82,7 +82,10 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const entry = assetMetadata.assets.find(
     (item) => item.fileName === assetFileName
   );
-  const filePath = join(await getOrCreateAssetsDir(), assetFileName);
+  const filePath = join(
+    await getOrCreateAssetsDir(),
+    `${basename(assetFileName, ".js")}.cjs`
+  );
 
   if (entry && etag !== "" && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);

--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -74,7 +74,7 @@ export const loadReplayEventsDependencies =
 export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   const fetchUrl = new URL(path, getSnippetsBaseUrl()).href;
-  const assetFileName = basename(new URL(fetchUrl).pathname);
+  const assetFileName = `${basename(new URL(fetchUrl).pathname, ".js")}.cjs`;
 
   const assetMetadata = await loadAssetMetadata();
   const etag = (await axios.head(fetchUrl)).headers["etag"] || "";
@@ -82,10 +82,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const entry = assetMetadata.assets.find(
     (item) => item.fileName === assetFileName
   );
-  const filePath = join(
-    await getOrCreateAssetsDir(),
-    `${basename(assetFileName, ".js")}.cjs`
-  );
+  const filePath = join(await getOrCreateAssetsDir(), basename(assetFileName));
 
   if (entry && etag !== "" && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);

--- a/packages/cli/src/local-data/replay-assets.ts
+++ b/packages/cli/src/local-data/replay-assets.ts
@@ -82,7 +82,7 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
   const entry = assetMetadata.assets.find(
     (item) => item.fileName === assetFileName
   );
-  const filePath = join(await getOrCreateAssetsDir(), basename(assetFileName));
+  const filePath = join(await getOrCreateAssetsDir(), assetFileName);
 
   if (entry && etag !== "" && etag === entry.etag) {
     logger.debug(`${fetchUrl} already present`);


### PR DESCRIPTION
This makes sure the bundle files are interpreted as CommonJS and not ESM.

See error:
```
Error [ERR_REQUIRE_ESM***: require() of ES Module /app/assets/node-network-stubbing.bundle.js from /app/node_modules/@alwaysmeticulous/replayer/dist/replayer.js not supported.
node-network-stubbing.bundle.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename node-network-stubbing.bundle.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /app/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```