### PR TITLE
[gitlab] push event test run context

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -27,6 +27,7 @@ export {
   TestRunGitHubWorkflowDispatchContext,
   TestRunGitLabContext,
   TestRunGitLabMergeRequestContext,
+  TestRunGitLabPushContext,
 } from "./sdk-bundle-api/sdk-to-bundle/test-run-environment";
 export { ReplayableEvent } from "./sdk-bundle-api/bidirectional/replayable-event";
 export {

--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/test-run-environment.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/test-run-environment.ts
@@ -65,7 +65,8 @@ export interface TestRunGitHubWorkflowDispatchContext {
   headSha: string;
 }
 
-export type TestRunGitLabContext = TestRunGitLabMergeRequestContext;
+export type TestRunGitLabContext = TestRunGitLabMergeRequestContext | TestRunGitLabPushContext;
+
 export interface TestRunGitLabMergeRequestContext {
   type: "gitlab";
   event: "merge-request";
@@ -84,4 +85,15 @@ export interface TestRunGitLabMergeRequestContext {
 
   /** Merge request URL (web page) */
   webUrl: string;
+}
+
+export interface TestRunGitLabPushContext {
+  type: "gitlab";
+  event: "push";
+
+  /** Commit hash before the push event */
+  beforeSha: string;
+
+  /** Commit hash after the push event */
+  afterSha: string;
 }


### PR DESCRIPTION
For use in push events and triggering test runs on base commits when no previous test run exists.