### PR TITLE
Add essential features only flag

### DIFF
--- a/packages/cli/src/command-utils/common-options.ts
+++ b/packages/cli/src/command-utils/common-options.ts
@@ -94,6 +94,12 @@ export const OPTIONS = {
     description: "Take a storyboard of screenshots during simulation",
     default: false,
   },
+  essentialFeaturesOnly: {
+    boolean: true,
+    description:
+      "Disable any features that are non-essential for running tests/executing replays. This includes disabling recording a video of the replay, for playback in the web app. This flag is useful to reduce noise when debugging.",
+    default: false,
+  },
 } as const;
 
 export const SCREENSHOT_DIFF_OPTIONS = {
@@ -117,4 +123,5 @@ export const COMMON_REPLAY_OPTIONS = {
   noSandbox: OPTIONS.noSandbox,
   maxDurationMs: OPTIONS.maxDurationMs,
   maxEventCount: OPTIONS.maxEventCount,
+  essentialFeaturesOnly: OPTIONS.essentialFeaturesOnly,
 };

--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -181,6 +181,7 @@ const handler: (options: Options) => Promise<void> = async ({
     maxDurationMs: null,
     maxEventCount: null,
     storyboard: false,
+    essentialFeaturesOnly: false,
   };
   const replay = await rawReplayCommandHandler(replayOptions);
 

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -353,6 +353,7 @@ export const rawReplayCommandHandler = async ({
   maxDurationMs,
   maxEventCount,
   storyboard,
+  essentialFeaturesOnly,
 }: RawReplayCommandHandlerOptions): Promise<Replay> => {
   const executionOptions: ReplayExecutionOptions = {
     headless,
@@ -367,6 +368,7 @@ export const rawReplayCommandHandler = async ({
     noSandbox,
     maxDurationMs: maxDurationMs ?? null,
     maxEventCount: maxEventCount ?? null,
+    essentialFeaturesOnly,
   };
   const generatedByOption: GeneratedBy = { type: "replayCommand" };
   const storyboardOptions: StoryboardOptions = storyboard

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -65,6 +65,7 @@ const handler: (options: Options) => Promise<void> = async ({
   maxDurationMs,
   maxEventCount,
   storyboard,
+  essentialFeaturesOnly,
 }) => {
   const executionOptions: ReplayExecutionOptions = {
     headless,
@@ -79,6 +80,7 @@ const handler: (options: Options) => Promise<void> = async ({
     moveBeforeClick,
     maxDurationMs: maxDurationMs ?? null,
     maxEventCount: maxEventCount ?? null,
+    essentialFeaturesOnly,
   };
   const storyboardOptions: StoryboardOptions = storyboard
     ? { enabled: true }

--- a/packages/common/src/types/replay.types.ts
+++ b/packages/common/src/types/replay.types.ts
@@ -64,6 +64,14 @@ export interface ReplayExecutionOptions {
   noSandbox: boolean;
   maxDurationMs: number | null;
   maxEventCount: number | null;
+
+  /**
+   * If true disables any features that are non-essential for running tests/executing replays.
+   * This includes disabling recording a video of the replay, for playback in the web app.
+   *
+   * This flag is useful to reduce noise when debugging.
+   */
+  essentialFeaturesOnly: boolean;
 }
 
 export type ScreenshottingOptions =

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -62,6 +62,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     noSandbox,
     bypassCSP,
     moveBeforeClick,
+    essentialFeaturesOnly,
   } = replayExecutionOptions;
   const metadata: ReplayMetadata = {
     session,
@@ -129,6 +130,7 @@ export const replayEvents: ReplayEventsFn = async (options) => {
     onTimelineEvent,
     bypassCSP,
     virtualTime,
+    essentialFeaturesOnly,
   });
   createReplayPageSpan?.finish();
 
@@ -292,7 +294,9 @@ export const replayEvents: ReplayEventsFn = async (options) => {
   const collectCoverageSpan = parentPerformanceSpan?.startChild({
     op: "collectCoverage",
   });
-  const coverageData = await page.coverage.stopJSCoverage();
+  const coverageData = essentialFeaturesOnly
+    ? []
+    : await page.coverage.stopJSCoverage();
   collectCoverageSpan?.finish();
   logger.debug("Collected coverage data");
 


### PR DESCRIPTION
When debugging it's often using to disable things like rrweb recording, since it adds a lot of noise to the logs (adding MutationObservers, scheduling timeouts etc.). Filtering it out enables you to focus on just the execution of the core application, and debug that. This PR adds a flag to disable an extraneous features, kind of like 'Safe Mode' for Windows 98.