### PR TITLE
Per test-case appUrl support

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -29,6 +29,7 @@ const validateReplayOptions: (
   options: TestCaseReplayOptions
 ) => TestCaseReplayOptions = (prevOptions) => {
   const {
+    appUrl,
     screenshotSelector,
     diffThreshold,
     diffPixelThreshold,
@@ -36,6 +37,7 @@ const validateReplayOptions: (
     simulationIdForAssets,
   } = prevOptions;
   return {
+    ...(appUrl != null ? { appUrl } : {}),
     ...(screenshotSelector != null ? { screenshotSelector } : {}),
     ...(diffThreshold != null ? { diffThreshold } : {}),
     ...(diffPixelThreshold != null ? { diffPixelThreshold } : {}),

--- a/packages/cli/src/utils/config.utils.ts
+++ b/packages/cli/src/utils/config.utils.ts
@@ -40,6 +40,16 @@ export const getReplayTargetForTestCase = ({
       simulationIdForAssets: testCase.baseReplayId,
     };
   }
+
+  if (testCase.options?.appUrl) {
+    if (appUrl) {
+      throw new Error(
+        `Test cases "${testCase.title}" has an "appUrl" option but --appUrl is also provided.`
+      );
+    }
+
+    return { type: "url", appUrl: testCase.options.appUrl };
+  }
   if (appUrl) {
     return { type: "url", appUrl };
   }


### PR DESCRIPTION
### Changes

This PR fixes the CLI support for specifying `appUrl` per test case via the `replay option`. Type-wise it was already supported though we didn't consume the `appUrl` correctly, this fixes it and also updates the replay target generation to take into account the replay option `appUrl` if set. 

Have made `--appUrl` and the per-test-case `appUrl` mutually-exclusive as it can lead to priority confusion but do shout it you think there are cases where we should allow doing this!