### PR TITLE
Add support for session selection from the Meticulous API

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,3 +1,5 @@
+export { Organization } from "./organization.types";
+export { Project, ProjectConfigurationData } from "./project.types";
 export {
   EndStateScreenshot,
   ReplayDiff,
@@ -10,12 +12,12 @@ export {
   ScreenshotDiffResultCompared,
   ScreenshotDiffResultDifferentSize,
   ScreenshotDiffResultMissingBase,
+  ScreenshotDiffResultMissingBaseAndHead,
   ScreenshotDiffResultMissingHead,
   ScreenshotIdentifier,
   ScreenshottingEnabledOptions,
-  StoryboardOptions,
-  ScreenshotDiffResultMissingBaseAndHead,
   SingleTryScreenshotDiffResult,
+  StoryboardOptions,
 } from "./replay/replay-diff.types";
 export {
   TestCase,

--- a/packages/api/src/organization.types.ts
+++ b/packages/api/src/organization.types.ts
@@ -1,0 +1,6 @@
+export interface Organization {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/api/src/project.types.ts
+++ b/packages/api/src/project.types.ts
@@ -1,0 +1,17 @@
+import { Organization } from "./organization.types";
+import { TestCase } from "./replay/test-run.types";
+
+export interface Project {
+  id: string;
+  organization: Organization;
+  name: string;
+  recordingToken: string;
+  apiToken: string;
+  configurationData: ProjectConfigurationData;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectConfigurationData {
+  testCases?: TestCase[];
+}

--- a/packages/cli/src/api/project.api.ts
+++ b/packages/cli/src/api/project.api.ts
@@ -1,15 +1,18 @@
+import { Project } from "@alwaysmeticulous/api";
 import axios, { AxiosInstance } from "axios";
 
-export const getProject: (client: AxiosInstance) => Promise<any> = async (
-  client
-) => {
-  const { data } = await client.get("projects/token-info").catch((error) => {
-    if (axios.isAxiosError(error)) {
-      if (error.response?.status === 404) {
-        return { data: null };
+export const getProject: (
+  client: AxiosInstance
+) => Promise<Project | null> = async (client) => {
+  const { data } = await client
+    .get<Project>("projects/token-info")
+    .catch((error) => {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 404) {
+          return { data: null };
+        }
       }
-    }
-    throw error;
-  });
+      throw error;
+    });
   return data;
 };

--- a/packages/cli/src/api/replay.api.ts
+++ b/packages/cli/src/api/replay.api.ts
@@ -141,6 +141,9 @@ export const getDiffUrl: (
   headReplayId: string
 ) => Promise<string> = async (client, baseReplayId, headReplayId) => {
   const project = await getProject(client);
+  if (!project) {
+    throw new Error(`Unexpected error: could not retrieve project data`);
+  }
   const organizationName = encodeURIComponent(project.organization.name);
   const projectName = encodeURIComponent(project.name);
   const diffUrl = `https://app.meticulous.ai/projects/${organizationName}/${projectName}/simulations/${headReplayId}/diff/${baseReplayId}`;

--- a/packages/cli/src/utils/run-all-tests.utils.ts
+++ b/packages/cli/src/utils/run-all-tests.utils.ts
@@ -8,9 +8,6 @@ import { DetailedTestCaseResult } from "../config/config.types";
 export const mergeTestCases = (
   ...testSuites: (TestCase[] | null | undefined)[]
 ): TestCase[] => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
-  logger.debug(testSuites.length);
-
   const seenSessionIds = new Set<string>();
 
   return testSuites.flatMap((testSuite) => {
@@ -25,12 +22,6 @@ export const mergeTestCases = (
       return [testCase];
     });
   });
-
-  // testSuites.forEach((arr) => {
-  //   logger.debug(arr);
-  // });
-
-  // return [];
 };
 
 export const sortResults: (options: {

--- a/packages/cli/src/utils/run-all-tests.utils.ts
+++ b/packages/cli/src/utils/run-all-tests.utils.ts
@@ -5,6 +5,34 @@ import log from "loglevel";
 import { getLatestTestRunResults } from "../api/test-run.api";
 import { DetailedTestCaseResult } from "../config/config.types";
 
+export const mergeTestCases = (
+  ...testSuites: (TestCase[] | null | undefined)[]
+): TestCase[] => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  logger.debug(testSuites.length);
+
+  const seenSessionIds = new Set<string>();
+
+  return testSuites.flatMap((testSuite) => {
+    if (testSuite == null) {
+      return [];
+    }
+    return testSuite.flatMap((testCase) => {
+      if (seenSessionIds.has(testCase.sessionId)) {
+        return [];
+      }
+      seenSessionIds.add(testCase.sessionId);
+      return [testCase];
+    });
+  });
+
+  // testSuites.forEach((arr) => {
+  //   logger.debug(arr);
+  // });
+
+  // return [];
+};
+
 export const sortResults: (options: {
   results: DetailedTestCaseResult[];
   testCases: TestCase[];


### PR DESCRIPTION
This change pulls the project configuration from the Meticulous API and merge the test cases to run with the ones present in the `meticulous.json` file (if it exists).

[SIM-386](https://toil.kitemaker.co/qpgVHi-Meticulous/pPGwrM-Engineering/items/386)