### PR TITLE
Fix run-all-tests sentry

### DIFF
--- a/packages/cli/src/parallel-tests/execute-test-in-child-process.ts
+++ b/packages/cli/src/parallel-tests/execute-test-in-child-process.ts
@@ -10,7 +10,12 @@ export const executeTestInChildProcess = (
 ): Promise<DetailedTestCaseResult> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
-  const taskHandler = join(__dirname, "task.handler.js");
+  const isTypeScript = __filename.endsWith(".ts");
+
+  const taskHandler = join(
+    __dirname,
+    `task.handler${isTypeScript ? ".ts" : ".js"}`
+  );
 
   const deferredResult = defer<DetailedTestCaseResult>();
   const child = fork(taskHandler, [], { stdio: "inherit" });

--- a/packages/cli/src/parallel-tests/task.handler.ts
+++ b/packages/cli/src/parallel-tests/task.handler.ts
@@ -1,11 +1,12 @@
 import {
-  setMeticulousLocalDataDir,
   METICULOUS_LOGGER_NAME,
+  setMeticulousLocalDataDir,
 } from "@alwaysmeticulous/common";
 import log from "loglevel";
 import { Duration } from "luxon";
 import { deflakeReplayCommandHandler } from "../deflake-tests/deflake-tests.handler";
 import { initLogger } from "../utils/logger.utils";
+import { initSentry } from "../utils/sentry.utils";
 import { InitMessage, ResultMessage } from "./messages.types";
 
 const INIT_TIMEOUT = Duration.fromObject({ second: 1 });
@@ -37,6 +38,7 @@ const waitForInitMessage: () => Promise<InitMessage> = () => {
 
 const main = async () => {
   initLogger();
+  await initSentry();
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   if (!process.send) {

--- a/packages/cli/src/utils/sentry.utils.ts
+++ b/packages/cli/src/utils/sentry.utils.ts
@@ -13,14 +13,16 @@ const getTracesSampleRate: () => number = () => {
   return parseFloat(process.env["METICULOUS_TELEMETRY_SAMPLE_RATE"] ?? "1.0");
 };
 
-export const initSentry: () => Promise<Sentry.Hub> = async () => {
+export const initSentry: (
+  tracesSampleRateOverride?: number
+) => Promise<Sentry.Hub> = async (tracesSampleRateOverride) => {
   const meticulousVersion = await getMeticulousVersion();
 
   Sentry.init({
     dsn: SENTRY_DSN,
     release: meticulousVersion,
 
-    tracesSampleRate: getTracesSampleRate(),
+    tracesSampleRate: tracesSampleRateOverride ?? getTracesSampleRate(),
     environment: __filename.endsWith(".ts") ? "development" : "production",
   });
 

--- a/packages/cli/src/utils/sentry.utils.ts
+++ b/packages/cli/src/utils/sentry.utils.ts
@@ -21,6 +21,7 @@ export const initSentry: () => Promise<Sentry.Hub> = async () => {
     release: meticulousVersion,
 
     tracesSampleRate: getTracesSampleRate(),
+    environment: __filename.endsWith(".ts") ? "development" : "production",
   });
 
   addExtensionMethods();


### PR DESCRIPTION
This fixes Sentry when running simulations within a child process,
such as when running via `run-all-tests` or the Github Action.