### PR TITLE
Add flag to re-run tests multiple times

### DIFF
--- a/packages/api/src/replay/replay-diff.types.ts
+++ b/packages/api/src/replay/replay-diff.types.ts
@@ -117,7 +117,7 @@ export interface ScreenshotDiffResultFlake {
   outcome: "flake";
 
   /**
-   * The original diff. Can be any outcome but for 'no-diff'.
+   * The original diff. Can be any outcome.
    */
   diffToBaseScreenshot: SingleTryScreenshotDiffResult;
 

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -28,6 +28,7 @@ interface Options
   parallelize: boolean;
   parallelTasks?: number | null | undefined;
   maxRetriesOnFailure: number;
+  rerunTestsNTimes: number;
   useCache: boolean;
   testsFile?: string | undefined;
   maxDurationMs: number | null | undefined;
@@ -52,6 +53,7 @@ const handler: (options: Options) => Promise<void> = async ({
   parallelize,
   parallelTasks: parrelelTasks_,
   maxRetriesOnFailure,
+  rerunTestsNTimes,
   useCache,
   testsFile,
   disableRemoteFonts,
@@ -105,6 +107,7 @@ const handler: (options: Options) => Promise<void> = async ({
     appUrl: appUrl ?? null,
     parallelTasks: parrelelTasks ?? null,
     maxRetriesOnFailure,
+    rerunTestsNTimes,
     cachedTestRunResults,
     githubSummary,
   });
@@ -154,6 +157,12 @@ export const runAllTestsCommand = buildCommand("run-all-tests")
       number: true,
       description:
         "If set to a value greater than 0 then will re-run any replays that give a screenshot diff and mark them as a flake if the screenshot generated on one of the retryed replays differs from that in the first replay.",
+      default: 0,
+    },
+    rerunTestsNTimes: {
+      number: true,
+      description:
+        "If set to a value greater than 0 then will re-run all replays the specified number of times and mark them as a flake if the screenshot generated on one of the retryed replays differs from that in the first replay.",
       default: 0,
     },
     useCache: {

--- a/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
+++ b/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
@@ -123,4 +123,16 @@ describe("mergeResults", () => {
       ])
     );
   });
+
+  it("returns a fail outcome if the original outcome was a pass and there are flakes", () => {
+    const currentResult = testResult("pass", [noDiff(0), noDiff(1)]);
+    const comparisonToHeadReplay = testResult("fail", [diff(0), noDiff(1)]);
+    const mergedResult = mergeResults({
+      currentResult,
+      comparisonToHeadReplay,
+    });
+    expect(mergedResult).toEqual(
+      testResult("fail", [flake(0, noDiff(), [diff()]), noDiff(1)])
+    );
+  });
 });

--- a/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
+++ b/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
@@ -123,16 +123,4 @@ describe("mergeResults", () => {
       ])
     );
   });
-
-  it("returns a fail outcome if the original outcome was a pass and there are flakes", () => {
-    const currentResult = testResult("pass", [noDiff(0), noDiff(1)]);
-    const comparisonToHeadReplay = testResult("fail", [diff(0), noDiff(1)]);
-    const mergedResult = mergeResults({
-      currentResult,
-      comparisonToHeadReplay,
-    });
-    expect(mergedResult).toEqual(
-      testResult("fail", [flake(0, noDiff(), [diff()]), noDiff(1)])
-    );
-  });
 });

--- a/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
+++ b/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
@@ -29,7 +29,8 @@ describe("mergeResults", () => {
       comparisonToHeadReplay,
     });
     expect(mergedResult).toEqual(
-      testResult("fail", [noDiff(0), flake(1, noDiff(), [diff()])])
+      // All screenshots are either "no-diff" or "flake" thus the overall result is "flake"
+      testResult("flake", [noDiff(0), flake(1, noDiff(), [diff()])])
     );
   });
 

--- a/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
+++ b/packages/cli/src/parallel-tests/__tests__/merge-test-results.spec.ts
@@ -21,14 +21,16 @@ describe("mergeResults", () => {
     expect(mergedResult).toEqual(testResult("fail", [diff(0), noDiff(1)]));
   });
 
