### PR TITLE
Fix bug where CLI would hang, waiting for a setTimeout, before exiting

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -22,7 +22,7 @@ import {
 } from "../../utils/out-of-date-client-error";
 import { openStepThroughDebuggerUI } from "./utils/replay-debugger.ui";
 
-export interface RawReplayCommandHandlerOptions
+interface ReplayCommandHandlerOptions
   extends ScreenshotDiffOptions,
     Omit<ReplayExecutionOptions, "maxDurationMs" | "maxEventCount"> {
   screenshot: boolean;
@@ -39,7 +39,7 @@ export interface RawReplayCommandHandlerOptions
   baseReplayId: string | null | undefined;
 }
 
-export const rawReplayCommandHandler = async ({
+const replayCommandHandler = async ({
   apiToken,
   commitSha,
   sessionId,
@@ -64,7 +64,7 @@ export const rawReplayCommandHandler = async ({
   storyboard,
   essentialFeaturesOnly,
   debugger: enableStepThroughDebugger,
-}: RawReplayCommandHandlerOptions): Promise<Replay> => {
+}: ReplayCommandHandlerOptions): Promise<void> => {
   if (!screenshot && storyboard) {
     throw new Error(
       "Cannot take storyboard screenshots without taking end state screenshots. Please set '--screenshot' to true, or '--storyboard' to false."
@@ -157,9 +157,7 @@ export const rawReplayCommandHandler = async ({
       getOnClosePageCallback.resolve(stepThroughDebuggerUI.close);
     }
 
-    const { replay } = await replayExecution.finalResult;
-
-    return replay;
+    await replayExecution.finalResult;
   } catch (error) {
     if (isOutOfDateClientError(error)) {
       throw new OutOfDateCLIError();
@@ -233,5 +231,5 @@ export const replayCommand = buildCommand("simulate")
     ...SCREENSHOT_DIFF_OPTIONS,
   })
   .handler(async (options) => {
-    await rawReplayCommandHandler(options);
+    await replayCommandHandler(options);
   });


### PR DESCRIPTION
NodeJS processes only exit when there are no scheduled setTimeouts/setIntervals etc. left. However I suspect that we have some un-cancelled setTimeouts when our code completes (e.g. maybe Sentry internally, or our replay code somewhere). Depending on zero setTimeouts being pending when the command completes is very fragile (any library can set some setTimeout for any reason), so better to explicitly process.exit(0).