### PR TITLE
Use network mocking mode from project settings

### DIFF
--- a/packages/api/src/project.types.ts
+++ b/packages/api/src/project.types.ts
@@ -1,5 +1,6 @@
 import { Organization } from "./organization.types";
 import { TestCase } from "./replay/test-run.types";
+import { NetworkStubbingMode } from "./sdk-bundle-api/sdk-to-bundle/network-stubbing";
 
 export interface Project {
   id: string;
@@ -10,6 +11,9 @@ export interface Project {
   createdAt: string;
   updatedAt: string;
   isGitHubIntegrationActive?: boolean;
+  settings: {
+    networkStubbingMode?: NetworkStubbingMode;
+  };
 }
 
 export interface ProjectConfigurationData {

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -16,6 +16,7 @@ import {
   OPTIONS,
   SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
+import { applyDefaultExecutionOptionsFromProject } from "../../utils/apply-default-execution-options-from-project";
 import {
   OutOfDateCLIError,
   isOutOfDateClientError,
@@ -91,7 +92,7 @@ const replayCommandHandler = async ({
     maxDurationMs: maxDurationMs ?? null,
     maxEventCount: maxEventCount ?? null,
     essentialFeaturesOnly,
-    logPossibleNonDeterminism
+    logPossibleNonDeterminism,
   };
   const generatedByOption: GeneratedBy = { type: "replayCommand" };
   const storyboardOptions: StoryboardOptions = storyboard
@@ -126,7 +127,10 @@ const replayCommandHandler = async ({
         appUrl: appUrl ?? null,
         simulationIdForAssets: simulationIdForAssets ?? null,
       }),
-      executionOptions,
+      executionOptions: await applyDefaultExecutionOptionsFromProject({
+        apiToken,
+        executionOptions,
+      }),
       screenshottingOptions,
       apiToken,
       commitSha,

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -12,6 +12,7 @@ import {
   OPTIONS,
   SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
+import { applyDefaultExecutionOptionsFromProject } from "../../utils/apply-default-execution-options-from-project";
 import {
   OutOfDateCLIError,
   isOutOfDateClientError,
@@ -94,7 +95,10 @@ const handler: (options: Options) => Promise<void> = async ({
   try {
     const { testRun } = await executeTestRun({
       testsFile: testsFile ?? null,
-      executionOptions,
+      executionOptions: await applyDefaultExecutionOptionsFromProject({
+        apiToken,
+        executionOptions,
+      }),
       screenshottingOptions,
       apiToken: apiToken ?? null,
       commitSha,

--- a/packages/cli/src/utils/apply-default-execution-options-from-project.ts
+++ b/packages/cli/src/utils/apply-default-execution-options-from-project.ts
@@ -1,0 +1,52 @@
+import { createClient, getProject } from "@alwaysmeticulous/client";
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { ReplayExecutionOptions } from "@alwaysmeticulous/sdk-bundles-api";
+import log from "loglevel";
+
+export const applyDefaultExecutionOptionsFromProject = async ({
+  apiToken,
+  executionOptions,
+}: {
+  apiToken: string | undefined | null;
+  executionOptions: ReplayExecutionOptions;
+}): Promise<ReplayExecutionOptions> => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const client = createClient({ apiToken });
+  const project = await getProject(client);
+  if (!project) {
+    throw new Error(
+      `Could not retrieve project data. Is the API token correct?`
+    );
+  }
+
+  if (
+    executionOptions.networkStubbingMode != null ||
+    project.settings.networkStubbingMode == null
+  ) {
+    return executionOptions;
+  }
+
+  if (project.settings.networkStubbingMode.type === "stub-non-ssr-requests") {
+    logger.info("");
+    logger.info(
+      "Stubbing all requests, except requests to render server components and requests for static assets"
+    );
+    logger.info("Visit your project settings page if you wish to change this");
+    logger.info("");
+  }
+  if (project.settings.networkStubbingMode.type === "custom-stubbing") {
+    logger.info("");
+    logger.info(
+      `Stubbing all requests, except requests which match one of the following regexes: [${project.settings.networkStubbingMode.requestsToNotStub
+        .map((request) => `'${request.urlRegex}'`)
+        .join(", ")}]`
+    );
+    logger.info("Visit your project settings page if you wish to change this");
+    logger.info("");
+  }
+
+  return {
+    ...executionOptions,
+    networkStubbingMode: project.settings.networkStubbingMode,
+  };
+};


### PR DESCRIPTION
Testing performed:
 - All three mocking modes work when run via CLI

*Do not merge before the corresponding PR on the BE has shipped (this depends on being able to load the project settings, which previously were not returned by the BE controller)*