### PR TITLE
Update workflow dispatch types

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -100,9 +100,6 @@ export interface TestRunGitHubWorkflowDispatchContext {
     [key: string]: unknown;
   };
 
-  /** Resolved base commit hash */
-  baseSha: string;
-
   /** Resolved head commit hash */
   headSha: string;
 }


### PR DESCRIPTION
Test runs triggered by workflow dispatch will run on head without comparing to a base commit.