### PR TITLE
Add locking for downloads & zip extraction

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,12 +38,14 @@
     "inquirer": "^8.2.4",
     "luxon": "^2.4.0",
     "pixelmatch": "^5.3.0",
+    "proper-lockfile": "^4.1.2",
     "pngjs": "^6.0.0",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
     "@alwaysmeticulous/api": "^2.19.1",
-    "@types/express": "^4.17.14"
+    "@types/express": "^4.17.14",
+    "@types/proper-lockfile": "^4.1.2"
   },
   "peerDependencies": {
     "@alwaysmeticulous/record": "^2.3.3",

--- a/packages/cli/src/api/replay.api.ts
+++ b/packages/cli/src/api/replay.api.ts
@@ -2,10 +2,10 @@ import { Replay } from "@alwaysmeticulous/common";
 import axios, { AxiosInstance } from "axios";
 import { getProject } from "./project.api";
 
-export const getReplay: (
+export const getReplay = async (
   client: AxiosInstance,
   replayId: string
-) => Promise<any> = async (client, replayId) => {
+): Promise<Replay> => {
   const { data } = await client.get(`replays/${replayId}`).catch((error) => {
     if (axios.isAxiosError(error)) {
       if (error.response?.status === 404) {

--- a/packages/cli/src/api/session.api.ts
+++ b/packages/cli/src/api/session.api.ts
@@ -1,9 +1,10 @@
+import { SessionData } from "@alwaysmeticulous/api";
 import axios, { AxiosInstance } from "axios";
 
-export const getRecordedSession: (
+export const getRecordedSession = async (
   client: AxiosInstance,
   sessionId: string
-) => Promise<any> = async (client, sessionId) => {
+): Promise<any> => {
   const { data } = await client.get(`sessions/${sessionId}`).catch((error) => {
     if (axios.isAxiosError(error)) {
       if (error.response?.status === 404) {
@@ -15,10 +16,10 @@ export const getRecordedSession: (
   return data;
 };
 
-export const getRecordedSessionData: (
+export const getRecordedSessionData = async (
   client: AxiosInstance,
   sessionId: string
-) => Promise<any> = async (client, sessionId) => {
+): Promise<SessionData> => {
   const { data } = await client
     .get(`sessions/${sessionId}/data`)
     .catch((error) => {

--- a/packages/cli/src/local-data/local-data.utils.ts
+++ b/packages/cli/src/local-data/local-data.utils.ts
@@ -1,4 +1,5 @@
-import { dirname, join } from "path";
+import { mkdir, rmdir, access } from "fs/promises";
+import { join } from "path";
 import { lock, LockOptions } from "proper-lockfile";
 
 export const sanitizeFilename: (filename: string) => string = (filename) => {
@@ -11,18 +12,44 @@ type ReleaseLock = () => Promise<void>;
 // time they don't interfere with each other. The second process to run will
 // wait for the first process to complete, and then return straight away because
 // it'll notice the file already exists.
-export const waitToAcquireLockOnFile = (
+export const waitToAcquireLockOnFile = async (
   filePath: string
 ): Promise<ReleaseLock> => {
-  // The first argument, the file argument to lock is just used
-  // to resolve symlinks. Since we don't create any symlinks within
-  // our download directories we can safely pass the directory name here.
-  // This avoids issues if the file does not exist yet.
-  return lock(dirname(filePath), {
-    retries: LOCK_RETRY_OPTIONS,
-    lockfilePath: `${filePath}.lock`,
-  });
+  // In many cases the file doesn't exist yet, and can't exist yet
+  // (need to download the data, and creating an empty file is risky if the process crashes)
+  // However proper-lockfile requires as to pass a file or directory as the first arg. This path is just used
+  // for it to resolve symlinks in the path correctly, and to detect if the same process tries taking
+  // out multiple locks on the same path. It just needs to be calculated as something
+  // that's unique to the file, and gives the same path for a given file everytime. So we create our
+  // own lock-target directory for this purpose (directory not file since mkdir is guaranteed to be synchronous).
+  const lockDirectory = `${filePath}.lock-target`;
+  await mkdir(lockDirectory, { recursive: true });
+
+  try {
+    const releaseLock = await lock(lockDirectory, {
+      retries: LOCK_RETRY_OPTIONS,
+      lockfilePath: `${filePath}.lock`,
+    });
+    return async () => {
+      // Clean up our directory _before_ releasing the lock
+      // We check if it exists first, because if we're just coming out of
+      // a lock released by someone else then they will have already deleted
+      // the directory
+      if (await fileExists(lockDirectory)) {
+        await rmdir(lockDirectory);
+      }
+      await releaseLock();
+    };
+  } catch (err) {
+    await rmdir(lockDirectory);
+    throw err;
+  }
 };
+
+export const fileExists = (filePath: string) =>
+  access(filePath)
+    .then(() => true)
+    .catch(() => false);
 
 export const waitToAcquireLockOnDirectory = (
   directoryPath: string

--- a/packages/cli/src/local-data/local-data.utils.ts
+++ b/packages/cli/src/local-data/local-data.utils.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { dirname, join } from "path";
 import { lock, LockOptions } from "proper-lockfile";
 
 export const sanitizeFilename: (filename: string) => string = (filename) => {
@@ -14,8 +14,13 @@ type ReleaseLock = () => Promise<void>;
 export const waitToAcquireLockOnFile = (
   filePath: string
 ): Promise<ReleaseLock> => {
-  return lock(filePath, {
+  // The first argument, the file argument to lock is just used
+  // to resolve symlinks. Since we don't create any symlinks within
+  // our download directories we can safely pass the directory name here.
+  // This avoids issues if the file does not exist yet.
+  return lock(dirname(filePath), {
     retries: LOCK_RETRY_OPTIONS,
+    lockfilePath: `${filePath}.lock`,
   });
 };
 

--- a/packages/cli/src/local-data/local-data.utils.ts
+++ b/packages/cli/src/local-data/local-data.utils.ts
@@ -1,4 +1,4 @@
-import { mkdir, rmdir, access, readFile, writeFile } from "fs/promises";
+import { mkdir, rmdir, access, readFile, writeFile, rm } from "fs/promises";
 import { dirname, join } from "path";
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import log from "loglevel";
@@ -81,12 +81,10 @@ const waitToAcquireLockOnFile = async (
     });
     return async () => {
       // Clean up our directory _before_ releasing the lock
-      // We check if it exists first, because if we're just coming out of
+      // Note: it may have already been deleted: if we're just coming out of
       // a lock released by someone else then they will have already deleted
       // the directory
-      if (await fileExists(lockDirectory)) {
-        await rmdir(lockDirectory);
-      }
+      await rm(lockDirectory, { recursive: true, force: true });
       await releaseLock();
     };
   } catch (err) {

--- a/packages/cli/src/local-data/local-data.utils.ts
+++ b/packages/cli/src/local-data/local-data.utils.ts
@@ -1,3 +1,47 @@
+import { join } from "path";
+import { lock, LockOptions } from "proper-lockfile";
+
 export const sanitizeFilename: (filename: string) => string = (filename) => {
   return filename.replace(/[^a-zA-Z0-9]/g, "_");
+};
+
+type ReleaseLock = () => Promise<void>;
+
+export const waitToAcquireLockOnFile = (
+  filePath: string
+): Promise<ReleaseLock> => {
+  // Create a lock file so that if multiple processes try downloading at the same
+  // time they don't interfere with each other. The second process to run will
+  // wait for the first process to complete, and then return straight away because
+  // it'll notice the file already exists.
+  return lock(filePath, {
+    retries: LOCK_RETRY_OPTIONS,
+  });
+};
+
+export const waitToAcquireLockOnDirectory = (
+  directoryPath: string
+): Promise<ReleaseLock> => {
+  // Create a lock file so that if multiple processes try downloading at the same
+  // time they don't interfere with each other. The second process to run will
+  // wait for the first process to complete, and then return straight away because
+  // it'll notice the files required already exist.
+  return lock(directoryPath, {
+    retries: LOCK_RETRY_OPTIONS,
+    lockfilePath: join(directoryPath, "dir.lock"),
+  });
+};
+
+const ONE_SECOND_IN_MS = 1_000;
+
+const LOCK_RETRY_OPTIONS: LockOptions["retries"] = {
+  // We want to keep on retrying till we get the maxRetryTime, so we set retries, which is a maximum, to a high value
+  retries: 1000,
+  factor: 1.05,
+  minTimeout: 500,
+  maxTimeout: 2000,
+  // Wait a maximum of 120s for the other process to finish downloading and/or extracting
+  maxRetryTime: 120 * ONE_SECOND_IN_MS,
+  // Randomize so processes are less likely to clash on their retries
+  randomize: true,
 };

--- a/packages/cli/src/local-data/local-data.utils.ts
+++ b/packages/cli/src/local-data/local-data.utils.ts
@@ -7,13 +7,13 @@ export const sanitizeFilename: (filename: string) => string = (filename) => {
 
 type ReleaseLock = () => Promise<void>;
 
+// We create a lock file so that if multiple processes try downloading at the same
+// time they don't interfere with each other. The second process to run will
+// wait for the first process to complete, and then return straight away because
+// it'll notice the file already exists.
 export const waitToAcquireLockOnFile = (
   filePath: string
 ): Promise<ReleaseLock> => {
-  // Create a lock file so that if multiple processes try downloading at the same
-  // time they don't interfere with each other. The second process to run will
-  // wait for the first process to complete, and then return straight away because
-  // it'll notice the file already exists.
   return lock(filePath, {
     retries: LOCK_RETRY_OPTIONS,
   });
@@ -22,10 +22,6 @@ export const waitToAcquireLockOnFile = (
 export const waitToAcquireLockOnDirectory = (
   directoryPath: string
 ): Promise<ReleaseLock> => {
-  // Create a lock file so that if multiple processes try downloading at the same
-  // time they don't interfere with each other. The second process to run will
-  // wait for the first process to complete, and then return straight away because
-  // it'll notice the files required already exist.
   return lock(directoryPath, {
     retries: LOCK_RETRY_OPTIONS,
     lockfilePath: join(directoryPath, "dir.lock"),

--- a/packages/cli/src/local-data/local-data.utils.ts
+++ b/packages/cli/src/local-data/local-data.utils.ts
@@ -15,13 +15,13 @@ type ReleaseLock = () => Promise<void>;
 export const waitToAcquireLockOnFile = async (
   filePath: string
 ): Promise<ReleaseLock> => {
-  // In many cases the file doesn't exist yet, and can't exist yet
-  // (need to download the data, and creating an empty file is risky if the process crashes)
-  // However proper-lockfile requires as to pass a file or directory as the first arg. This path is just used
-  // for it to resolve symlinks in the path correctly, and to detect if the same process tries taking
-  // out multiple locks on the same path. It just needs to be calculated as something
-  // that's unique to the file, and gives the same path for a given file everytime. So we create our
+  // In many cases the file doesn't exist yet, and can't exist yet (need to download the data, and creating an
+  // empty file beforehand is risky if the process crashes, and a second process tries reading the empty file).
+  // However proper-lockfile requires us to pass a file or directory as the first arg. This path is just used
+  // to detect if the same process tries taking out multiple locks on the same file. It just needs to be calculated
+  // as something that's unique to the file, and gives the same path for a given file everytime. So we create our
   // own lock-target directory for this purpose (directory not file since mkdir is guaranteed to be synchronous).
+  // The path needs to actually exist, since proper-lockfile resolves symlinks on it.
   const lockDirectory = `${filePath}.lock-target`;
   await mkdir(lockDirectory, { recursive: true });
 

--- a/packages/cli/src/local-data/replays.ts
+++ b/packages/cli/src/local-data/replays.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, opendir, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, opendir, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import {
   getMeticulousLocalDataDir,
@@ -10,6 +10,7 @@ import log from "loglevel";
 import { downloadFile } from "../api/download";
 import { getReplay, getReplayDownloadUrl } from "../api/replay.api";
 import {
+  fileExists,
   waitToAcquireLockOnDirectory,
   waitToAcquireLockOnFile,
 } from "./local-data.utils";
@@ -92,11 +93,6 @@ export const getOrFetchReplayArchive: (
     await releaseLock();
   }
 };
-
-const fileExists = (filePath: string) =>
-  access(filePath)
-    .then(() => true)
-    .catch(() => false);
 
 export const getScreenshotFiles: (
   screenshotsDirPath: string

--- a/packages/cli/src/local-data/replays.ts
+++ b/packages/cli/src/local-data/replays.ts
@@ -30,14 +30,14 @@ export const getOrFetchReplay = async (
     downloadJson: () => getReplay(client, replayId),
   });
 
-    if (!replay) {
-      logger.error(
-        `Error: Could not retrieve replay with id "${replayId}". Is the API token correct?`
-      );
-      process.exit(1);
-    }
+  if (!replay) {
+    logger.error(
+      `Error: Could not retrieve replay with id "${replayId}". Is the API token correct?`
+    );
+    process.exit(1);
+  }
 
-    return replay;
+  return replay;
 };
 
 export const getOrFetchReplayArchive = async (

--- a/packages/cli/src/local-data/sessions.ts
+++ b/packages/cli/src/local-data/sessions.ts
@@ -34,6 +34,7 @@ export const getOrFetchRecordedSession: (
       logger.error(
         "Error: Could not retrieve session. Is the API token correct?"
       );
+      await releaseLock();
       process.exit(1);
     }
 
@@ -41,7 +42,7 @@ export const getOrFetchRecordedSession: (
     logger.debug(`Wrote session to ${sessionFile}`);
     return session;
   } finally {
-    releaseLock();
+    await releaseLock();
   }
 };
 

--- a/packages/cli/src/local-data/sessions.ts
+++ b/packages/cli/src/local-data/sessions.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
+import { SessionData } from "@alwaysmeticulous/api";
 import {
   getMeticulousLocalDataDir,
   METICULOUS_LOGGER_NAME,
@@ -7,83 +7,58 @@ import {
 import { AxiosInstance } from "axios";
 import log from "loglevel";
 import { getRecordedSession, getRecordedSessionData } from "../api/session.api";
-import { sanitizeFilename, waitToAcquireLockOnFile } from "./local-data.utils";
+import { getOrDownloadJsonFile, sanitizeFilename } from "./local-data.utils";
 
-export const getOrFetchRecordedSession: (
+export const getOrFetchRecordedSession = async (
   client: AxiosInstance,
   sessionId: string
-) => Promise<any> = async (client, sessionId) => {
+): Promise<any> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const sessionsDir = join(getMeticulousLocalDataDir(), "sessions");
-  await mkdir(sessionsDir, { recursive: true });
-  const sessionFile = join(sessionsDir, `${sanitizeFilename(sessionId)}.json`);
-  const releaseLock = await waitToAcquireLockOnFile(sessionFile);
+  const sessionFile = join(
+    getMeticulousLocalDataDir(),
+    "sessions",
+    `${sanitizeFilename(sessionId)}.json`
+  );
 
-  try {
-    const existingSession = await readFile(sessionFile)
-      .then((data) => JSON.parse(data.toString("utf-8")))
-      .catch(() => null);
-    if (existingSession) {
-      logger.debug(`Reading session from local copy in ${sessionFile}`);
-      return existingSession;
-    }
-
-    const session = await getRecordedSession(client, sessionId);
-    if (!session) {
-      logger.error(
-        "Error: Could not retrieve session. Is the API token correct?"
-      );
-      await releaseLock();
-      process.exit(1);
-    }
-
-    await writeFile(sessionFile, JSON.stringify(session, null, 2));
-    logger.debug(`Wrote session to ${sessionFile}`);
-    return session;
-  } finally {
-    await releaseLock();
+  const session = await getOrDownloadJsonFile({
+    filePath: sessionFile,
+    dataDescription: "session",
+    downloadJson: () => getRecordedSession(client, sessionId),
+  });
+  if (!session) {
+    logger.error(
+      "Error: Could not retrieve session. Is the API token correct?"
+    );
+    process.exit(1);
   }
+
+  return session;
 };
 
-export const getOrFetchRecordedSessionData: (
+export const getOrFetchRecordedSessionData = async (
   client: AxiosInstance,
   sessionId: string
-) => Promise<any> = async (client, sessionId) => {
+): Promise<SessionData> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const sessionsDir = join(getMeticulousLocalDataDir(), "sessions");
-  await mkdir(sessionsDir, { recursive: true });
-  const sessionDataFile = join(
-    sessionsDir,
+  const sessionFile = join(
+    getMeticulousLocalDataDir(),
+    "sessions",
     `${sanitizeFilename(sessionId)}_data.json`
   );
-  const releaseLock = await waitToAcquireLockOnFile(sessionDataFile);
 
-  try {
-    const existingSessionData = await readFile(sessionDataFile)
-      .then((data) => JSON.parse(data.toString("utf-8")))
-      .catch(() => null);
-    if (existingSessionData) {
-      logger.debug(
-        `Reading session data from local copy in ${sessionDataFile}`
-      );
-      return existingSessionData;
-    }
-
-    const sessionData = await getRecordedSessionData(client, sessionId);
-    if (!sessionData) {
-      logger.error(
-        "Error: Could not retrieve session data. This may be an invalid session"
-      );
-      await releaseLock();
-      process.exit(1);
-    }
-
-    await writeFile(sessionDataFile, JSON.stringify(sessionData, null, 2));
-    logger.debug(`Wrote session data to ${sessionDataFile}`);
-    return sessionData;
-  } finally {
-    await releaseLock();
+  const sessionData = await getOrDownloadJsonFile({
+    filePath: sessionFile,
+    dataDescription: "session data",
+    downloadJson: () => getRecordedSessionData(client, sessionId),
+  });
+  if (!sessionData) {
+    logger.error(
+      "Error: Could not retrieve session data. This may be an invalid session"
+    );
+    process.exit(1);
   }
+
+  return sessionData;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2691,6 +2691,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
+"@types/proper-lockfile@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz#49537cee7134055ee13a1833b76a1c298f39bb26"
+  integrity sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -2725,6 +2732,11 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/retry@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
+  integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
 
 "@types/scheduler@*":
   version "0.16.2"
@@ -8566,6 +8578,15 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
Currently if two processes download the same file at the same time it can cause issues. For example when running with retries I'll often see process A download the zip of a replay, then process B start downloading it, but by the time process B finishes downloading it and starts extracting it, process A has already extracted the zip and deleted it.

By using lock files we also avoid two processes making the same download at the same time. Instead the 2nd will just wait for the first to finish, and then use the already downloaded file.

This uses proper-lockfile under the hood which handles things like left over lockfiles when the application crashes (it bumps mtime every 5s while lockfile is still being used, and ignores lockfiles which haven't been updated for > 10s).