-  it("ignores diffs to screenshots which originally passed", () => {
+  it("doesn't ignore diffs to screenshots which originally passed", () => {
     const currentResult = testResult("pass", [noDiff(0), noDiff(1)]);
     const comparisonToHeadReplay = testResult("fail", [noDiff(0), diff(1)]);
     const mergedResult = mergeResults({
       currentResult,
       comparisonToHeadReplay,
     });
-    expect(mergedResult).toEqual(testResult("pass", [noDiff(0), noDiff(1)]));
+    expect(mergedResult).toEqual(
+      testResult("fail", [noDiff(0), flake(1, noDiff(), [diff()])])
+    );
   });
 
   it("marks screenshots as flakes if the screenshot comparison originally failed, but the second retry gives a different screenshot again", () => {

--- a/packages/cli/src/parallel-tests/__tests__/parrallel-tests.handler.spec.ts
+++ b/packages/cli/src/parallel-tests/__tests__/parrallel-tests.handler.spec.ts
@@ -233,7 +233,7 @@ describe("runAllTestsInParallel", () => {
     expect(results).toEqual([
       testResult(
         // Flake outcome is returned iff all screenshots are flaky.
-        "fail",
+        "flake",
         [flake(0, diff(), [missingHead()]), flake(1, noDiff(), [diff()])],
         testCase(0)
       ),

--- a/packages/cli/src/parallel-tests/__tests__/parrallel-tests.handler.spec.ts
+++ b/packages/cli/src/parallel-tests/__tests__/parrallel-tests.handler.spec.ts
@@ -209,8 +209,6 @@ describe("runAllTestsInParallel", () => {
 
   it("retries N times if rerunTestsNTimes > 0", async () => {
     let rerunNum = 0;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    // const { baseTestRunId, ...testCaseWithoutBase } = testCase(0);
     const results = await runAllTestsInParallel({
       testsToRun: [testCase(0)],
       parallelTasks: 2,

--- a/packages/cli/src/parallel-tests/__tests__/parrallel-tests.handler.spec.ts
+++ b/packages/cli/src/parallel-tests/__tests__/parrallel-tests.handler.spec.ts
@@ -25,6 +25,7 @@ describe("runAllTestsInParallel", () => {
       testsToRun: [testCase(0), testCase(1), testCase(2), testCase(3)],
       parallelTasks: 2,
       maxRetriesOnFailure: 0,
+      rerunTestsNTimes: 0,
       executeTest: async (
         testCase: TestCase
       ): Promise<DetailedTestCaseResult> => {
@@ -96,6 +97,7 @@ describe("runAllTestsInParallel", () => {
       testsToRun: [testCase(0), testCase(1), testCase(2), testCase(3)],
       parallelTasks: 2,
       maxRetriesOnFailure: 0,
+      rerunTestsNTimes: 0,
       executeTest: async (
         testCase: TestCase
       ): Promise<DetailedTestCaseResult> => {
@@ -133,6 +135,7 @@ describe("runAllTestsInParallel", () => {
       testsToRun: [testCase(0)],
       parallelTasks: 2,
       maxRetriesOnFailure: 0,
+      rerunTestsNTimes: 0,
       executeTest: async (
         testCase: TestCase
       ): Promise<DetailedTestCaseResult> => {
@@ -149,6 +152,7 @@ describe("runAllTestsInParallel", () => {
       testsToRun: [testCase(0)],
       parallelTasks: 2,
       maxRetriesOnFailure: 10,
+      rerunTestsNTimes: 0,
       executeTest: async (
         testCase: TestCase,
         isRetry
@@ -182,6 +186,7 @@ describe("runAllTestsInParallel", () => {
       testsToRun: [testCase(0)],
       parallelTasks: 2,
       maxRetriesOnFailure: 3,
+      rerunTestsNTimes: 0,
       executeTest: async (
         testCase: TestCase,
         isRetry
@@ -197,6 +202,41 @@ describe("runAllTestsInParallel", () => {
       testResult(
         "fail",
         [diff(0), flake(1, diff(), [diff(), diff(), diff()])],
+        testCase(0)
+      ),
+    ]);
+  });
+
+  it("retries N times if rerunTestsNTimes > 0", async () => {
+    let rerunNum = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // const { baseTestRunId, ...testCaseWithoutBase } = testCase(0);
+    const results = await runAllTestsInParallel({
+      testsToRun: [testCase(0)],
+      parallelTasks: 2,
+      maxRetriesOnFailure: 0,
+      rerunTestsNTimes: 3,
+      executeTest: async (
+        testCase: TestCase,
+        isRetry
+      ): Promise<DetailedTestCaseResult> => {
+        if (!isRetry) {
+          return testResult("pass", [diff(0), noDiff(1)], testCase);
+        }
+        if (rerunNum === 2) {
+          return testResult("fail", [missingHead(0), diff(1)], testCase);
+        }
+        rerunNum++;
+        return testResult("pass", [noDiff(0), noDiff(1)], testCase);
+      },
+    });
+
+    expect(rerunNum).toEqual(2);
+    expect(results).toEqual([
+      testResult(
+        // Flake outcome is returned iff all screenshots are flaky.
+        "fail",
+        [flake(0, diff(), [missingHead()]), flake(1, noDiff(), [diff()])],
         testCase(0)
       ),
     ]);

--- a/packages/cli/src/parallel-tests/merge-test-results.ts
+++ b/packages/cli/src/parallel-tests/merge-test-results.ts
@@ -42,9 +42,6 @@ export const mergeResults = ({
   const newScreenshotDiffResults = flattenScreenshotDiffResults(
     currentResult
   ).map((currentDiff): ScreenshotDiffResultWithBaseReplayId => {
-    if (currentDiff.outcome === "no-diff") {
-      return currentDiff;
-    }
     const hash = hashScreenshotIdentifier(currentDiff.identifier);
     const diffWhenRetrying = retryDiffById.get(hash);
 

--- a/packages/cli/src/parallel-tests/merge-test-results.ts
+++ b/packages/cli/src/parallel-tests/merge-test-results.ts
@@ -1,5 +1,7 @@
-import { ScreenshotIdentifier } from "@alwaysmeticulous/api";
-import { SingleTryScreenshotDiffResult } from "@alwaysmeticulous/api/dist/replay/replay-diff.types";
+import {
+  ScreenshotIdentifier,
+  SingleTryScreenshotDiffResult,
+} from "@alwaysmeticulous/api";
 import { logger } from "@sentry/utils";
 import stringify from "fast-json-stable-stringify";
 import { DetailedTestCaseResult } from "../config/config.types";
@@ -108,6 +110,9 @@ export const mergeResults = ({
     result:
       currentResult.result === "fail" && noLongerHasFailures
         ? "flake"
+        : currentResult.result === "pass" &&
+          comparisonToHeadReplay.result === "fail"
+        ? "fail"
         : currentResult.result,
     screenshotDiffResultsByBaseReplayId: groupScreenshotDiffResults(
       newScreenshotDiffResults

--- a/packages/cli/src/parallel-tests/merge-test-results.ts
+++ b/packages/cli/src/parallel-tests/merge-test-results.ts
@@ -1,15 +1,17 @@
 import {
+  ScreenshotDiffResult,
   ScreenshotIdentifier,
   SingleTryScreenshotDiffResult,
 } from "@alwaysmeticulous/api";
 import { logger } from "@sentry/utils";
 import stringify from "fast-json-stable-stringify";
-import { DetailedTestCaseResult } from "../config/config.types";
+import { DetailedTestCaseResult, TestCaseResult } from "../config/config.types";
 import {
   flattenScreenshotDiffResults,
   groupScreenshotDiffResults,
   ScreenshotDiffResultWithBaseReplayId,
 } from "./screenshot-diff-results.utils";
+import { hasNotableDifferences } from "../commands/screenshot-diff/utils/has-notable-differences";
 
 export interface ResultsToMerge {
   currentResult: DetailedTestCaseResult;
@@ -101,19 +103,12 @@ export const mergeResults = ({
     }
   });
 
-  const noLongerHasFailures = newScreenshotDiffResults.every(
-    ({ outcome }) => outcome === "flake" || outcome === "no-diff"
-  );
-
   return {
     ...currentResult,
-    result:
-      currentResult.result === "fail" && noLongerHasFailures
-        ? "flake"
-        : currentResult.result === "pass" &&
-          comparisonToHeadReplay.result === "fail"
-        ? "fail"
-        : currentResult.result,
+    result: testRunOutcomeFromDiffResults(
+      currentResult.result,
+      newScreenshotDiffResults
+    ),
     screenshotDiffResultsByBaseReplayId: groupScreenshotDiffResults(
       newScreenshotDiffResults
     ),
@@ -154,4 +149,29 @@ const unknownScreenshotIdentifierType = (identifier: never) => {
   logger.error(
     `Unknown type of screenshot identifier: ${JSON.stringify(identifier)}`
   );
+};
+
+export const testRunOutcomeFromDiffResults = (
+  currentResult: TestCaseResult["result"],
+  newScreenshotDiffResults: ScreenshotDiffResult[]
+): TestCaseResult["result"] => {
+  // If a test run is already flakey, we don't want to overwrite that with a 'fail' result.
+  if (currentResult === "flake") {
+    return "flake";
+  }
+
+  const hasOnlyFlakes = newScreenshotDiffResults.every(
+    ({ outcome }) => outcome === "flake" || outcome === "no-diff"
+  );
+
+  if (hasOnlyFlakes) {
+    return "flake";
+  }
+
+  // If we've had a test run has already failed, we don't want to overwrite that with a 'pass' result.
+  // Otherwise, if there are any notable differences, we want to fail the test run.
+  return currentResult === "fail" ||
+    hasNotableDifferences(newScreenshotDiffResults)
+    ? "fail"
+    : "pass";
 };

--- a/packages/cli/src/parallel-tests/merge-test-results.ts
+++ b/packages/cli/src/parallel-tests/merge-test-results.ts
@@ -5,13 +5,13 @@ import {
 } from "@alwaysmeticulous/api";
 import { logger } from "@sentry/utils";
 import stringify from "fast-json-stable-stringify";
+import { hasNotableDifferences } from "../commands/screenshot-diff/utils/has-notable-differences";
 import { DetailedTestCaseResult, TestCaseResult } from "../config/config.types";
 import {
   flattenScreenshotDiffResults,
   groupScreenshotDiffResults,
   ScreenshotDiffResultWithBaseReplayId,
 } from "./screenshot-diff-results.utils";
-import { hasNotableDifferences } from "../commands/screenshot-diff/utils/has-notable-differences";
 
 export interface ResultsToMerge {
   currentResult: DetailedTestCaseResult;

--- a/packages/cli/src/parallel-tests/run-all-tests.ts
+++ b/packages/cli/src/parallel-tests/run-all-tests.ts
@@ -20,7 +20,7 @@ import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-type
 import { readConfig } from "../config/config";
 import { DetailedTestCaseResult, TestCaseResult } from "../config/config.types";
 import { loadReplayEventsDependencies } from "../local-data/replay-assets";
-import { runAllTestsInParallel } from "../parallel-tests/parallel-tests.handler";
+import { runAllTestsInParallel } from "./parallel-tests.handler";
 import { getReplayTargetForTestCase } from "../utils/config.utils";
 import { writeGitHubSummary } from "../utils/github-summary.utils";
 import { mergeTestCases, sortResults } from "../utils/run-all-tests.utils";
@@ -66,6 +66,17 @@ export interface Options {
    */
   maxRetriesOnFailure: number;
 
+  /**
+   * If set to a value greater than 0 then will re-run all replays the specified number of times
+   * and mark them as a flake if the screenshot generated on one of the retryed replays differs from that
+   * in the first replay.
+   *
+   * This is useful for checking flake rates.
+   *
+   * This option is mutually exclusive with maxRetriesOnFailure.
+   */
+  rerunTestsNTimes: number;
+
   githubSummary: boolean;
 
   /**
@@ -108,6 +119,7 @@ export const runAllTests = async ({
   screenshottingOptions,
   parallelTasks,
   maxRetriesOnFailure,
+  rerunTestsNTimes,
   cachedTestRunResults: cachedTestRunResults_,
   githubSummary,
   environment,
@@ -264,6 +276,7 @@ export const runAllTests = async ({
     testsToRun,
     parallelTasks,
     maxRetriesOnFailure,
+    rerunTestsNTimes,
     executeTest: (testCase, isRetry) => {
       const initMessage: InitMessage = {
         kind: "init",

--- a/packages/cli/src/parallel-tests/run-all-tests.ts
+++ b/packages/cli/src/parallel-tests/run-all-tests.ts
@@ -20,7 +20,6 @@ import { ScreenshotAssertionsEnabledOptions } from "../command-utils/common-type
 import { readConfig } from "../config/config";
 import { DetailedTestCaseResult, TestCaseResult } from "../config/config.types";
 import { loadReplayEventsDependencies } from "../local-data/replay-assets";
-import { runAllTestsInParallel } from "./parallel-tests.handler";
 import { getReplayTargetForTestCase } from "../utils/config.utils";
 import { writeGitHubSummary } from "../utils/github-summary.utils";
 import { mergeTestCases, sortResults } from "../utils/run-all-tests.utils";
@@ -28,6 +27,7 @@ import { getEnvironment } from "../utils/test-run-environment.utils";
 import { getMeticulousVersion } from "../utils/version.utils";
 import { executeTestInChildProcess } from "./execute-test-in-child-process";
 import { InitMessage } from "./messages.types";
+import { runAllTestsInParallel } from "./parallel-tests.handler";
 import { TestRunProgress } from "./run-all-tests.types";
 
 export type RunAllTestsTestRun = Pick<


### PR DESCRIPTION
### Changes

This PR adds an optional argument to `runAllTests`. As name suggests it runs tests up to N times, regardless of whether it has a difference to base on the head run.

This is useful for determining flake rate of a given session.