### PR TITLE
Allow skipping upload stage when replaying

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -50,6 +50,7 @@ import { addTestCase } from "../../utils/config.utils";
 import { getMeticulousVersion } from "../../utils/version.utils";
 import { ScreenshotDiffsSummary } from "../screenshot-diff/screenshot-diff.command";
 import { computeDiff } from "./utils/compute-diff";
+import { exitEarlyIfSkipUploadEnvVarSet } from "./utils/exit-early-if-skip-upload-env-var-set";
 
 export interface ReplayOptions extends AdditionalReplayOptions {
   replayTarget: ReplayTarget;
@@ -196,6 +197,9 @@ export const replayCommandHandler = async ({
   logger.info(
     `Simulation time: ${endTime.diff(startTime).as("seconds")} seconds`
   );
+
+  exitEarlyIfSkipUploadEnvVarSet(baseReplayId);
+
   logger.info("Sending simulation results to Meticulous");
 
   // 8. Create a Zip archive containing the replay files

--- a/packages/cli/src/commands/replay/utils/exit-early-if-skip-upload-env-var-set.ts
+++ b/packages/cli/src/commands/replay/utils/exit-early-if-skip-upload-env-var-set.ts
@@ -1,0 +1,32 @@
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import log from "loglevel";
+
+const METICULOUS_SKIP_UPLOAD_ENV_VAR = "METICULOUS_SKIP_UPLOAD";
+
+// Uploading the zip can take a long time, so we expose a env variable to support skipping it
+// We don't expose this as a first-class CLI option because we don't want to pollute the list of CLI options
+export const exitEarlyIfSkipUploadEnvVarSet = (
+  baseReplayId: string | null | undefined
+) => {
+  if (!shouldSkipUpload()) {
+    return;
+  }
+
+  if (baseReplayId != null) {
+    throw new Error(
+      `Cannot specify baseReplayId and compare to base results when ${METICULOUS_SKIP_UPLOAD_ENV_VAR} is set to true`
+    );
+  }
+
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  logger.info(
+    `Skipping upload / exiting early since ${METICULOUS_SKIP_UPLOAD_ENV_VAR} is set to true`
+  );
+  process.exit(0);
+};
+
+const shouldSkipUpload = () => {
+  return (
+    (process.env[METICULOUS_SKIP_UPLOAD_ENV_VAR] ?? "").toLowerCase() === "true"
+  );
+};


### PR DESCRIPTION
For many sessions uploading the archive takes up to 9 times as long as the replay itself, so being able to skip the upload stage can speed up testing (e.g. when running command repeatedly in a bash for loop to check for flakey issues).