### PR TITLE
maxSemanticVersion typings

### DIFF
--- a/packages/replay-orchestrator/src/replay/replay-and-store-results.ts
+++ b/packages/replay-orchestrator/src/replay/replay-and-store-results.ts
@@ -45,7 +45,7 @@ import { uploadArchive } from "./utils/upload";
 /**
  * See {@link ReplayAndStoreResultsOptions.maxSemanticVersionSupported} for more details.
  */
-export const CURRENT_REPLAY_AND_STORE_RESULTS_SEMANTIC_VERSION = 1;
+export const CURRENT_REPLAY_AND_STORE_RESULTS_SEMANTIC_VERSION: ReplayAndStoreResultsOptions["maxSemanticVersionSupported"] = 1;
 
 export const replayAndStoreResults = async ({
   replayTarget,

--- a/packages/sdk-bundles-api/src/replay-orchestrator/README.md
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/README.md
@@ -1,0 +1,9 @@
+## replay-orchestrator bundles API
+
+Workflow when making a break:
+
+- Open SDK PR to bump the `maxSemanticVersionSupported` on the API, make the API changes, and update the SDK to work with both the new and old API version. Release SDK and report-diffs-action.
+- Open main repo PR to update it to the new version of these typings, and to throw when maxSemanticVersionSupported < the new version number. Merge & release.
+- Open SDK PR to remove support for the old version.
+
+Read the README.md files in the sub-folders to understand exactly what constitutes a 'break'. It's different for the files in each sub-folder.

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -35,8 +35,11 @@ export interface ReplayAndStoreResultsOptions {
    * code to detect if it's being called by client that is not compatible with the latest version,
    * and if so throw an OutOfDateClientError. It is then up to the client to display a message to ask
    * the user to update to a newer version.
+   *
+   * Note: this is typed as a const of the latest known version, rather than a number, to ensure
+   * that all clients bump the version number passed when they upgrade to the types.
    */
-  maxSemanticVersionSupported: number;
+  maxSemanticVersionSupported: 1;
 }
 
 /**

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
@@ -72,6 +72,9 @@ export interface ExecuteTestRunOptions {
    * code to detect if it's being called by client that is not compatible with the latest version,
    * and if so throw an OutOfDateClientError. It is then up to the client to display a message to ask
    * the user to update to a newer version.
+   *
+   * Note: this is typed as a const of the latest known version, rather than a number, to ensure
+   * that all clients bump the version number passed when they upgrade to the types.
    */
-  maxSemanticVersionSupported: number;
+  maxSemanticVersionSupported: 1;
 }


### PR DESCRIPTION
Type as a const of the latest known version, rather than a number, to ensure that all clients bump the version number passed when they upgrade to the types.