### PR TITLE
Default --skipPauses to true

### DIFF
--- a/packages/cli/src/command-utils/common-options.ts
+++ b/packages/cli/src/command-utils/common-options.ts
@@ -51,8 +51,8 @@ export const OPTIONS = {
   skipPauses: {
     boolean: true,
     description:
-      "Fast forward through any pauses to replay as fast as possible. Warning: this option is experimental and may be deprecated",
-    default: false,
+      "Fast forward through any pauses to replay as fast as possible.",
+    default: true,
   },
   moveBeforeClick: {
     boolean: true,

--- a/packages/cli/src/commands/create-test/create-test.command.ts
+++ b/packages/cli/src/commands/create-test/create-test.command.ts
@@ -237,7 +237,7 @@ export const createTestCommand = buildCommand("create-test")
     skipPauses: {
       ...COMMON_REPLAY_OPTIONS.skipPauses,
       description:
-        "Fast forward through any pauses to replay as fast as possible when replaying for the first time to create the test. Warning: this option is experimental and may be deprecated",
+        "Fast forward through any pauses to replay as fast as possible when replaying for the first time to create the test.",
     },
   })
   .handler(handler);


### PR DESCRIPTION
This is now the best tested and most reliable way to run the tests (e.g. notice that `--skipPauses false` tests flake a lot on Meticulous CI, but `--skipPauses true` tests do not), so we should default it to true so users get the best experience by default. I'll leave in `--skipPauses false` as a debugging option.