### PR TITLE
Decouple replay debugger from rest of replay code

### DIFF
--- a/packages/api/src/project.types.ts
+++ b/packages/api/src/project.types.ts
@@ -10,6 +10,7 @@ export interface Project {
   configurationData: ProjectConfigurationData;
   createdAt: string;
   updatedAt: string;
+  isGitHubIntegrationActive?: boolean;
 }
 
 export interface ProjectConfigurationData {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,13 +32,15 @@
     "@alwaysmeticulous/common": "^2.41.0",
     "@alwaysmeticulous/downloading-helpers": "^2.41.0",
     "@alwaysmeticulous/record": "^2.41.0",
+    "@alwaysmeticulous/replay-debugger-ui": "^2.40.3",
     "@alwaysmeticulous/replay-orchestrator": "^2.41.0",
     "@alwaysmeticulous/sdk-bundles-api": "^2.41.0",
     "@alwaysmeticulous/sentry": "^2.40.0",
     "@sentry/node": "^7.36.0",
     "axios": "^1.2.6",
     "loglevel": "^1.8.0",
-    "yargs": "^17.5.1"
+    "yargs": "^17.5.1",
+    "puppeteer": "^19.7.5"
   },
   "devDependencies": {
     "@types/yargs": "^17.0.10"

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -12,7 +12,7 @@ import {
   ReplayTarget,
   StoryboardOptions,
   BeforeUserEventOptions,
-  OnBeforeNextEventResult,
+  BeforeUserEventResult,
 } from "@alwaysmeticulous/sdk-bundles-api";
 import { buildCommand } from "../../command-utils/command-builder";
 import {
@@ -123,7 +123,7 @@ export const rawReplayCommandHandler = async ({
 
   const getOnBeforeUserEventCallback =
     defer<
-      (options: BeforeUserEventOptions) => Promise<OnBeforeNextEventResult>
+      (options: BeforeUserEventOptions) => Promise<BeforeUserEventResult>
     >();
   const getOnClosePageCallback = defer<() => Promise<void>>();
 

--- a/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
+++ b/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
@@ -3,7 +3,7 @@ import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import { startUIServer } from "@alwaysmeticulous/replay-debugger-ui";
 import {
   BeforeUserEventOptions,
-  OnBeforeNextEventResult,
+  BeforeUserEventResult,
 } from "@alwaysmeticulous/sdk-bundles-api";
 import log from "loglevel";
 import { launch, Browser, Page } from "puppeteer";
@@ -26,7 +26,7 @@ export interface ReplayDebuggerUI {
 
 type OnBeforeUserEventCallback = (
   options: BeforeUserEventOptions
-) => Promise<OnBeforeNextEventResult>;
+) => Promise<BeforeUserEventResult>;
 
 export interface StepThroughDebuggerUI {
   onBeforeUserEvent: OnBeforeUserEventCallback;
@@ -81,11 +81,11 @@ export const openStepThroughDebuggerUI = async ({
     await setState(state);
   };
 
-  let advanceToEvent: ((advanceTo: OnBeforeNextEventResult) => void) | null =
+  let advanceToEvent: ((advanceTo: BeforeUserEventResult) => void) | null =
     null;
   const onBeforeUserEvent = async ({
     userEventIndex,
-  }: BeforeUserEventOptions): Promise<OnBeforeNextEventResult> => {
+  }: BeforeUserEventOptions): Promise<BeforeUserEventResult> => {
     await setState({
       loading: userEventIndex < targetIndex,
       index: Math.max(0, Math.min(state.events.length - 1, userEventIndex)),
@@ -96,7 +96,7 @@ export const openStepThroughDebuggerUI = async ({
       return { nextEventIndexToPauseBefore: targetIndex }; // keep going
     }
 
-    return new Promise<OnBeforeNextEventResult>((resolve) => {
+    return new Promise<BeforeUserEventResult>((resolve) => {
       advanceToEvent = resolve;
     });
   };

--- a/packages/replay-debugger-ui/scripts/index.ts
+++ b/packages/replay-debugger-ui/scripts/index.ts
@@ -4,21 +4,24 @@ import { resolve } from "path";
 const PORT = 3005;
 
 export interface Server {
+  url: string;
   close: () => void;
 }
 
-export const startServer: () => Promise<Server> = async () => {
+export const startUIServer: () => Promise<Server> = async () => {
   const workDir = resolve(__dirname, "..");
 
   const child = spawn("serve", ["-s", "-p", `${PORT}`, "out"], {
     cwd: workDir,
   });
 
+  const url = `http://localhost:${PORT}`;
+
   const startedLogPromise = new Promise<void>((resolve) => {
     child.stdout.on("data", (data) => {
       if (`${data}`.includes("Accepting connections")) {
         resolve();
-        console.log("Server started");
+        console.log(`UI Server started at ${url}`);
         child.stdout.removeAllListeners();
       }
     });
@@ -35,6 +38,7 @@ export const startServer: () => Promise<Server> = async () => {
   };
 
   return {
+    url,
     close,
   };
 };

--- a/packages/replay-orchestrator/src/api/replay.api.ts
+++ b/packages/replay-orchestrator/src/api/replay.api.ts
@@ -1,21 +1,23 @@
 import { Replay } from "@alwaysmeticulous/api";
 import axios, { AxiosInstance } from "axios";
 
-export const createReplay: (options: {
+export interface CreateReplayOptions {
   client: AxiosInstance;
   commitSha: string;
   sessionId: string;
   meticulousSha: string;
   version: "v1" | "v2";
   metadata: { [key: string]: any };
-}) => Promise<Replay> = async ({
+}
+
+export const createReplay = async ({
   client,
   commitSha,
   sessionId,
   meticulousSha,
   version,
   metadata,
-}) => {
+}: CreateReplayOptions): Promise<Replay> => {
   const { data } = await client.post("replays", {
     commitSha,
     sessionId,

--- a/packages/replay-orchestrator/src/test-run/parallel-tests/execute-test-run.ts
+++ b/packages/replay-orchestrator/src/test-run/parallel-tests/execute-test-run.ts
@@ -257,7 +257,6 @@ export const executeTestRun = async ({
             generatedBy: { type: "testRun", runId: testRun.id },
             testRunId: testRun.id,
             replayEventsDependencies,
-            debugger: false,
             cookiesFile: null,
 
             // Specific to each task

--- a/packages/replay-orchestrator/src/test-run/parallel-tests/task.handler.ts
+++ b/packages/replay-orchestrator/src/test-run/parallel-tests/task.handler.ts
@@ -57,8 +57,9 @@ const main = async () => {
   logger.setLevel(logLevel);
   setMeticulousLocalDataDir(dataDir);
 
+  const replayExecution = await replayAndStoreResults(replayOptions);
   const { replay, screenshotDiffResultsByBaseReplayId } =
-    await replayAndStoreResults(replayOptions);
+    await replayExecution.finalResult;
   const result = hasNotableDifferences(
     Object.values(screenshotDiffResultsByBaseReplayId).flat()
   )

--- a/packages/replayer/package.json
+++ b/packages/replayer/package.json
@@ -31,14 +31,6 @@
     "@types/luxon": "^3.2.0",
     "next": "^13.1.6"
   },
-  "peerDependencies": {
-    "@alwaysmeticulous/replay-debugger-ui": "^2.5.0"
-  },
-  "peerDependenciesMeta": {
-    "@alwaysmeticulous/replay-debugger-ui": {
-      "optional": true
-    }
-  },
   "author": {
     "name": "The Meticulous Team",
     "email": "eng@meticulous.ai",

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -9,21 +9,20 @@ import {
   RecordedSession,
 } from "@alwaysmeticulous/common";
 import {
+  GeneratedBy,
   OnReplayTimelineEventFn,
+  ReplayAndStoreResultsOptions,
+  ReplayExecution,
+  ReplayExecutionOptions,
+  ReplayOrchestratorScreenshottingOptions,
   ReplayUserInteractionsResult,
   SetupReplayNetworkStubbingFn,
   VirtualTimeOptions,
-  GeneratedBy,
-  ReplayExecutionOptions,
-  ReplayOrchestratorScreenshottingOptions,
-  ReplayAndStoreResultsOptions,
-  ReplayExecution,
 } from "@alwaysmeticulous/sdk-bundles-api";
 import { SetupBrowserContextSeedingFn } from "@alwaysmeticulous/sdk-bundles-api/dist/replay/sdk-to-bundle";
 import { Span } from "@sentry/types";
 import log, { LogLevelDesc } from "loglevel";
 import { Browser, launch, Page } from "puppeteer";
-import { openStepThroughDebuggerUI } from "./debugger/replay-debugger.ui";
 import { prepareScreenshotsDir, writeOutput } from "./output.utils";
 import { ReplayEventsDependencies, ReplayMetadata } from "./replay.types";
 import {

--- a/packages/replayer/src/replayer.ts
+++ b/packages/replayer/src/replayer.ts
@@ -423,13 +423,13 @@ const replaySessionInPage = async (
 };
 
 const logEventTarget = async (page: Page, event: ReplayableEvent) => {
-  await page.evaluate(() => {
+  await page.evaluate((event) => {
     const target = (window as any).__meticulous.replayFunctions.findEventTarget(
       event
     );
     console.log("Next event target:");
     console.log(target);
-  });
+  }, event);
 };
 
 const shouldHoldBrowserOpen = () => {

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -43,7 +43,6 @@ export {
   CompareScreenshotsToSpecificReplay,
   CompareScreenshotsToTestRun,
   DoNotCompareScreenshots,
-  OnBeforeNextEventOptions,
 } from "./replay-orchestrator/sdk-to-bundle/execute-replay";
 export { ExecuteTestRunOptions } from "./replay-orchestrator/sdk-to-bundle/execute-test-run";
 export {
@@ -57,5 +56,5 @@ export {
 export {
   ReplayAndStoreResultsResult,
   ReplayExecution,
-  OnBeforeNextEventResult,
+  BeforeUserEventResult,
 } from "./replay-orchestrator/bundle-to-sdk/execute-replay";

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -43,6 +43,7 @@ export {
   CompareScreenshotsToSpecificReplay,
   CompareScreenshotsToTestRun,
   DoNotCompareScreenshots,
+  OnBeforeNextEventOptions,
 } from "./replay-orchestrator/sdk-to-bundle/execute-replay";
 export { ExecuteTestRunOptions } from "./replay-orchestrator/sdk-to-bundle/execute-test-run";
 export {
@@ -53,4 +54,8 @@ export {
   TestRunProgress,
   DetailedTestCaseResult,
 } from "./replay-orchestrator/bundle-to-sdk/execute-test-run";
-export { ReplayAndStoreResultsResult } from "./replay-orchestrator/bundle-to-sdk/execute-replay";
+export {
+  ReplayAndStoreResultsResult,
+  ReplayExecution,
+  OnBeforeNextEventResult,
+} from "./replay-orchestrator/bundle-to-sdk/execute-replay";

--- a/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
@@ -1,4 +1,27 @@
-import { Replay, ScreenshotDiffResult } from "@alwaysmeticulous/api";
+import {
+  Replay,
+  ReplayableEvent,
+  ScreenshotDiffResult,
+} from "@alwaysmeticulous/api";
+
+export interface ReplayExecution {
+  /**
+   * Promise resolves when the replay is complete.
+   */
+  finalResult: Promise<ReplayAndStoreResultsResult>;
+
+  eventsBeingReplayed: ReplayableEvent[];
+
+  /**
+   * When called will log the target of the given event to the browser console.
+   */
+  logEventTarget: (event: ReplayableEvent) => Promise<void>;
+
+  /**
+   * Closes the browser window and stops the replay short.
+   */
+  closePage: () => Promise<void>;
+}
 
 export interface ReplayAndStoreResultsResult {
   replay: Replay;
@@ -7,4 +30,14 @@ export interface ReplayAndStoreResultsResult {
    * Empty if screenshottingOptions.enabled was false.
    */
   screenshotDiffResultsByBaseReplayId: Record<string, ScreenshotDiffResult[]>;
+}
+
+export interface OnBeforeNextEventResult {
+  /**
+   * If provided then execution will continue, without calling onBeforeUserEvent, until
+   * the next event with this index is reached.
+   *
+   * If omitted then onBeforeUserEvent will be called again on the immediate next event.
+   */
+  nextEventIndexToPauseBefore?: number;
 }

--- a/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
@@ -32,7 +32,7 @@ export interface ReplayAndStoreResultsResult {
   screenshotDiffResultsByBaseReplayId: Record<string, ScreenshotDiffResult[]>;
 }
 
-export interface OnBeforeNextEventResult {
+export interface BeforeUserEventResult {
   /**
    * If provided then execution will continue, without calling onBeforeUserEvent, until
    * the next event with this index is reached.

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -1,5 +1,6 @@
 import { ScreenshotDiffOptions } from "@alwaysmeticulous/api";
-import { OnBeforeNextEventResult } from "../bundle-to-sdk/execute-replay";
+import { BeforeUserEventOptions } from "../../replay/bundle-to-sdk";
+import { BeforeUserEventResult } from "../bundle-to-sdk/execute-replay";
 
 export interface ReplayAndStoreResultsOptions {
   replayTarget: ReplayTarget;
@@ -23,15 +24,8 @@ export interface ReplayAndStoreResultsOptions {
    * next event. This allows the caller to pause the replay, or control the playback.
    */
   onBeforeUserEvent?: (
-    opts: OnBeforeNextEventOptions
-  ) => Promise<OnBeforeNextEventResult>;
-}
-
-export interface OnBeforeNextEventOptions {
-  /**
-   * The index of the next event in sessionData.userEvents.event_log
-   */
-  userEventIndex: number;
+    opts: BeforeUserEventOptions
+  ) => Promise<BeforeUserEventResult>;
 }
 
 /**

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -1,4 +1,5 @@
 import { ScreenshotDiffOptions } from "@alwaysmeticulous/api";
+import { OnBeforeNextEventResult } from "../bundle-to-sdk/execute-replay";
 
 export interface ReplayAndStoreResultsOptions {
   replayTarget: ReplayTarget;
@@ -11,7 +12,26 @@ export interface ReplayAndStoreResultsOptions {
   commitSha: string | null | undefined;
   sessionId: string;
   cookiesFile: string | null | undefined;
-  debugger: boolean;
+
+  /**
+   * Called when the user or runner closes the page or browser window
+   */
+  onClosePage?: () => void;
+
+  /**
+   * The replay runner will block on the promise returned before replaying the
+   * next event. This allows the caller to pause the replay, or control the playback.
+   */
+  onBeforeUserEvent?: (
+    opts: OnBeforeNextEventOptions
+  ) => Promise<OnBeforeNextEventResult>;
+}
+
+export interface OnBeforeNextEventOptions {
+  /**
+   * The index of the next event in sessionData.userEvents.event_log
+   */
+  userEventIndex: number;
 }
 
 /**


### PR DESCRIPTION
This should allow us to pull the replay code into the main repo while leaving the replay debugger in the CLI.

- [x] Test using --debugger with next event and log event target
- [x] Test not using --debugger