### PR TITLE
handle simulation timeout errors

### DIFF
--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -293,7 +293,11 @@ export const replayEvents: ReplayEventsFn = async (options) => {
       }
     }
   } catch (error) {
-    logger.error("Error thrown during replay", error);
+    if (error instanceof Error && error.name === "MeticulousTimeoutError") {
+      await browser.close();
+      throw error;
+    }
+
     onTimelineEvent({
       kind: "fatalError",
       start: new Date().getTime(),


### PR DESCRIPTION
This terminates the replay early if timeout occurs while replaying user interaction events