### PR TITLE
Add projectSettingsHash to ReplayExecutionOptions.

### DIFF
--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -179,13 +179,17 @@ export interface ReplayExecutionOptions {
    * This flag is useful to reduce noise when debugging.
    */
   essentialFeaturesOnly: boolean;
-
-  vercel?: VercelExecutionSettings;
-
+  
   /**
    * If populated, each header will be injected into all requests when fetching resources during a replay.
    */
   customRequestHeaders?: InjectableRequestHeader[];
+  
+  /**
+   * Hash of the project settings at the time the test run or replay was initiated. Used as part of `ReplayLogicVersion`
+   * to ensure that we don't compare screenshots that were generated from replays with different project settings.
+   */
+  projectSettingsHash?: string;
 }
 
 export interface VercelExecutionSettings {


### PR DESCRIPTION
Needed for https://github.com/alwaysmeticulous/meticulous/pull/2198

Also removes `VercelExecutionSettings` now that Vercel bypass tokens are handled as part of custom request headers.