### PR TITLE
Run debugger UI server on random port

### DIFF
--- a/packages/replay-debugger-ui/scripts/index.ts
+++ b/packages/replay-debugger-ui/scripts/index.ts
@@ -1,7 +1,9 @@
+import type { AddressInfo } from "net";
 import { join } from "path";
 import express from "express";
 
-const PORT = 3005;
+// Our UI server will run on port 0, which means that the OS will assign a random port.
+const PORT = 0;
 
 export interface Server {
   url: string;
@@ -15,11 +17,12 @@ export const startUIServer = async (): Promise<Server> => {
 
   app.use(express.static(staticRoot));
 
-  const url = `http://localhost:${PORT}`;
-
   return new Promise((resolve, reject) => {
     try {
       const server = app.listen(PORT, () => {
+        const url = `http://localhost:${
+          (server.address() as AddressInfo).port
+        }`;
         console.log(`UI Server started at ${url}`);
         resolve({ url, close: () => server.close() });
       });


### PR DESCRIPTION
We don't depend on the debugger UI port being static so can run it on a random port. This also enables running multiple debuggers locally. 