### PR TITLE
Cleanup package.json and tsconfig.json

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json",
     "dev": "tsc --build tsconfig.json --watch",
     "format": "prettier --write src",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./src",
     /* Emit */

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "meticulous": "bin/meticulous"
   },
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json",
     "dev": "tsc --build tsconfig.json --watch",
     "format": "prettier --write src",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,14 +2,14 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./src",
     /* Emit */
     "outDir": "./dist",
     "paths": {
-        "*": [ "./src/custom-types/*"]
-    },
+      "*": ["./src/custom-types/*"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json",
     "dev": "tsc --build tsconfig.json --watch",
     "format": "prettier --write src",

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./src",
     /* Emit */

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json",
     "dev": "tsc --build tsconfig.json --watch",
     "format": "prettier --write src",

--- a/packages/record/tsconfig.json
+++ b/packages/record/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./src",
     /* Emit */

--- a/packages/recorder-loader/package.json
+++ b/packages/recorder-loader/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "dev": "parcel watch",
     "build": "parcel build",
     "format": "prettier --write src",

--- a/packages/recorder-loader/tsconfig.json
+++ b/packages/recorder-loader/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./src",
     /* Emit */

--- a/packages/replay-debugger-ui/tsconfig.scripts.json
+++ b/packages/replay-debugger-ui/tsconfig.scripts.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./scripts",
     /* Emit */

--- a/packages/replayer/package.json
+++ b/packages/replayer/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json",
     "dev": "tsc --build tsconfig.json --watch",
     "format": "prettier --write src",

--- a/packages/replayer/tsconfig.json
+++ b/packages/replayer/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./src",
     /* Emit */

--- a/packages/sdk-bundles-api/package.json
+++ b/packages/sdk-bundles-api/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json",
     "dev": "tsc --build tsconfig.json --watch",
     "format": "prettier --write src",

--- a/packages/sdk-bundles-api/tsconfig.json
+++ b/packages/sdk-bundles-api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     /* Projects */
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     /* Modules */
     "rootDir": "./src",
     /* Emit */


### PR DESCRIPTION
The `tsconfig.tsbuildinfo` file is a `tsc` build cache and should not be packaged in `./dist`.