### PR TITLE
drop deflake logic from parallel tests

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -37,7 +37,6 @@ export interface TestRunArguments {
   baseCommitSha?: string | null;
   appUrl?: string | null;
   parallelTasks?: number | null;
-  deflake?: boolean;
   githubSummary?: boolean;
   [key: string]: unknown;
 }

--- a/packages/cli/src/commands/bootstrap/bootstrap.command.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.command.ts
@@ -22,7 +22,7 @@ const handler: (options: Options) => Promise<void> = async () => {
   logger.info(`Setting up ${chalk.green("test:meticulous")} script...`);
   await npmSetScript({
     script: "test:meticulous",
-    command: "meticulous run-all-tests --headless --parallelize --deflake",
+    command: "meticulous run-all-tests --headless --parallelize",
   });
 };
 

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -27,7 +27,6 @@ interface Options
   githubSummary: boolean;
   parallelize: boolean;
   parallelTasks?: number | null | undefined;
-  deflake: boolean;
   maxRetriesOnFailure: number;
   useCache: boolean;
   testsFile?: string | undefined;
@@ -52,7 +51,6 @@ const handler: (options: Options) => Promise<void> = async ({
   githubSummary,
   parallelize,
   parallelTasks: parrelelTasks_,
-  deflake,
   maxRetriesOnFailure,
   useCache,
   testsFile,
@@ -106,7 +104,6 @@ const handler: (options: Options) => Promise<void> = async ({
     baseTestRunId: baseTestRunId ?? null,
     appUrl: appUrl ?? null,
     parallelTasks: parrelelTasks ?? null,
-    deflake,
     maxRetriesOnFailure,
     cachedTestRunResults,
     githubSummary,
@@ -152,11 +149,6 @@ export const runAllTestsCommand = buildCommand("run-all-tests")
         }
         return value;
       },
-    },
-    deflake: {
-      boolean: true,
-      description: "Attempt to deflake failing tests",
-      default: false,
     },
     maxRetriesOnFailure: {
       number: true,

--- a/packages/cli/src/parallel-tests/messages.types.ts
+++ b/packages/cli/src/parallel-tests/messages.types.ts
@@ -1,13 +1,13 @@
 import log from "loglevel";
 import { DetailedTestCaseResult } from "../config/config.types";
-import { DeflakeReplayCommandHandlerOptions } from "../deflake-tests/deflake-tests.handler";
+import { ParallelTestsReplayOptions } from "./parallel-replay.types";
 
 export interface InitMessage {
   kind: "init";
   data: {
     logLevel: log.LogLevel[keyof log.LogLevel];
     dataDir: string;
-    replayOptions: DeflakeReplayCommandHandlerOptions;
+    replayOptions: ParallelTestsReplayOptions;
   };
 }
 

--- a/packages/cli/src/parallel-tests/parallel-replay.types.ts
+++ b/packages/cli/src/parallel-tests/parallel-replay.types.ts
@@ -1,0 +1,22 @@
+import {
+  GeneratedBy,
+  ReplayEventsDependencies,
+  ReplayExecutionOptions,
+  ReplayTarget,
+} from "@alwaysmeticulous/common";
+import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-types";
+import { TestCase } from "@alwaysmeticulous/api";
+
+export interface ParallelTestsReplayOptions {
+  replayTarget: ReplayTarget;
+  executionOptions: ReplayExecutionOptions;
+  screenshottingOptions: ScreenshotAssertionsEnabledOptions;
+  testCase: TestCase;
+  apiToken: string | null;
+  commitSha: string;
+  generatedBy: GeneratedBy;
+  testRunId: string | null;
+  baseTestRunId: string | null;
+  replayEventsDependencies: ReplayEventsDependencies;
+  suppressScreenshotDiffLogging: boolean;
+}

--- a/packages/cli/src/parallel-tests/parallel-replay.types.ts
+++ b/packages/cli/src/parallel-tests/parallel-replay.types.ts
@@ -1,3 +1,4 @@
+import { TestCase } from "@alwaysmeticulous/api";
 import {
   GeneratedBy,
   ReplayEventsDependencies,
@@ -5,7 +6,6 @@ import {
   ReplayTarget,
 } from "@alwaysmeticulous/common";
 import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-types";
-import { TestCase } from "@alwaysmeticulous/api";
 
 export interface ParallelTestsReplayOptions {
   replayTarget: ReplayTarget;

--- a/packages/cli/src/parallel-tests/run-all-tests.ts
+++ b/packages/cli/src/parallel-tests/run-all-tests.ts
@@ -58,7 +58,6 @@ export interface Options {
    * Set to 1 to disable parralelism.
    */
   parallelTasks: number | null;
-  deflake: boolean;
 
   /**
    * If set to a value greater than 1 then will re-run any replays that give a screenshot diff
@@ -108,7 +107,6 @@ export const runAllTests = async ({
   executionOptions,
   screenshottingOptions,
   parallelTasks,
-  deflake,
   maxRetriesOnFailure,
   cachedTestRunResults: cachedTestRunResults_,
   githubSummary,
@@ -117,12 +115,6 @@ export const runAllTests = async ({
   onTestRunCreated,
   onTestFinished: onTestFinished_,
 }: Options): Promise<RunAllTestsResult> => {
-  if (deflake && maxRetriesOnFailure > 1) {
-    throw new Error(
-      "Arguments deflake and maxRetriesOnFailure are mutually exclusive"
-    );
-  }
-
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   const client = createClient({ apiToken });
@@ -174,7 +166,6 @@ export const runAllTests = async ({
         baseCommitSha,
         appUrl,
         parallelTasks,
-        deflake,
         githubSummary,
       },
       environment: getEnvironment(environment),
@@ -283,7 +274,6 @@ export const runAllTests = async ({
             apiToken,
             commitSha,
             testCase,
-            deflake,
             replayTarget: getReplayTargetForTestCase({
               appUrl,
               testCase,

--- a/packages/cli/src/parallel-tests/task.handler.ts
+++ b/packages/cli/src/parallel-tests/task.handler.ts
@@ -5,10 +5,10 @@ import {
 import * as Sentry from "@sentry/node";
 import log from "loglevel";
 import { Duration } from "luxon";
-import { deflakeReplayCommandHandler } from "../deflake-tests/deflake-tests.handler";
 import { initLogger } from "../utils/logger.utils";
 import { initSentry, SENTRY_FLUSH_TIMEOUT } from "../utils/sentry.utils";
 import { InitMessage, ResultMessage } from "./messages.types";
+import { handleReplay } from "./parallel-replay.handler";
 
 const INIT_TIMEOUT = Duration.fromObject({ second: 1 });
 
@@ -53,7 +53,7 @@ const main = async () => {
   logger.setLevel(logLevel);
   setMeticulousLocalDataDir(dataDir);
 
-  const result = await deflakeReplayCommandHandler(replayOptions);
+  const result = await handleReplay(replayOptions);
   const resultMessage: ResultMessage = {
     kind: "result",
     data: {


### PR DESCRIPTION
This is now handled via `maxRetriesOnFailure`.