### PR TITLE
Export apply-default-execution-options-from-project

### DIFF
--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -1,4 +1,5 @@
 import { ScreenshotDiffOptions } from "@alwaysmeticulous/api";
+import { applyDefaultExecutionOptionsFromProject } from "@alwaysmeticulous/client";
 import { defer } from "@alwaysmeticulous/common";
 import { replayAndStoreResults } from "@alwaysmeticulous/replay-orchestrator-launcher";
 import {
@@ -16,7 +17,6 @@ import {
   OPTIONS,
   SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
-import { applyDefaultExecutionOptionsFromProject } from "../../utils/apply-default-execution-options-from-project";
 import {
   OutOfDateCLIError,
   isOutOfDateClientError,

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -3,6 +3,7 @@ import {
   ScreenshotDiffOptions,
   StoryboardOptions,
 } from "@alwaysmeticulous/api";
+import { applyDefaultExecutionOptionsFromProject } from "@alwaysmeticulous/client";
 import { getCommitSha } from "@alwaysmeticulous/common";
 import { executeTestRun } from "@alwaysmeticulous/replay-orchestrator-launcher";
 import { ReplayExecutionOptions } from "@alwaysmeticulous/sdk-bundles-api";
@@ -12,7 +13,6 @@ import {
   OPTIONS,
   SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
-import { applyDefaultExecutionOptionsFromProject } from "../../utils/apply-default-execution-options-from-project";
 import {
   OutOfDateCLIError,
   isOutOfDateClientError,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@alwaysmeticulous/api": "^2.69.0",
     "@alwaysmeticulous/common": "^2.69.0",
+    "@alwaysmeticulous/sdk-bundles-api": "^2.69.0",
     "axios": "^1.2.6",
     "axios-retry": "^3.5.0",
     "loglevel": "^1.8.0"

--- a/packages/client/src/api/apply-default-execution-options-from-project.ts
+++ b/packages/client/src/api/apply-default-execution-options-from-project.ts
@@ -1,7 +1,8 @@
-import { createClient, getProject } from "@alwaysmeticulous/client";
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import { ReplayExecutionOptions } from "@alwaysmeticulous/sdk-bundles-api";
 import log from "loglevel";
+import { createClient } from "../client";
+import { getProject } from "./project.api";
 
 export const applyDefaultExecutionOptionsFromProject = async ({
   apiToken,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,6 @@
+export { applyDefaultExecutionOptionsFromProject } from "./api/apply-default-execution-options-from-project";
 export { getProject } from "./api/project.api";
+export { getReplay, getReplayDownloadUrl } from "./api/replay.api";
 export {
   getRecordedSession,
   getRecordedSessionData,
@@ -6,9 +8,7 @@ export {
   postSessionIdNotification,
 } from "./api/session.api";
 export {
-  getLatestTestRunResults,
   GetLatestTestRunOptions,
+  getLatestTestRunResults,
 } from "./api/test-run.api";
-export { getReplay, getReplayDownloadUrl } from "./api/replay.api";
-
-export { createClient, ClientOptions } from "./client";
+export { ClientOptions, createClient } from "./client";


### PR DESCRIPTION
We'll need to consume this in reports-diff-action