### PR TITLE
explicitly call URL observer start listening function

### DIFF
--- a/packages/replayer/src/replay.utils.ts
+++ b/packages/replayer/src/replay.utils.ts
@@ -5,9 +5,9 @@ import {
   ReplayEventsDependencies,
 } from "@alwaysmeticulous/common";
 import {
+  InstallVirtualEventLoopOpts,
   OnReplayTimelineEventFn,
   VirtualTimeOptions,
-  InstallVirtualEventLoopOpts,
 } from "@alwaysmeticulous/sdk-bundles-api";
 import log from "loglevel";
 import { DateTime, Duration } from "luxon";
@@ -116,13 +116,22 @@ export const createReplayPage = async ({
   }
 
   // Setup the url-observer snippet
-  if (!essentialFeaturesOnly) {
-    const urlObserverFile = await readFile(
-      dependencies.browserUrlObserver.location,
-      "utf-8"
-    );
-    await page.evaluateOnNewDocument(urlObserverFile);
+  const urlObserverFile = await readFile(
+    dependencies.browserUrlObserver.location,
+    "utf-8"
+  );
+  await page.evaluateOnNewDocument(urlObserverFile);
 
+  if (!essentialFeaturesOnly) {
+    await page.evaluateOnNewDocument(`
+      const urlObserverStartListening = window.__meticulous?.urlObserver?.startListening;
+      if(urlObserverStartListening) {
+        urlObserverStartListening();
+      }
+    `);
+  }
+
+  if (!essentialFeaturesOnly) {
     // Collect js coverage data
     await page.coverage.startJSCoverage({ resetOnNavigation: false });
   }


### PR DESCRIPTION
The expectation going forward is for the URL observer bundle to be present on all pages as other bundles depend on functions it exposes.

Newer versions of the URL observer bundle won't start the observer by default, in order to enable conditional listening.