### PR TITLE
Auto-generate logs.concise.txt

### DIFF
--- a/packages/cli/src/commands/download-replay/download-replay.command.ts
+++ b/packages/cli/src/commands/download-replay/download-replay.command.ts
@@ -1,9 +1,13 @@
+import { readFileSync, writeFileSync } from "fs";
+import { access, readFile, writeFile } from "fs/promises";
+import { join } from "path";
 import { createClient } from "@alwaysmeticulous/client";
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
 } from "@alwaysmeticulous/downloading-helpers";
+import { fileExists } from "@alwaysmeticulous/downloading-helpers/dist/file-downloads/local-data.utils";
 import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 
@@ -28,6 +32,31 @@ const handler: (options: Options) => Promise<void> = async ({
     client,
     replayId
   );
+
+  // Generate logs.concise.txt file
+  const logsFile = join(replayFolderFilePath, "logs.json");
+  const logsFileExists = await access(logsFile)
+    .then(() => true)
+    .catch(() => false);
+  if (logsFileExists) {
+    try {
+      const logs = JSON.parse(
+        await readFile(join(replayFolderFilePath, "logs.json"), "utf8")
+      );
+      const conciseLogs = logs.console.map(
+        (log: { type: string; message: string }) => {
+          return log.message.replace("[METICULOUS] ", "");
+        }
+      );
+      await writeFile(
+        join(replayFolderFilePath, "logs.concise.txt"),
+        conciseLogs.join("\n")
+      );
+    } catch (err) {
+      logger.error("Error creating concise version of logs file", err);
+    }
+  }
+
   logger.info(`Downloaded replay data to: ${replayFolderFilePath}`);
 };
 

--- a/packages/cli/src/commands/download-replay/download-replay.command.ts
+++ b/packages/cli/src/commands/download-replay/download-replay.command.ts
@@ -1,4 +1,3 @@
-import { readFileSync, writeFileSync } from "fs";
 import { access, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { createClient } from "@alwaysmeticulous/client";
@@ -7,7 +6,6 @@ import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
 } from "@alwaysmeticulous/downloading-helpers";
-import { fileExists } from "@alwaysmeticulous/downloading-helpers/dist/file-downloads/local-data.utils";
 import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 

--- a/packages/cli/src/commands/download-replay/download-replay.command.ts
+++ b/packages/cli/src/commands/download-replay/download-replay.command.ts
@@ -39,7 +39,7 @@ const handler: (options: Options) => Promise<void> = async ({
   if (logsFileExists) {
     try {
       const logs = JSON.parse(
-        await readFile(join(replayFolderFilePath, "logs.json"), "utf8")
+        await readFile(logsFile, "utf8")
       );
       const conciseLogs = logs.console.map(
         (log: { type: string; message: string }) => {


### PR DESCRIPTION
When debugging replays logs.json can be pretty verbose, so we often use jq to create a more readable version. This is time consuming so this PR updates the CLI to generate it automatically. We could generate it at replay time, but that'd increase the size of the replay zips. So better to generate at consumption time.

Potentially we may want Meticulous BE to generate this instead, and display it in the web-app. However it's not obvious how often the internal logs will be useful for users. I expect we'll want to do this at some point though with the raw console logs. If when we do that we may potentially be able to remove this code here, and add it to the Meticulous FE/BE instead.