### PR TITLE
Use chrome extension to disable SVG animations

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -25,7 +25,6 @@ export const COMMON_CHROMIUM_FLAGS = [
   // work-around this issue (a temporary directory will always be used to create
   // anonymous shared memory files).
   "--disable-dev-shm-usage",
-  "--disable-extensions",
   // Suppresses hang monitor dialogs in renderer processes.
   // This may allow slow unload handlers on a page to prevent the tab from closing,
   // but the Task Manager can be used to terminate the offending process in this case.

--- a/packages/replayer/chrome-extensions/set-animation-policy-extension/background.js
+++ b/packages/replayer/chrome-extensions/set-animation-policy-extension/background.js
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-undef
+chrome.accessibilityFeatures.animationPolicy.set(
+  { value: "none" },
+  function () {
+    /* No-op callback */
+  }
+);

--- a/packages/replayer/chrome-extensions/set-animation-policy-extension/manifest.json
+++ b/packages/replayer/chrome-extensions/set-animation-policy-extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Set Animation Policy",
+  "action": {},
+  "manifest_version": 3,
+  "version": "0.1",
+  "description": "Pauses all animations",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "accessibilityFeatures.read",
+    "accessibilityFeatures.modify"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/packages/replayer/package.json
+++ b/packages/replayer/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build": "tsc --build tsconfig.json",
+    "build": "tsc --build tsconfig.json && cp -r chrome-extensions/* dist/",
     "dev": "tsc --build tsconfig.json --watch",
     "format": "prettier --write src",
     "lint": "eslint src --ext=ts,tsx,js --cache",


### PR DESCRIPTION
This disables Incognito browser context. Do we need that?

If so it's a pain to auto enable extensions in incognito mode (https://github.com/puppeteer/puppeteer/issues/3442#issuecomment-1165315256), but we could just use a MutationObserver that looks for new animated SVGs and does `Array.from(document.getElementsByTagName("svg")).forEach(s => s.pauseAnimations())`.