### PR TITLE
Store head and base replay id for flakes

### DIFF
--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
@@ -121,3 +121,15 @@ export interface ScreenshotDiffResultFlake {
     SingleTryScreenshotDiffResult | ScreenshotDiffResultMissingBaseAndHead
   >;
 }
+
+export type ScreenshotDiffRetryResult = {
+  /**
+   * Only present on diffs from newer replays.
+   */
+  baseReplayId?: string;
+
+  /**
+   * Only present on diffs from newer replays.
+   */
+  headReplayId?: string;
+} & (SingleTryScreenshotDiffResult | ScreenshotDiffResultMissingBaseAndHead);


### PR DESCRIPTION
Without the head replay id it's impossible to find / load the correct screenshots for the flake retry