### PR TITLE
improve test run typings and expose project within run-all-tests callbacks

### DIFF
--- a/packages/cli/src/api/test-run.api.ts
+++ b/packages/cli/src/api/test-run.api.ts
@@ -3,18 +3,7 @@ import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import axios, { AxiosError, AxiosInstance } from "axios";
 import log from "loglevel";
 import { TestCaseResult } from "../config/config.types";
-
-export type TestRunStatus = "Running" | "Success" | "Failure";
-
-export interface TestRun {
-  id: string;
-  status: TestRunStatus;
-  resultData?: {
-    results: TestCaseResult[];
-    [key: string]: any;
-  };
-  [key: string]: any;
-}
+import { TestRun, TestRunStatus } from "./types";
 
 export const getTestRun: (options: {
   client: AxiosInstance;
@@ -53,7 +42,7 @@ export const createTestRun: (options: {
 export const putTestRunResults: (options: {
   client: AxiosInstance;
   testRunId: string;
-  status: "Running" | "Success" | "Failure";
+  status: TestRunStatus;
   resultData: { [key: string]: any };
 }) => Promise<TestRun> = async ({ client, testRunId, status, resultData }) => {
   const { data } = await client.put(`test-runs/${testRunId}/results`, {

--- a/packages/cli/src/api/types.ts
+++ b/packages/cli/src/api/types.ts
@@ -1,0 +1,35 @@
+import { TestCaseResult } from "../config/config.types";
+
+interface Organization {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Project {
+  id: string;
+  name: string;
+  recordingToken: string;
+  apiToken: string;
+  isGitHubIntegrationActive: boolean;
+  url: string;
+
+  organization: Organization;
+
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type TestRunStatus = "Running" | "Success" | "Failure";
+
+export interface TestRun {
+  id: string;
+  status: TestRunStatus;
+  project: Project;
+  resultData?: {
+    results: TestCaseResult[];
+    [key: string]: any;
+  };
+  [key: string]: any;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,9 @@ export { updateTestsCommand } from "./commands/update-tests/update-tests.command
 export {
   runAllTests,
   RunAllTestsResult,
-  TestRun,
+  // Exported as `TestRun` as well to maintain backward compatibility.
+  RunAllTestsTestRun as TestRun,
+  RunAllTestsTestRun,
 } from "./parallel-tests/run-all-tests";
 export { initLogger, setLogLevel } from "./utils/logger.utils";
 export { initSentry } from "./utils/sentry.utils";


### PR DESCRIPTION
Exposing project data is needed for making the callback hooks logic within the
GitHub Action dependent on the properties of the project of the test run (e.g. 
whether the project has GitHub App integration enabled).