### PR TITLE
Bootstrap user interactions

### DIFF
--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -5,6 +5,8 @@ export {
   ReplayUserInteractionsResultShort,
 } from "./replay/bundle-to-sdk/index";
 export {
+  BootstrapReplayUserInteractionsFn,
+  BootstrapReplayUserInteractionsOptions,
   OnReplayTimelineEventFn,
   ReplayUserInteractionsFn,
   ReplayUserInteractionsOptions,

--- a/packages/sdk-bundles-api/src/replay/sdk-to-bundle/index.ts
+++ b/packages/sdk-bundles-api/src/replay/sdk-to-bundle/index.ts
@@ -21,6 +21,15 @@ export type ReplayUserInteractionsFn = (
   options: ReplayUserInteractionsOptions
 ) => Promise<ReplayUserInteractionsResult>;
 
+export interface BootstrapReplayUserInteractionsOptions {
+  page: Page;
+  logLevel: LogLevelDesc;
+}
+
+export type BootstrapReplayUserInteractionsFn = (
+  options: BootstrapReplayUserInteractionsOptions
+) => Promise<ReplayUserInteractionsFn>;
+
 // In future we intend to add new options, but only to the enabled: true case
 // (for example we'll add an optional 'recreatePauses' option)
 export type VirtualTimeOptions = { enabled: false } | { enabled: true };


### PR DESCRIPTION
### Motivation 

The user interactions script now depends on pre-navigation page setup.

### Changes

This PR updates the replayer to call `boostrapUserInteractions` within the `nodeUserInteractions` module, if available.

