### PR TITLE
More screenshotting options

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,9 @@
 export { Organization } from "./organization.types";
-export { Project, ProjectConfigurationData } from "./project.types";
+export {
+  Project,
+  ProjectConfigurationData,
+  ProjectSettingsScreenshottingOptions,
+} from "./project.types";
 export {
   EndStateScreenshot,
   ScreenshotAfterEvent,

--- a/packages/api/src/project.types.ts
+++ b/packages/api/src/project.types.ts
@@ -1,6 +1,7 @@
 import { Organization } from "./organization.types";
 import { TestCase } from "./replay/test-run.types";
 import { NetworkStubbingMode } from "./sdk-bundle-api/sdk-to-bundle/network-stubbing";
+import { ScreenshottingEnabledOptions } from "./sdk-bundle-api/sdk-to-bundle/screenshotting-options";
 
 export interface Project {
   id: string;
@@ -13,8 +14,16 @@ export interface Project {
   isGitHubIntegrationActive?: boolean;
   settings: {
     networkStubbingMode?: NetworkStubbingMode;
+    defaultScreenshottingOptions?: ProjectSettingsScreenshottingOptions;
   };
 }
+
+export type ProjectSettingsScreenshottingOptions = Partial<
+  Pick<
+    ScreenshottingEnabledOptions,
+    "waitBeforeScreenshotsMs" | "captureFullPage"
+  >
+>;
 
 export interface ProjectConfigurationData {
   testCases?: TestCase[];

--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/screenshotting-options.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/screenshotting-options.ts
@@ -15,6 +15,9 @@ export interface ScreenshotAssertionsEnabledOptions
 export interface ScreenshottingEnabledOptions {
   enabled: true;
   storyboardOptions: StoryboardOptions;
+
+  waitBeforeScreenshotsMs?: number;
+  captureFullPage?: boolean;
 }
 
 export declare type StoryboardOptions = { enabled: false } | { enabled: true };

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -1,4 +1,7 @@
-import { ScreenshotDiffOptions } from "@alwaysmeticulous/api";
+import {
+  ScreenshotDiffOptions,
+  StoryboardOptions,
+} from "@alwaysmeticulous/api";
 import { applyDefaultExecutionOptionsFromProject } from "@alwaysmeticulous/client";
 import { defer } from "@alwaysmeticulous/common";
 import { replayAndStoreResults } from "@alwaysmeticulous/replay-orchestrator-launcher";
@@ -9,7 +12,6 @@ import {
   ReplayExecutionOptions,
   ReplayTarget,
   ScreenshotComparisonOptions,
-  StoryboardOptions,
 } from "@alwaysmeticulous/sdk-bundles-api";
 import { buildCommand } from "../../command-utils/command-builder";
 import {
@@ -18,8 +20,8 @@ import {
   SCREENSHOT_DIFF_OPTIONS,
 } from "../../command-utils/common-options";
 import {
-  OutOfDateCLIError,
   isOutOfDateClientError,
+  OutOfDateCLIError,
 } from "../../utils/out-of-date-client-error";
 import { openStepThroughDebuggerUI } from "./utils/replay-debugger.ui";
 

--- a/packages/downloading-helpers/src/scripts/replay-assets.ts
+++ b/packages/downloading-helpers/src/scripts/replay-assets.ts
@@ -41,11 +41,11 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
     );
     const filePath = join(await getOrCreateAssetsDir(), assetFileName);
 
-    // if (entry && etag !== "" && etag === entry.etag) {
-    //   logger.debug(`${fetchUrl} already present`);
-    //   releaseLock();
-    //   return filePath;
-    // }
+    if (entry && etag !== "" && etag === entry.etag) {
+      logger.debug(`${fetchUrl} already present`);
+      releaseLock();
+      return filePath;
+    }
 
     const contents = (await client.get(fetchUrl)).data;
     await writeFile(filePath, contents);

--- a/packages/downloading-helpers/src/scripts/replay-assets.ts
+++ b/packages/downloading-helpers/src/scripts/replay-assets.ts
@@ -41,11 +41,11 @@ export const fetchAsset: (path: string) => Promise<string> = async (path) => {
     );
     const filePath = join(await getOrCreateAssetsDir(), assetFileName);
 
-    if (entry && etag !== "" && etag === entry.etag) {
-      logger.debug(`${fetchUrl} already present`);
-      releaseLock();
-      return filePath;
-    }
+    // if (entry && etag !== "" && etag === entry.etag) {
+    //   logger.debug(`${fetchUrl} already present`);
+    //   releaseLock();
+    //   return filePath;
+    // }
 
     const contents = (await client.get(fetchUrl)).data;
     await writeFile(filePath, contents);

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -11,8 +11,6 @@ export {
   OriginalRecordedURLReplayTarget,
   ReplayExecutionOptions,
   ReplayOrchestratorScreenshottingOptions,
-  ScreenshottingEnabledOptions,
-  StoryboardOptions,
   GeneratedBy,
   GeneratedByNotebookRun,
   GeneratedByTestRun,

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -1,6 +1,8 @@
 import {
-  ScreenshotDiffOptions,
   NetworkStubbingMode,
+  ScreenshotAssertionsEnabledOptions,
+  ScreenshotDiffOptions,
+  ScreenshottingEnabledOptions,
 } from "@alwaysmeticulous/api";
 import { LogLevelNumbers } from "loglevel";
 import { BeforeUserEventResult } from "../bundle-to-sdk/execute-replay";
@@ -180,15 +182,7 @@ export interface ReplayExecutionOptions {
 
 export type ReplayOrchestratorScreenshottingOptions =
   | { enabled: false }
-  | ScreenshottingEnabledOptions;
-
-export interface ScreenshottingEnabledOptions {
-  enabled: true;
-
-  storyboardOptions: StoryboardOptions;
-}
-
-export type StoryboardOptions = { enabled: false } | { enabled: true };
+  | Omit<ScreenshotAssertionsEnabledOptions, "diffOptions">;
 
 export type NotebookRunId = StringId<"notebookRunId">;
 export type TestRunId = StringId<"testRunId">;


### PR DESCRIPTION
This PR adds a couple extra screenshotting options -- optional wait before taking a screenshot and a flag to take a full page screenshot rather than viewport one.

Additionally, these will have default values on project level so `Project` API type is extended to include those.