### PR TITLE
Throw instead of process.exit(1)

### DIFF
--- a/packages/downloading-helpers/src/scripts/replays.ts
+++ b/packages/downloading-helpers/src/scripts/replays.ts
@@ -62,11 +62,9 @@ export const getOrFetchReplayArchive = async (
 
     const downloadUrlData = await getReplayDownloadUrl(client, replayId);
     if (!downloadUrlData) {
-      logger.error(
+      throw new Error(
         "Error: Could not retrieve replay archive URL. This may be an invalid replay"
       );
-      await releaseLock();
-      process.exit(1);
     }
 
     await downloadFile(downloadUrlData.dowloadUrl, replayArchiveFile);


### PR DESCRIPTION
process.exit bypasses any try/catches if using this as a utility methods (was originally OK-ish since was only used by CLI originally)