### PR TITLE
Deprecate requestsBeforeNetworkRecordingStarted

### DIFF
--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
@@ -25,6 +25,9 @@ export interface SessionData {
   hostname: string;
   abandoned: boolean;
 
+  /**
+   * @deprecated This isn't set for new sessions.
+   */
   requestsBeforeNetworkRecordingStarted?: EarlyRequest[];
   applicationSpecificData?: ApplicationSpecificData;
 }


### PR DESCRIPTION
This field isn't set within the session data for newly recorded sessions.