### PR TITLE
Expand list of test cases to run with those from the base test run

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -107,6 +107,7 @@ export interface TestRun {
   id: string;
   status: TestRunStatus;
   project: Project;
+  configData: TestRunConfigData;
   resultData?: {
     results: TestCaseResult[];
     [key: string]: any;

--- a/packages/replay-orchestrator/src/test-run/parallel-tests/run-all-tests.ts
+++ b/packages/replay-orchestrator/src/test-run/parallel-tests/run-all-tests.ts
@@ -19,7 +19,6 @@ import {
   ReplayExecutionOptions,
 } from "@alwaysmeticulous/common";
 import { loadReplayEventsDependencies } from "@alwaysmeticulous/download-helpers/dist/scripts/replay-assets";
-import { AxiosInstance } from "axios";
 import log from "loglevel";
 import { createReplayDiff } from "../../api/replay-diff.api";
 import {
@@ -167,8 +166,7 @@ export const runAllTests = async ({
   const shouldIncludeBaseTestCases =
     !!fallbackTestRun &&
     (await shouldUseBaseTestRunTestCases({
-      client,
-      baseTestRunId: fallbackTestRun.id,
+      baseTestRun: fallbackTestRun,
     }));
 
   // We merge the test cases from the project config, the meticulous.json and the "fallback"(run-all-tests-level)
@@ -420,16 +418,12 @@ const getTestCasesWithBaseTestRunId = async ({
 };
 
 const shouldUseBaseTestRunTestCases = async ({
-  client,
-  baseTestRunId,
+  baseTestRun,
 }: {
-  client: AxiosInstance;
-  baseTestRunId: string;
+  baseTestRun: TestRun;
 }) => {
-  const testRun = await getTestRun({ client, testRunId: baseTestRunId });
-
   // We only want to include the test cases from the base test run if it has no base test run itself, i.e the
   // the base test run is for a "push" event.
   // This safeguards against the test run expanding indefinitely.
-  return !testRun?.configData?.baseTestRunId;
+  return !baseTestRun?.configData?.baseTestRunId;
 };


### PR DESCRIPTION
This PR updates the `runAllTests` logic to expand the list of test cases to include those from the base test run. This is necessary to prevent a drop in coverage when the project config test cases are updated. Such updates have the potential to entirely replace the set of sessions to run and will occur more frequently in the future.