### PR TITLE
Improve replay diff typings

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,6 +14,8 @@ export {
   ScreenshotIdentifier,
   ScreenshottingEnabledOptions,
   StoryboardOptions,
+  ScreenshotDiffResultMissingBaseAndHead,
+  SingleTryScreenshotDiffResult,
 } from "./replay/replay-diff.types";
 export {
   TestCase,

--- a/packages/api/src/replay/replay-diff.types.ts
+++ b/packages/api/src/replay/replay-diff.types.ts
@@ -36,16 +36,16 @@ export interface ScreenshotDiffOptions {
   diffPixelThreshold: number;
 }
 
-/** Represents the result of comparing two screenshots */
-export type ScreenshotDiffResult = {
-  identifier: ScreenshotIdentifier;
-} & (
+export type SingleTryScreenshotDiffResult =
   | ScreenshotDiffResultMissingBase
   | ScreenshotDiffResultMissingHead
   | ScreenshotDiffResultDifferentSize
-  | ScreenshotDiffResultCompared
-  | ScreenshotDiffResultFlake
-);
+  | ScreenshotDiffResultCompared;
+
+/** Represents the result of comparing two screenshots */
+export type ScreenshotDiffResult = {
+  identifier: ScreenshotIdentifier;
+} & (SingleTryScreenshotDiffResult | ScreenshotDiffResultFlake);
 
 export type ScreenshotIdentifier = EndStateScreenshot | ScreenshotAfterEvent;
 
@@ -72,6 +72,10 @@ export interface ScreenshotDiffResultMissingHead {
 
   /** Relative path to the replay archive */
   baseScreenshotFile: string;
+}
+
+export interface ScreenshotDiffResultMissingBaseAndHead {
+  outcome: "missing-base-and-head";
 }
 
 export interface ScreenshotDiffResultDifferentSize {
@@ -115,7 +119,7 @@ export interface ScreenshotDiffResultFlake {
   /**
    * The original diff. Can be any outcome but for 'no-diff'.
    */
-  diffToBaseScreenshot: Omit<ScreenshotDiffResult, "identifier">;
+  diffToBaseScreenshot: SingleTryScreenshotDiffResult;
 
   /**
    * The diffs created by retrying taking the head screenshot and comparing
@@ -126,9 +130,6 @@ export interface ScreenshotDiffResultFlake {
    * and head means the new head screenshot taken.
    */
   diffsToHeadScreenshotOnRetries: Array<
-    Omit<
-      ScreenshotDiffResult | { outcome: "missing-base-and-head" },
-      "identifier"
-    >
+    SingleTryScreenshotDiffResult | ScreenshotDiffResultMissingBaseAndHead
   >;
 }

--- a/packages/cli/src/parallel-tests/merge-test-results.ts
+++ b/packages/cli/src/parallel-tests/merge-test-results.ts
@@ -2,6 +2,7 @@ import {
   ScreenshotDiffResult,
   ScreenshotIdentifier,
 } from "@alwaysmeticulous/api";
+import { SingleTryScreenshotDiffResult } from "@alwaysmeticulous/api/dist/replay/replay-diff.types";
 import { logger } from "@sentry/utils";
 import { DetailedTestCaseResult } from "../config/config.types";
 
@@ -70,6 +71,12 @@ export const mergeResults = ({
         return currentDiff; // no difference, both screenshots were missing
       }
 
+      if (diffWhenRetrying.outcome === "flake") {
+        throw new Error(
+          "Expected diffs when retrying and comparing to the original head screenshot to be first-try diffs, but got a flake."
+        );
+      }
+
       if (currentDiff.outcome === "flake") {
         return {
           ...currentDiff,
@@ -105,8 +112,10 @@ export const mergeResults = ({
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const withoutIdentifier = ({ identifier, ...rest }: ScreenshotDiffResult) =>
+const withoutIdentifier = ({
+  identifier, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ...rest
+}: { identifier: ScreenshotIdentifier } & SingleTryScreenshotDiffResult) =>
   rest;
 
 type ScreenshotIdentifierHash = string;


### PR DESCRIPTION
No functional changes. These changes just make the typings far easier to use, and a little more precise. In particular Typescript doesn't like it when you do an `Omit<>` over a discriminated type union -- you lose all type narrowing -- when you filter on an outcome it doesn't filter down the type.