### PR TITLE
Introduce and pass environment version for screenshotting bundle

### DIFF
--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
@@ -13,10 +13,11 @@ export type ScreenshotIdentifier = EndStateScreenshot | ScreenshotAfterEvent;
 
 export interface LogicVersioned {
   /**
-   * The version of the logic used to generate the screenshot. This should be bumped
+   * The version of the logic and environment used to generate the screenshot. This should be bumped
    * whenever the Meticulous code changes such that two screenshots on different logic versions
-   * are incomparable. This field is used to avoid falsely flagging a diff to our users when
-   * the logic to generate a screenshot or execute a replay changes.
+   * are incomparable or the replay environment differs. This field is used to avoid falsely flagging a
+   * diff to our users when the logic to generate a screenshot or execute a replay changes, or if
+   * the replay environment changes, e.g. the browser or Puppeteer versions changes.
    */
   logicVersion?: number;
 }

--- a/packages/replay-orchestrator-launcher/src/index.ts
+++ b/packages/replay-orchestrator-launcher/src/index.ts
@@ -10,10 +10,12 @@ import {
 import log from "loglevel";
 import { executablePath } from "puppeteer";
 
+const ENVIRONMENT_VERSION = 0;
+
 export const replayAndStoreResults = async (
   options: Omit<
     ReplayAndStoreResultsOptions,
-    "logLevel" | "chromeExecutablePath"
+    "logLevel" | "chromeExecutablePath" | "logicalEnvironmentVersion"
   >
 ): Promise<ReplayExecution> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
@@ -25,13 +27,14 @@ export const replayAndStoreResults = async (
     ...options,
     chromeExecutablePath: getChromiumExecutablePath(),
     logLevel: logger.getLevel(),
+    logicalEnvironmentVersion: ENVIRONMENT_VERSION,
   });
 };
 
 export const executeScheduledTestRun = async (
   options: Omit<
     ExecuteScheduledTestRunOptions,
-    "logLevel" | "chromeExecutablePath"
+    "logLevel" | "chromeExecutablePath" | "logicalEnvironmentVersion"
   >
 ): Promise<ExecuteTestRunResult> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
@@ -43,11 +46,15 @@ export const executeScheduledTestRun = async (
     ...options,
     chromeExecutablePath: getChromiumExecutablePath(),
     logLevel: logger.getLevel(),
+    logicalEnvironmentVersion: ENVIRONMENT_VERSION,
   });
 };
 
 export const executeTestRun = async (
-  options: Omit<ExecuteTestRunOptions, "logLevel" | "chromeExecutablePath">
+  options: Omit<
+    ExecuteTestRunOptions,
+    "logLevel" | "chromeExecutablePath" | "logicalEnvironmentVersion"
+  >
 ): Promise<ExecuteTestRunResult> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   const bundleLocation = await fetchAsset(
@@ -58,6 +65,7 @@ export const executeTestRun = async (
     ...options,
     chromeExecutablePath: getChromiumExecutablePath(),
     logLevel: logger.getLevel(),
+    logicalEnvironmentVersion: ENVIRONMENT_VERSION,
   });
 };
 

--- a/packages/replay-orchestrator-launcher/src/index.ts
+++ b/packages/replay-orchestrator-launcher/src/index.ts
@@ -10,7 +10,7 @@ import {
 import log from "loglevel";
 import { executablePath } from "puppeteer";
 
-const ENVIRONMENT_VERSION = 0;
+export const ENVIRONMENT_VERSION = 0;
 
 export const replayAndStoreResults = async (
   options: Omit<

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -47,9 +47,6 @@ export interface ReplayAndStoreResultsOptions {
    * The version of the environment in which a replay is executed. This should be bumped
    * whenever the environment changes in a way that affects the replay, e.g. the version of
    * Chromium, or the version of Puppeteer.
-   *
-   * See `LogicVersioned` in `@alwaysmeticulous/api`.
-   * Values are truncated to 8 bits, so must be in the range 0-255.
    */
   logicalEnvironmentVersion?: number;
 }

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -42,6 +42,16 @@ export interface ReplayAndStoreResultsOptions {
    * that all clients bump the version number passed when they upgrade to the types.
    */
   maxSemanticVersionSupported: 1;
+
+  /**
+   * The version of the environment in which a replay is executed. This should be bumped
+   * whenever the environment changes in a way that affects the replay, e.g. the version of
+   * Chromium, or the version of Puppeteer.
+   *
+   * See `LogicVersioned` in `@alwaysmeticulous/api`.
+   * Values are truncated to 8 bits, so must be in the range 0-255.
+   */
+  logicalEnvironmentVersion?: number;
 }
 
 export interface BeforeUserEventOptions {

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-scheduled-test-run.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-scheduled-test-run.ts
@@ -8,6 +8,7 @@ export type ExecuteScheduledTestRunOptions = Pick<
   | "maxRetriesOnFailure"
   | "rerunTestsNTimes"
   | "logLevel"
+  | "logicalEnvironmentVersion"
 > & {
   /**
    * The ID of the scheduled test run to execute.

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
@@ -73,4 +73,14 @@ export interface ExecuteTestRunOptions {
    * that all clients bump the version number passed when they upgrade to the types.
    */
   maxSemanticVersionSupported: 1;
+
+  /**
+   * The version of the environment in which a replay is executed. This should be bumped
+   * whenever the environment changes in a way that affects the replay, e.g. the version of
+   * Chromium, or the version of Puppeteer.
+   *
+   * See `LogicVersioned` in `@alwaysmeticulous/api`.
+   * Values are truncated to 8 bits, so must be in the range 0-255.
+   */
+  logicalEnvironmentVersion?: number;
 }

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
@@ -78,9 +78,6 @@ export interface ExecuteTestRunOptions {
    * The version of the environment in which a replay is executed. This should be bumped
    * whenever the environment changes in a way that affects the replay, e.g. the version of
    * Chromium, or the version of Puppeteer.
-   *
-   * See `LogicVersioned` in `@alwaysmeticulous/api`.
-   * Values are truncated to 8 bits, so must be in the range 0-255.
    */
   logicalEnvironmentVersion?: number;
 }


### PR DESCRIPTION
Differences in environment, e.g. Puppeteer version change can cause visual diffs not caused by a code change.

This PR introduces an env. version which will be used to compute the overall `screenshotting version` within the bundle.