### PR TITLE
don't export unknown as timeline entry type

### DIFF
--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/timeline.types.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/timeline.types.ts
@@ -34,6 +34,6 @@ export interface FatalErrorTimelineEntry extends GenericReplayTimelineEntry {
  * The Meticulous BE code internally uses additional timeline entries, but these
  * types are stored seperately.
  */
-export type SDKReplayTimelineEntry = FatalErrorTimelineEntry | unknown;
+export type SDKReplayTimelineEntry = FatalErrorTimelineEntry;
 
 export type SDKReplayTimelineData = SDKReplayTimelineEntry[];


### PR DESCRIPTION
Having `unknown` as a type complicates the consumption of this field within the monorepo.