### PR TITLE
Return screenshot diff results from run-all-tests

### DIFF
--- a/packages/cli/src/api/test-run.api.ts
+++ b/packages/cli/src/api/test-run.api.ts
@@ -78,7 +78,7 @@ export interface GetLatestTestRunResultsOptions {
 export const getCachedTestRunResults = async ({
   client,
   commitSha,
-}: GetLatestTestRunResultsOptions): Promise<DetailedTestCaseResult[]> => {
+}: GetLatestTestRunResultsOptions): Promise<TestCaseResult[]> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   if (!commitSha || commitSha === "unknown") {
@@ -91,12 +91,7 @@ export const getCachedTestRunResults = async ({
       ?.results ?? [];
 
   // Only return passing tests
-  return (
-    results
-      .filter(({ result }) => result === "pass")
-      // If it passed it can't have any screenshot diffs:
-      .map((result) => ({ ...result, screenshotDiffResults: [] }))
-  );
+  return results.filter(({ result }) => result === "pass");
 };
 
 export const getLatestTestRunResults = async ({

--- a/packages/cli/src/api/test-run.api.ts
+++ b/packages/cli/src/api/test-run.api.ts
@@ -1,6 +1,5 @@
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import axios, { AxiosError, AxiosInstance } from "axios";
-import { restoreDefaultPrompts } from "inquirer";
 import log from "loglevel";
 import { DetailedTestCaseResult, TestCaseResult } from "../config/config.types";
 

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -221,7 +221,7 @@ export const replayCommandHandler = async ({
     // 12. Diff against base replay screenshot if one is provided
     const { screenshotDiffResults, screenshotDiffError } =
       screenshottingOptions.enabled && baseReplayId_
-        ? await computeAndSafeDiff({
+        ? await computeAndSaveDiff({
             client,
             baseReplayId: baseReplayId_ ?? "",
             headReplayId: replay.id,
@@ -261,7 +261,7 @@ interface ComputeAndSaveDiffOptions {
   screenshottingOptions: ScreenshotAssertionsEnabledOptions;
 }
 
-const computeAndSafeDiff = async ({
+const computeAndSaveDiff = async ({
   client,
   baseReplayId,
   tempDir,

--- a/packages/cli/src/commands/replay/utils/compute-and-save-diff.ts
+++ b/packages/cli/src/commands/replay/utils/compute-and-save-diff.ts
@@ -1,0 +1,83 @@
+import {
+  ScreenshotAssertionsEnabledOptions,
+  ScreenshotDiffResult,
+} from "@alwaysmeticulous/api";
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { AxiosInstance } from "axios";
+import log from "loglevel";
+import { createReplayDiff } from "../../../api/replay-diff.api";
+import {
+  getOrFetchReplay,
+  getOrFetchReplayArchive,
+  getReplayDir,
+  getScreenshotsDir,
+} from "../../../local-data/replays";
+import {
+  checkScreenshotDiffResult,
+  diffScreenshots,
+  ScreenshotDiffError,
+} from "../../screenshot-diff/screenshot-diff.command";
+
+export interface ComputeAndSaveDiffOptions {
+  client: AxiosInstance;
+  testRunId: string | null;
+  baseReplayId: string;
+  headReplayId: string;
+  tempDir: string;
+  screenshottingOptions: ScreenshotAssertionsEnabledOptions;
+}
+
+export const computeAndSaveDiff = async ({
+  client,
+  baseReplayId,
+  tempDir,
+  headReplayId,
+  screenshottingOptions,
+  testRunId,
+}: ComputeAndSaveDiffOptions): Promise<{
+  screenshotDiffResults: ScreenshotDiffResult[];
+  screenshotDiffError: ScreenshotDiffError | null;
+}> => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  logger.info(`Diffing screenshots against replay ${baseReplayId}`);
+
+  await getOrFetchReplay(client, baseReplayId);
+  await getOrFetchReplayArchive(client, baseReplayId);
+
+  const baseReplayScreenshotsDir = getScreenshotsDir(
+    getReplayDir(baseReplayId)
+  );
+  const headReplayScreenshotsDir = getScreenshotsDir(tempDir);
+
+  const screenshotDiffResults = await diffScreenshots({
+    client,
+    baseReplayId,
+    headReplayId,
+    baseScreenshotsDir: baseReplayScreenshotsDir,
+    headScreenshotsDir: headReplayScreenshotsDir,
+    diffOptions: screenshottingOptions.diffOptions,
+  });
+
+  const replayDiff = await createReplayDiff({
+    client,
+    headReplayId,
+    baseReplayId,
+    testRunId,
+    data: {
+      screenshotAssertionsOptions: screenshottingOptions,
+      screenshotDiffResults,
+    },
+  });
+
+  logger.debug(replayDiff);
+
+  const screenshotDiffError = checkScreenshotDiffResult({
+    baseReplayId,
+    headReplayId,
+    results: screenshotDiffResults,
+    diffOptions: screenshottingOptions.diffOptions,
+  });
+
+  return { screenshotDiffResults, screenshotDiffError };
+};

--- a/packages/cli/src/commands/replay/utils/compute-and-save-diff.ts
+++ b/packages/cli/src/commands/replay/utils/compute-and-save-diff.ts
@@ -13,9 +13,9 @@ import {
   getScreenshotsDir,
 } from "../../../local-data/replays";
 import {
-  checkScreenshotDiffResult,
+  summarizeDifferences,
   diffScreenshots,
-  ScreenshotDiffError,
+  ScreenshotDiffsSummary,
 } from "../../screenshot-diff/screenshot-diff.command";
 
 export interface ComputeAndSaveDiffOptions {
@@ -36,7 +36,7 @@ export const computeAndSaveDiff = async ({
   testRunId,
 }: ComputeAndSaveDiffOptions): Promise<{
   screenshotDiffResults: ScreenshotDiffResult[];
-  screenshotDiffError: ScreenshotDiffError | null;
+  screenshotDiffsSummary: ScreenshotDiffsSummary;
 }> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -72,12 +72,12 @@ export const computeAndSaveDiff = async ({
 
   logger.debug(replayDiff);
 
-  const screenshotDiffError = checkScreenshotDiffResult({
+  const screenshotDiffsSummary = summarizeDifferences({
     baseReplayId,
     headReplayId,
     results: screenshotDiffResults,
     diffOptions: screenshottingOptions.diffOptions,
   });
 
-  return { screenshotDiffResults, screenshotDiffError };
+  return { screenshotDiffResults, screenshotDiffsSummary };
 };

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -2,6 +2,8 @@ import {
   ReplayExecutionOptions,
   StoryboardOptions,
 } from "@alwaysmeticulous/common";
+import { createClient } from "../../api/client";
+import { getCachedTestRunResults } from "../../api/test-run.api";
 import { buildCommand } from "../../command-utils/command-builder";
 import {
   COMMON_REPLAY_OPTIONS,
@@ -13,6 +15,7 @@ import {
   ScreenshotDiffOptions,
 } from "../../command-utils/common-types";
 import { runAllTests } from "../../parallel-tests/run-all-tests";
+import { getCommitSha } from "../../utils/commit-sha.utils";
 
 interface Options
   extends ScreenshotDiffOptions,
@@ -35,7 +38,7 @@ interface Options
 
 const handler: (options: Options) => Promise<void> = async ({
   apiToken,
-  commitSha,
+  commitSha: commitSha_,
   baseCommitSha,
   appUrl,
   useAssetsSnapshottedInBaseSimulation,
@@ -86,7 +89,12 @@ const handler: (options: Options) => Promise<void> = async ({
   };
 
   const parrelelTasks = parallelize ? parrelelTasks_ : 1;
-  const result = await runAllTests({
+  const commitSha = (await getCommitSha(commitSha_)) || "unknown";
+  const client = createClient({ apiToken });
+  const cachedTestRunResults = useCache
+    ? await getCachedTestRunResults({ client, commitSha })
+    : [];
+  const { testRun } = await runAllTests({
     testsFile: testsFile ?? null,
     executionOptions,
     screenshottingOptions,
@@ -97,11 +105,11 @@ const handler: (options: Options) => Promise<void> = async ({
     useAssetsSnapshottedInBaseSimulation,
     parallelTasks: parrelelTasks ?? null,
     deflake,
-    useCache,
+    cachedTestRunResults,
     githubSummary,
   });
 
-  if (result.testRun.status === "Failure") {
+  if (testRun.status === "Failure") {
     process.exit(1);
   }
 };

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -99,7 +99,7 @@ const handler: (options: Options) => Promise<void> = async ({
     executionOptions,
     screenshottingOptions,
     apiToken: apiToken ?? null,
-    commitSha: commitSha ?? null,
+    commitSha,
     baseCommitSha: baseCommitSha ?? null,
     appUrl: appUrl ?? null,
     useAssetsSnapshottedInBaseSimulation,

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -158,7 +158,7 @@ export const checkScreenshotDiffResult = ({
   headReplayId: string;
   results: ScreenshotDiffResult[];
   diffOptions: ScreenshotDiffOptions;
-}): void => {
+}): ScreenshotDiffError | null => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const missingHeadImagesResults = results.flatMap((result) =>
@@ -169,7 +169,7 @@ export const checkScreenshotDiffResult = ({
       .map(({ baseScreenshotFile }) => basename(baseScreenshotFile))
       .sort()} => FAIL!`;
     logger.info(message);
-    throw new ScreenshotDiffError(message, {
+    return new ScreenshotDiffError(message, {
       baseReplayId,
       headReplayId,
     });
@@ -193,7 +193,7 @@ export const checkScreenshotDiffResult = ({
         result.headScreenshotFile
       )} have different sizes => FAIL!`;
       logger.info(message);
-      throw new ScreenshotDiffError(message, {
+      return new ScreenshotDiffError(message, {
         baseReplayId,
         headReplayId,
       });
@@ -209,13 +209,15 @@ export const checkScreenshotDiffResult = ({
       }`;
       logger.info(message);
       if (outcome === "diff") {
-        throw new ScreenshotDiffError(message, {
+        return new ScreenshotDiffError(message, {
           baseReplayId,
           headReplayId,
         });
       }
     }
   });
+
+  return null;
 };
 
 export class ScreenshotDiffError extends Error {

--- a/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
+++ b/packages/cli/src/commands/screenshot-diff/screenshot-diff.command.ts
@@ -148,7 +148,7 @@ export const diffScreenshots = async ({
   return [...missingHeadImagesResults, ...headDiffResults];
 };
 
-export const checkScreenshotDiffResult = ({
+export const summarizeDifferences = ({
   baseReplayId,
   headReplayId,
   results,
@@ -158,7 +158,7 @@ export const checkScreenshotDiffResult = ({
   headReplayId: string;
   results: ScreenshotDiffResult[];
   diffOptions: ScreenshotDiffOptions;
-}): ScreenshotDiffError | null => {
+}): ScreenshotDiffsSummary => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const missingHeadImagesResults = results.flatMap((result) =>
@@ -169,10 +169,12 @@ export const checkScreenshotDiffResult = ({
       .map(({ baseScreenshotFile }) => basename(baseScreenshotFile))
       .sort()} => FAIL!`;
     logger.info(message);
-    return new ScreenshotDiffError(message, {
+    return {
+      hasDiffs: true,
+      summaryMessage: message,
       baseReplayId,
       headReplayId,
-    });
+    };
   }
 
   const missingBaseImagesResults = results.flatMap((result) =>
@@ -193,10 +195,12 @@ export const checkScreenshotDiffResult = ({
         result.headScreenshotFile
       )} have different sizes => FAIL!`;
       logger.info(message);
-      return new ScreenshotDiffError(message, {
+      return {
+        hasDiffs: true,
+        summaryMessage: message,
         baseReplayId,
         headReplayId,
-      });
+      };
     }
 
     if (outcome === "diff" || outcome === "no-diff") {
@@ -209,27 +213,32 @@ export const checkScreenshotDiffResult = ({
       }`;
       logger.info(message);
       if (outcome === "diff") {
-        return new ScreenshotDiffError(message, {
+        return {
+          hasDiffs: true,
+          summaryMessage: message,
           baseReplayId,
           headReplayId,
-        });
+        };
       }
     }
   });
 
-  return null;
+  return { hasDiffs: false };
 };
 
-export class ScreenshotDiffError extends Error {
-  constructor(
-    message: string,
-    readonly extras?: {
-      baseReplayId: string;
-      headReplayId: string;
-    }
-  ) {
-    super(message);
-  }
+export type ScreenshotDiffsSummary =
+  | HasDiffsScreenshotDiffsResult
+  | NoDiffsScreenshotDiffsResult;
+
+export interface HasDiffsScreenshotDiffsResult {
+  hasDiffs: true;
+  summaryMessage: string;
+  baseReplayId: string;
+  headReplayId: string;
+}
+
+export interface NoDiffsScreenshotDiffsResult {
+  hasDiffs: false;
 }
 
 const getScreenshotIdentifier = (
@@ -301,12 +310,16 @@ const handler: (options: Options) => Promise<void> = async ({
 
   logger.debug(results);
 
-  checkScreenshotDiffResult({
+  const diffSummary = summarizeDifferences({
     baseReplayId,
     headReplayId,
     results,
     diffOptions,
   });
+
+  if (diffSummary.hasDiffs) {
+    process.exit(1);
+  }
 };
 
 export const screenshotDiffCommand = buildCommand("screenshot-diff")

--- a/packages/cli/src/config/config.types.ts
+++ b/packages/cli/src/config/config.types.ts
@@ -1,3 +1,4 @@
+import { ScreenshotDiffResult } from "@alwaysmeticulous/api";
 import { ScreenshotDiffOptions } from "../command-utils/common-types";
 
 export interface TestCaseReplayOptions extends Partial<ScreenshotDiffOptions> {
@@ -27,4 +28,8 @@ export interface MeticulousCliConfig {
 export interface TestCaseResult extends TestCase {
   headReplayId: string;
   result: "pass" | "fail";
+}
+
+export interface DetailedTestCaseResult extends TestCaseResult {
+  screenshotDiffResults: ScreenshotDiffResult[];
 }

--- a/packages/cli/src/deflake-tests/deflake-tests.handler.ts
+++ b/packages/cli/src/deflake-tests/deflake-tests.handler.ts
@@ -28,7 +28,7 @@ const handleReplay = async ({
   testRunId,
   replayEventsDependencies,
 }: HandleReplayOptions): Promise<DetailedTestCaseResult> => {
-  const { replay, screenshotDiffResults, screenshotDiffError } =
+  const { replay, screenshotDiffResults, screenshotDiffsSummary } =
     await replayCommandHandler({
       replayTarget,
       executionOptions: applyTestCaseExecutionOptionOverrides(
@@ -59,7 +59,7 @@ const handleReplay = async ({
   return {
     ...testCase,
     headReplayId: replay.id,
-    result: screenshotDiffError == null ? "pass" : "fail",
+    result: screenshotDiffsSummary.hasDiffs ? "pass" : "fail",
     screenshotDiffResults,
   };
 };

--- a/packages/cli/src/parallel-tests/messages.types.ts
+++ b/packages/cli/src/parallel-tests/messages.types.ts
@@ -1,5 +1,5 @@
 import log from "loglevel";
-import { TestCaseResult } from "../config/config.types";
+import { DetailedTestCaseResult } from "../config/config.types";
 import { DeflakeReplayCommandHandlerOptions } from "../deflake-tests/deflake-tests.handler";
 
 export interface InitMessage {
@@ -14,6 +14,6 @@ export interface InitMessage {
 export interface ResultMessage {
   kind: "result";
   data: {
-    result: TestCaseResult;
+    result: DetailedTestCaseResult;
   };
 }

--- a/packages/cli/src/parallel-tests/parallel-tests.handler.ts
+++ b/packages/cli/src/parallel-tests/parallel-tests.handler.ts
@@ -8,42 +8,37 @@ import {
   ReplayEventsDependencies,
   ReplayExecutionOptions,
 } from "@alwaysmeticulous/common";
-import { AxiosInstance } from "axios";
 import log from "loglevel";
-import { putTestRunResults, TestRun } from "../api/test-run.api";
+import { TestRun } from "../api/test-run.api";
 import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-types";
 import {
   DetailedTestCaseResult,
   MeticulousCliConfig,
   TestCase,
-  TestCaseResult,
 } from "../config/config.types";
 import { getReplayTargetForTestCase } from "../utils/config.utils";
-import { getTestsToRun, sortResults } from "../utils/run-all-tests.utils";
+import { sortResults } from "../utils/run-all-tests.utils";
 import { InitMessage, ResultMessage } from "./messages.types";
 import { TestRunProgress } from "./run-all-tests.types";
 export interface RunAllTestsInParallelOptions {
   config: MeticulousCliConfig;
-  client: AxiosInstance;
   testRun: TestRun;
+  testsToRun: TestCase[];
   executionOptions: ReplayExecutionOptions;
   screenshottingOptions: ScreenshotAssertionsEnabledOptions;
   apiToken: string | null;
   commitSha: string;
 
-  /**
-   * The base commit to compare test results against for test cases that don't have a baseReplayId specified.
-   */
-  baseCommitSha: string | null;
-
   appUrl: string | null;
   useAssetsSnapshottedInBaseSimulation: boolean;
   parallelTasks: number | null;
   deflake: boolean;
-  cachedTestRunResults: DetailedTestCaseResult[];
   replayEventsDependencies: ReplayEventsDependencies;
 
-  onTestFinished?: (progress: TestRunProgress) => void;
+  onTestFinished?: (
+    progress: TestRunProgress,
+    resultsSoFar: DetailedTestCaseResult[]
+  ) => Promise<void>;
 }
 
 /** Handler for running Meticulous tests in parallel using child processes */
@@ -51,30 +46,22 @@ export const runAllTestsInParallel: (
   options: RunAllTestsInParallelOptions
 ) => Promise<DetailedTestCaseResult[]> = async ({
   config,
-  client,
   testRun,
+  testsToRun: queue,
   apiToken,
   commitSha,
-  baseCommitSha,
   appUrl,
   useAssetsSnapshottedInBaseSimulation,
   executionOptions,
   screenshottingOptions,
   parallelTasks,
   deflake,
-  cachedTestRunResults,
   replayEventsDependencies,
   onTestFinished,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const results: DetailedTestCaseResult[] = [...cachedTestRunResults];
-  const queue = await getTestsToRun({
-    client,
-    testCases: config.testCases || [],
-    cachedTestRunResults,
-    baseCommitSha,
-  });
+  const results: DetailedTestCaseResult[] = [];
   const progress: TestRunProgress = {
     runningTestCases: queue.length,
     failedTestCases: 0,
@@ -167,21 +154,11 @@ export const runAllTestsInParallel: (
         progress.failedTestCases += result.result === "fail" ? 1 : 0;
         progress.passedTestCases += result.result === "pass" ? 1 : 0;
         --progress.runningTestCases;
-        onTestFinished?.(progress);
-        putTestRunResults({
-          client,
-          testRunId: testRun.id,
-          status: "Running",
-          resultData: { results },
-        })
-          .catch((error) => {
-            logger.error(`Error while pushing partial results: ${error}`);
-          })
-          .then(() => {
-            if (results.length === (config.testCases?.length || 0)) {
-              allTasksDone.resolve();
-            }
-          });
+        onTestFinished?.(progress, results).then(() => {
+          if (results.length === (config.testCases?.length || 0)) {
+            allTasksDone.resolve();
+          }
+        });
 
         process.nextTick(checkNextTask);
       });

--- a/packages/cli/src/parallel-tests/run-all-tests.ts
+++ b/packages/cli/src/parallel-tests/run-all-tests.ts
@@ -212,7 +212,7 @@ export const runAllTests = async ({
 
     const results: DetailedTestCaseResult[] = [];
     const progress: TestRunProgress = {
-      runningTestCases: testRun.length,
+      runningTestCases: testsToRun.length,
       failedTestCases: 0,
       passedTestCases: 0,
     };

--- a/packages/cli/src/parallel-tests/run-all-tests.ts
+++ b/packages/cli/src/parallel-tests/run-all-tests.ts
@@ -6,18 +6,16 @@ import log from "loglevel";
 import { createClient } from "../api/client";
 import {
   createTestRun,
-  getCachedTestRunResults,
   getTestRunUrl,
   putTestRunResults,
   TestRunStatus,
 } from "../api/test-run.api";
 import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-types";
 import { readConfig } from "../config/config";
-import { DetailedTestCaseResult } from "../config/config.types";
+import { DetailedTestCaseResult, TestCaseResult } from "../config/config.types";
 import { deflakeReplayCommandHandler } from "../deflake-tests/deflake-tests.handler";
 import { loadReplayEventsDependencies } from "../local-data/replay-assets";
 import { runAllTestsInParallel } from "../parallel-tests/parallel-tests.handler";
-import { getCommitSha } from "../utils/commit-sha.utils";
 import { getReplayTargetForTestCase } from "../utils/config.utils";
 import { writeGitHubSummary } from "../utils/github-summary.utils";
 import { getTestsToRun, sortResults } from "../utils/run-all-tests.utils";
@@ -29,7 +27,7 @@ export interface Options {
   executionOptions: ReplayExecutionOptions;
   screenshottingOptions: ScreenshotAssertionsEnabledOptions;
   apiToken: string | null;
-  commitSha: string | null;
+  commitSha: string;
 
   /**
    * The base commit to compare test results against for test cases that don't have a baseReplayId specified.
@@ -46,10 +44,15 @@ export interface Options {
    */
   parallelTasks: number | null;
   deflake: boolean;
-  useCache: boolean;
 
   githubSummary: boolean;
 
+  /**
+   * If provided it will incorportate the cachedTestRunResults in any calls to store
+   * test run results in the BE, but won't include the cachedTestRunResults in the returned
+   * RunAllTestsResult.
+   */
+  cachedTestRunResults?: TestCaseResult[];
   onTestRunCreated?: (testRun: TestRun & { status: "Running" }) => void;
   onTestFinished?: (testRun: TestRun & { status: "Running" }) => void;
 }
@@ -65,10 +68,14 @@ export interface TestRun {
   progress: TestRunProgress;
 }
 
+/**
+ * Runs all the test cases in the provided file.
+ * @returns The results of the tests that were executed (note that this does not include results from any cachedTestRunResults passed in)
+ */
 export const runAllTests = async ({
   testsFile,
   apiToken,
-  commitSha: commitSha_,
+  commitSha,
   baseCommitSha,
   appUrl,
   useAssetsSnapshottedInBaseSimulation,
@@ -76,10 +83,10 @@ export const runAllTests = async ({
   screenshottingOptions,
   parallelTasks,
   deflake,
-  useCache,
+  cachedTestRunResults: cachedTestRunResults_,
   githubSummary,
   onTestRunCreated,
-  onTestFinished,
+  onTestFinished: onTestFinished_,
 }: Options): Promise<RunAllTestsResult> => {
   if (appUrl != null && useAssetsSnapshottedInBaseSimulation) {
     throw new Error(
@@ -90,20 +97,27 @@ export const runAllTests = async ({
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const client = createClient({ apiToken });
+  const cachedTestRunResults = cachedTestRunResults_ ?? [];
 
   const config = await readConfig(testsFile || undefined);
-  const testCases = config.testCases || [];
+  const allTestCases = config.testCases || [];
 
-  if (!testCases.length) {
+  if (!allTestCases.length) {
     throw new Error("Error! No test case defined");
   }
 
-  const commitSha = (await getCommitSha(commitSha_)) || "unknown";
-  const meticulousSha = await getMeticulousVersion();
+  // Only run the uncached test cases
+  const testCases = allTestCases.filter(
+    ({ sessionId, baseReplayId, title }) =>
+      !cachedTestRunResults.find(
+        (cached) =>
+          cached.sessionId === sessionId &&
+          cached.baseReplayId === baseReplayId &&
+          cached.title === title
+      )
+  );
 
-  const cachedTestRunResults = useCache
-    ? await getCachedTestRunResults({ client, commitSha })
-    : [];
+  const meticulousSha = await getMeticulousVersion();
 
   const replayEventsDependencies = await loadReplayEventsDependencies();
 
@@ -121,7 +135,7 @@ export const runAllTests = async ({
     status: "Running",
     progress: {
       failedTestCases: 0,
-      passedTestCases: 0,
+      passedTestCases: cachedTestRunResults.length,
       runningTestCases: testCases.length,
     },
   });
@@ -129,12 +143,59 @@ export const runAllTests = async ({
   logger.info(`Test run URL: ${testRunUrl}`);
   logger.info("");
 
+  const testsToRun = await getTestsToRun({
+    testCases,
+    client,
+    baseCommitSha: baseCommitSha ?? null,
+  });
+
+  const storeTestRunResults = async (
+    status: TestRunStatus,
+    resultsSoFar: DetailedTestCaseResult[]
+  ) => {
+    const resultsToSendToBE = [
+      ...cachedTestRunResults,
+      ...resultsSoFar.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        ({ screenshotDiffResults, ...result }) => result
+      ),
+    ];
+    try {
+      await putTestRunResults({
+        client,
+        testRunId: testRun.id,
+        status,
+        resultData: {
+          results: resultsToSendToBE,
+        },
+      });
+    } catch (error) {
+      logger.error(`Error while pushing partial results: ${error}`);
+    }
+  };
+
+  const onTestFinished = async (
+    progress: TestRunProgress,
+    resultsSoFar: DetailedTestCaseResult[]
+  ) => {
+    onTestFinished_?.({
+      id: testRun.id,
+      url: testRunUrl,
+      status: "Running",
+      progress: {
+        ...progress,
+        passedTestCases: progress.passedTestCases + cachedTestRunResults.length,
+      },
+    });
+    await storeTestRunResults("Running", resultsSoFar);
+  };
+
   const getResults = async () => {
     if (parallelTasks == null || parallelTasks > 1) {
       const results = await runAllTestsInParallel({
         config,
-        client,
         testRun,
+        testsToRun,
         executionOptions,
         screenshottingOptions,
         apiToken,
@@ -143,28 +204,13 @@ export const runAllTests = async ({
         useAssetsSnapshottedInBaseSimulation,
         parallelTasks,
         deflake,
-        cachedTestRunResults,
         replayEventsDependencies,
-        baseCommitSha,
-        onTestFinished: (progress) => {
-          onTestFinished?.({
-            id: testRun.id,
-            url: testRunUrl,
-            status: "Running",
-            progress,
-          });
-        },
+        onTestFinished,
       });
       return results;
     }
 
-    const results: DetailedTestCaseResult[] = [...cachedTestRunResults];
-    const testsToRun = await getTestsToRun({
-      testCases,
-      cachedTestRunResults,
-      client,
-      baseCommitSha: baseCommitSha ?? null,
-    });
+    const results: DetailedTestCaseResult[] = [];
     const progress: TestRunProgress = {
       runningTestCases: testRun.length,
       failedTestCases: 0,
@@ -191,18 +237,7 @@ export const runAllTests = async ({
       progress.failedTestCases += result.result === "fail" ? 1 : 0;
       progress.passedTestCases += result.result === "pass" ? 1 : 0;
       --progress.runningTestCases;
-      onTestFinished?.({
-        id: testRun.id,
-        url: testRunUrl,
-        status: "Running",
-        progress,
-      });
-      await putTestRunResults({
-        client,
-        testRunId: testRun.id,
-        status: "Running",
-        resultData: { results },
-      });
+      await onTestFinished(progress, results);
     }
     return sortResults({ results, testCases });
   };
@@ -211,17 +246,7 @@ export const runAllTests = async ({
 
   const runAllFailure = results.find(({ result }) => result === "fail");
   const overallStatus = runAllFailure ? "Failure" : "Success";
-  await putTestRunResults({
-    client,
-    testRunId: testRun.id,
-    status: overallStatus,
-    resultData: {
-      results: results.map(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ({ screenshotDiffResults, ...coreResult }) => coreResult
-      ),
-    },
-  });
+  await storeTestRunResults(overallStatus, results);
 
   logger.info("");
   logger.info("Results");

--- a/packages/cli/src/parallel-tests/run-all-tests.ts
+++ b/packages/cli/src/parallel-tests/run-all-tests.ts
@@ -13,7 +13,7 @@ import {
 } from "../api/test-run.api";
 import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-types";
 import { readConfig } from "../config/config";
-import { TestCaseResult } from "../config/config.types";
+import { DetailedTestCaseResult } from "../config/config.types";
 import { deflakeReplayCommandHandler } from "../deflake-tests/deflake-tests.handler";
 import { loadReplayEventsDependencies } from "../local-data/replay-assets";
 import { runAllTestsInParallel } from "../parallel-tests/parallel-tests.handler";
@@ -55,7 +55,7 @@ export interface Options {
 }
 export interface RunAllTestsResult {
   testRun: TestRun & { status: "Success" | "Failure" };
-  testCaseResults: TestCaseResult[];
+  testCaseResults: DetailedTestCaseResult[];
 }
 
 export interface TestRun {
@@ -158,7 +158,7 @@ export const runAllTests = async ({
       return results;
     }
 
-    const results: TestCaseResult[] = [...cachedTestRunResults];
+    const results: DetailedTestCaseResult[] = [...cachedTestRunResults];
     const testsToRun = await getTestsToRun({
       testCases,
       cachedTestRunResults,
@@ -215,7 +215,12 @@ export const runAllTests = async ({
     client,
     testRunId: testRun.id,
     status: overallStatus,
-    resultData: { results },
+    resultData: {
+      results: results.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        ({ screenshotDiffResults, ...coreResult }) => coreResult
+      ),
+    },
   });
 
   logger.info("");

--- a/packages/cli/src/utils/run-all-tests.utils.ts
+++ b/packages/cli/src/utils/run-all-tests.utils.ts
@@ -2,14 +2,18 @@ import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import { AxiosInstance } from "axios";
 import log from "loglevel";
 import { getLatestTestRunResults } from "../api/test-run.api";
-import { TestCase, TestCaseResult } from "../config/config.types";
+import {
+  DetailedTestCaseResult,
+  TestCase,
+  TestCaseResult,
+} from "../config/config.types";
 
 export const sortResults: (options: {
-  results: TestCaseResult[];
+  results: DetailedTestCaseResult[];
   testCases: TestCase[];
-}) => TestCaseResult[] = ({ results: unsorted_, testCases }) => {
+}) => DetailedTestCaseResult[] = ({ results: unsorted_, testCases }) => {
   const unsorted = [...unsorted_];
-  const results: TestCaseResult[] = [];
+  const results: DetailedTestCaseResult[] = [];
 
   testCases.forEach(({ title, baseReplayId, sessionId }) => {
     const idx = unsorted.findIndex(

--- a/packages/cli/src/utils/run-all-tests.utils.ts
+++ b/packages/cli/src/utils/run-all-tests.utils.ts
@@ -2,11 +2,7 @@ import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import { AxiosInstance } from "axios";
 import log from "loglevel";
 import { getLatestTestRunResults } from "../api/test-run.api";
-import {
-  DetailedTestCaseResult,
-  TestCase,
-  TestCaseResult,
-} from "../config/config.types";
+import { DetailedTestCaseResult, TestCase } from "../config/config.types";
 
 export const sortResults: (options: {
   results: DetailedTestCaseResult[];
@@ -37,7 +33,6 @@ export const sortResults: (options: {
 export interface GetTestsToRunOptions {
   client: AxiosInstance;
   testCases: TestCase[];
-  cachedTestRunResults: TestCaseResult[];
 
   /**
    * The base commit to compare test results against for test cases that don't have a baseReplayId specified.
@@ -47,25 +42,14 @@ export interface GetTestsToRunOptions {
 
 export const getTestsToRun = async ({
   testCases,
-  cachedTestRunResults,
   client,
   baseCommitSha,
 }: GetTestsToRunOptions): Promise<TestCase[]> => {
-  const uncachedTestCases = testCases.filter(
-    ({ sessionId, baseReplayId, title }) =>
-      !cachedTestRunResults.find(
-        (cached) =>
-          cached.sessionId === sessionId &&
-          cached.baseReplayId === baseReplayId &&
-          cached.title === title
-      )
-  );
-
-  const testCasesMissingBaseReplayId = uncachedTestCases.filter(
+  const testCasesMissingBaseReplayId = testCases.filter(
     (testCase) => testCase.baseReplayId == null
   );
-  const testCasesWithBaseReplayId = uncachedTestCases.flatMap(
-    (testCase): TestCase[] => (testCase.baseReplayId == null ? [] : [testCase])
+  const testCasesWithBaseReplayId = testCases.flatMap((testCase): TestCase[] =>
+    testCase.baseReplayId == null ? [] : [testCase]
   );
 
   if (testCasesMissingBaseReplayId.length === 0) {
@@ -87,7 +71,7 @@ export const getTestsToRun = async ({
     baseCommitSha,
   });
 
-  return uncachedTestCases.flatMap((test) => {
+  return testCases.flatMap((test) => {
     if (test.baseReplayId != null) {
       return [test];
     }


### PR DESCRIPTION
This is required for https://github.com/alwaysmeticulous/report-diffs-action/pull/26, which is important to ensure we don't report that a session failed with a link when the link leads the user to an empty set of screenshot diffs (e.g. because all sessions completely failed to even run), and since the # differing screens is more useful feedback than the # of differing sessions (the sessions are pretty random, some cover many distinct parts of the app) and lets the user know what to expect when they click the link.