### PR TITLE
Expose Sentry initialization and make sample rate configurable

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -99,11 +99,19 @@ export const replayCommandHandler = async ({
     );
   }
 
-  const transaction = Sentry.startTransaction({
+  const rootTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+  const handlerSpanContext = {
     name: "replay.command_handler",
     description: "Handle the replay command",
     op: "replay.command_handler",
-  });
+  };
+  let transaction: Sentry.Span;
+  if (rootTransaction) {
+    transaction = rootTransaction.startChild(handlerSpanContext);
+  } else {
+    transaction = Sentry.startTransaction(handlerSpanContext);
+  }
+
   Sentry.getCurrentHub().configureScope((scope) => scope.setSpan(transaction));
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,3 +18,4 @@ export {
   TestRun,
 } from "./parallel-tests/run-all-tests";
 export { initLogger, setLogLevel } from "./utils/logger.utils";
+export { initSentry } from "./utils/sentry.utils";

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -13,7 +13,6 @@ import { showProjectCommand } from "./commands/show-project/show-project.command
 import { updateTestsCommand } from "./commands/update-tests/update-tests.command";
 import { initLogger, setLogLevel } from "./utils/logger.utils";
 import { initSentry, setOptions } from "./utils/sentry.utils";
-import { getMeticulousVersion } from "./utils/version.utils";
 
 const handleDataDir: (dataDir: string | null | undefined) => void = (
   dataDir
@@ -23,8 +22,7 @@ const handleDataDir: (dataDir: string | null | undefined) => void = (
 
 export const main: () => void = async () => {
   initLogger();
-  const meticulousVersion = await getMeticulousVersion();
-  initSentry(meticulousVersion);
+  await initSentry();
 
   yargs
     .scriptName("meticulous")

--- a/packages/cli/src/utils/sentry.utils.ts
+++ b/packages/cli/src/utils/sentry.utils.ts
@@ -3,24 +3,19 @@ import * as Sentry from "@sentry/node";
 import { addExtensionMethods } from "@sentry/tracing";
 import log from "loglevel";
 import { Duration } from "luxon";
+import { getMeticulousVersion } from "./version.utils";
 
 const SENTRY_DSN =
   "https://10c6a6c9f5434786b37fb81b01323798@o914390.ingest.sentry.io/6435232";
 const SENTRY_FLUSH_TIMEOUT = Duration.fromObject({ seconds: 1 });
 
 const getTracesSampleRate: () => number = () => {
-  if (
-    (process.env["METICULOUS_TELEMETRY_ENABLED"] ?? "true").toLowerCase() ==
-    "true"
-  ) {
-    return 1.0;
-  }
-  return 0.0;
+  return parseFloat(process.env["METICULOUS_TELEMETRY_SAMPLE_RATE"] ?? "1.0");
 };
 
-export const initSentry: (meticulousVersion: string) => void = (
-  meticulousVersion
-) => {
+export const initSentry: () => void = async () => {
+  const meticulousVersion = await getMeticulousVersion();
+
   Sentry.init({
     dsn: SENTRY_DSN,
     release: meticulousVersion,


### PR DESCRIPTION
The GitHub action calls the replay handler directly, skipping the init logic within the CLI.

This PR exposes the Sentry initialisation logic to enable recording GitHub action runs performance data.

Additionally this makes the sample rate configurable and handles cases where replay handler is called within a Sentry transaction (so action runs can be grouped in a single transaction) 