### PR TITLE
Handle new logs format

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cli": "yarn workspace @alwaysmeticulous/cli cli",
     "cli:debug": "yarn workspace @alwaysmeticulous/cli cli:debug",
     "cli:dev": "yarn workspace @alwaysmeticulous/cli cli:dev",
+    "cli:dev-staging": "yarn workspace @alwaysmeticulous/cli cli:dev-staging",
     "cli:dev-localhost": "yarn workspace @alwaysmeticulous/cli cli:dev-localhost",
     "publish": "lerna version",
     "depcheck": "turbo run depcheck"

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -61,3 +61,12 @@ export {
   CustomStubbing,
   RequestFilter,
 } from "./sdk-bundle-api/sdk-to-bundle/network-stubbing";
+export {
+  ConsoleMessageWithStackTracePointer,
+  VirtualTimeChange,
+  MeticulousConsoleMessage,
+  ApplicationConsoleMessage,
+  ConsoleMessageCoreData,
+  ConsoleMessageType,
+  ConsoleMessageLocation,
+} from "./sdk-bundle-api/bundle-to-sdk/console-message";

--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/console-message.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/console-message.ts
@@ -1,0 +1,66 @@
+/**
+ * logs.ndjson contains one ConsoleMessageWithStackTracePointer in JSON format per line
+ */
+export type ConsoleMessageWithStackTracePointer =
+  | MeticulousConsoleMessage
+  | ApplicationConsoleMessage
+  | VirtualTimeChange;
+
+export interface VirtualTimeChange {
+  type: "virtual-time-change";
+  virtualTime: number;
+}
+
+export interface MeticulousConsoleMessage extends ConsoleMessageCoreData {
+  source: "meticulous";
+  realTime: number;
+}
+
+export interface ApplicationConsoleMessage extends ConsoleMessageCoreData {
+  source: "application";
+  // Note: we don't store real times for application messages, only meticulous ones, yet
+  // (to get an accurate real time we'd have to override console.log etc., and snapshot performance.now() at the time of the call)
+}
+
+export interface ConsoleMessageCoreData {
+  type: ConsoleMessageType;
+  message: string;
+  repetitionCount?: number;
+  stackTraceId: number;
+}
+
+export type ConsoleMessageType =
+  | "log"
+  | "debug"
+  | "info"
+  | "error"
+  | "warning"
+  | "dir"
+  | "dirxml"
+  | "table"
+  | "trace"
+  | "clear"
+  | "startGroup"
+  | "startGroupCollapsed"
+  | "endGroup"
+  | "assert"
+  | "profile"
+  | "profileEnd"
+  | "count"
+  | "timeEnd"
+  | "verbose";
+
+export interface ConsoleMessageLocation {
+  /**
+   * URL of the resource if known or `undefined` otherwise.
+   */
+  url?: string;
+  /**
+   * 0-based line number in the resource if known or `undefined` otherwise.
+   */
+  lineNumber?: number;
+  /**
+   * 0-based column number in the resource if known or `undefined` otherwise.
+   */
+  columnNumber?: number;
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "cli:debug": "echo '\n\nVisit chrome://inspect in Chrome and attach the debugger\n\n' && node --inspect-brk dist/main.js",
     "cli:dev": "ts-node src/main.ts",
     "cli:dev-localhost": "METICULOUS_API_URL=http://localhost:3001/api/ ts-node src/main.ts",
+    "cli:dev-staging": "METICULOUS_API_URL=https://staging-backend.alb.meticulous.ai/api/ ts-node src/main.ts",
     "test": "jest --passWithNoTests",
     "depcheck": "depcheck --ignore-patterns=dist"
   },


### PR DESCRIPTION
See corresponding main Meticulous PR for details.

An example of the concise logs (used for debugging only):

```
[trace-id: 6] [virtual: 1743.60009765625ms, real: 527.5ms] Executing event {"type":"setTimeout","executeAt":1743.60009765625,"id":4,"debugMetadata":{"originalDelay":382}}
[trace-id: 7] [virtual: 1743.60009765625ms, real: 527.7ms] Begun waitUntilDOMStopsChanging
[trace-id: 8] [virtual: 1743.60009765625ms, real: 527.8ms] Triggering 1 virtual animation frame
[trace-id: 5] [virtual: 1743.60009765625ms, real: 528ms] Waited 1 virtual frames for DOM to stop changing
[trace-id: 9] [virtual: 1743.60009765625ms, real: 528ms] Finished executing events up to 1968.60009765625ms. Setting virtual time to 1968.60009765625ms

[trace-id: 12] [virtual: 1968.60009765625ms, real: 533.6ms] Replaying keydown event on selector 'label:nth-child(1) > input:nth-child(1)'
[trace-id: 13] [virtual: 1968.60009765625ms, real: 533.8ms] PASS Found exact selector match for label:nth-child(1) > input:nth-child(1)
[trace-id: 2] [virtual: 1968.60009765625ms, real: 535.4ms] Executing events up to 1968.60009765625ms
[trace-id: 15] [virtual: 1968.60009765625ms, real: 535.5ms] Triggering 1 virtual animation frame
[trace-id: 9] [virtual: 1968.60009765625ms, real: 535.6ms] Finished executing events up to 1968.60009765625ms. Setting virtual time to 1968.60009765625ms
[trace-id: 12] [virtual: 1968.60009765625ms, real: 539.8ms] Replaying keypress event on selector 'label:nth-child(1) > input:nth-child(1)'
[trace-id: 13] [virtual: 1968.60009765625ms, real: 539.9ms] PASS Found exact selector match for label:nth-child(1) > input:nth-child(1)
[trace-id: 2] [virtual: 1968.60009765625ms, real: 546.6ms] Executing events up to 1989.699951171875ms
[trace-id: 3] [virtual: 1968.60009765625ms, real: 546.9ms] Begun waitUntilDOMStopsChanging
[trace-id: 4] [virtual: 1968.60009765625ms, real: 546.9ms] Triggering 1 virtual animation frame
[trace-id: 5] [virtual: 1968.60009765625ms, real: 547.1ms] Waited 1 virtual frames for DOM to stop changing
[trace-id: 9] [virtual: 1968.60009765625ms, real: 547.3ms] Finished executing events up to 1989.699951171875ms. Setting virtual time to 1989.699951171875ms

[trace-id: 12] [virtual: 1989.699951171875ms, real: 551.3ms] Replaying input event on selector 'label:nth-child(1) > input:nth-child(1)'
[trace-id: 13] [virtual: 1989.699951171875ms, real: 551.5ms] PASS Found exact selector match for label:nth-child(1) > input:nth-child(1)
[trace-id: 17] [virtual: 1989.699951171875ms, real: 551.7ms] Scheduled new setTimeout with id 5 to execute at 2019.699951171875ms (stack trace = Error
    at onNewCallbackScheduled (<anonymous>:57:123347)
    at window.setTimeout (<anonymous>:57:118877)
    at HTMLInputElement.set [as value] (<anonymous>:16:25494)
    at t.simulateEvent (<anonymous>:57:102663)
```