### PR TITLE
Simplify recorder script injection

### DIFF
--- a/packages/cli/src/commands/record-login-flow/record-login-flow.command.ts
+++ b/packages/cli/src/commands/record-login-flow/record-login-flow.command.ts
@@ -5,6 +5,7 @@ import { recordLoginFlowSession } from "@alwaysmeticulous/record";
 import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 import { COMMON_RECORD_OPTIONS } from "../../command-utils/common-options";
+import { MANUAL_INIT_RECORDING_SNIPPET_PATH } from "../../utils/constants";
 
 export interface RecordCommandHandlerOptions {
   apiToken: string | null | undefined;
@@ -61,9 +62,8 @@ export const recordLoginFlowCommandHandler: (
   logger.debug(`Recording token: ${recordingToken}`);
 
   // 3. Load recording snippets
-  const recordingSnippet = await fetchAsset("v1/meticulous.js");
-  const earlyNetworkRecorderSnippet = await fetchAsset(
-    "record/v1/network-recorder.bundle.js"
+  const recordingSnippetManualInit = await fetchAsset(
+    MANUAL_INIT_RECORDING_SNIPPET_PATH
   );
 
   // 4. Start recording
@@ -71,8 +71,7 @@ export const recordLoginFlowCommandHandler: (
     recordingToken,
     devTools,
     bypassCSP,
-    recordingSnippet,
-    earlyNetworkRecorderSnippet,
+    recordingSnippetManualInit,
     width,
     height,
     uploadIntervalMs,

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -19,6 +19,7 @@ import {
   COMMON_RECORD_OPTIONS,
   OPTIONS,
 } from "../../command-utils/common-options";
+import { MANUAL_INIT_RECORDING_SNIPPET_PATH } from "../../utils/constants";
 
 export interface RecordCommandHandlerOptions {
   apiToken: string | null | undefined;
@@ -87,9 +88,8 @@ export const recordCommandHandler: (
   logger.debug(`Commit: ${commitSha}`);
 
   // 3. Load recording snippets
-  const recordingSnippet = await fetchAsset("v1/meticulous.js");
-  const earlyNetworkRecorderSnippet = await fetchAsset(
-    "record/v1/network-recorder.bundle.js"
+  const recordingSnippetManualInit = await fetchAsset(
+    MANUAL_INIT_RECORDING_SNIPPET_PATH
   );
 
   const cookieDir = join(getMeticulousLocalDataDir(), "cookies");
@@ -123,8 +123,7 @@ export const recordCommandHandler: (
     appCommitHash: commitSha,
     devTools,
     bypassCSP,
-    recordingSnippet,
-    earlyNetworkRecorderSnippet,
+    recordingSnippetManualInit,
     width,
     height,
     uploadIntervalMs,

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,0 +1,2 @@
+export const MANUAL_INIT_RECORDING_SNIPPET_PATH =
+  "v1/meticulous-manual-init.js";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,12 +6,6 @@ export {
 export { METICULOUS_LOGGER_NAME } from "./logger/console-logger";
 export { DebugLogger } from "./logger/debug-logger";
 export type {
-  RecordSessionFn,
-  RecordSessionOptions,
-  RecordLoginFlowOptions,
-  RecordLoginFlowSessionFn,
-} from "./types/record.types";
-export type {
   CreateReplayDebuggerFn,
   ReplayDebuggerDependencies,
   ReplayDebuggerOptions,

--- a/packages/record/src/record/record-login-flow.ts
+++ b/packages/record/src/record/record-login-flow.ts
@@ -1,11 +1,8 @@
-import {
-  defer,
-  METICULOUS_LOGGER_NAME,
-  RecordLoginFlowSessionFn,
-} from "@alwaysmeticulous/common";
+import { defer, METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import chalk from "chalk";
 import log from "loglevel";
 import { Browser, launch } from "puppeteer";
+import { RecordLoginFlowOptions } from "../types";
 import {
   DEFAULT_NAVIGATION_TIMEOUT_MS,
   DEFAULT_UPLOAD_INTERVAL_MS,
@@ -33,8 +30,7 @@ export const LOGIN_FLOW_DATA_SESSION_RECORDING_SOURCE =
 const bootstrapLoginFlowRecordingPage = async ({
   page,
   recordingToken,
-  recordingSnippet,
-  earlyNetworkRecorderSnippet,
+  recordingSnippetManualInit,
   uploadIntervalMs,
   captureHttpOnlyCookies,
   recordingSource,
@@ -57,25 +53,24 @@ const bootstrapLoginFlowRecordingPage = async ({
     page,
     recordingToken,
     appCommitHash: "unknown",
-    recordingSnippet,
-    earlyNetworkRecorderSnippet,
+    recordingSnippetManualInit,
+
     uploadIntervalMs: uploadIntervalMs || DEFAULT_UPLOAD_INTERVAL_MS,
     captureHttpOnlyCookies: captureHttpOnlyCookies ?? true,
     recordingSource,
   });
 };
 
-export const recordLoginFlowSession: RecordLoginFlowSessionFn = async ({
+export const recordLoginFlowSession = async ({
   recordingToken,
   devTools,
   bypassCSP,
-  recordingSnippet,
-  earlyNetworkRecorderSnippet,
+  recordingSnippetManualInit,
   width,
   height,
   uploadIntervalMs,
   captureHttpOnlyCookies,
-}) => {
+}: RecordLoginFlowOptions) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   logger.info("Opening browser...");
@@ -97,8 +92,8 @@ export const recordLoginFlowSession: RecordLoginFlowSessionFn = async ({
   await bootstrapLoginFlowRecordingPage({
     page: loginFlowPage,
     recordingToken,
-    recordingSnippet,
-    earlyNetworkRecorderSnippet,
+    recordingSnippetManualInit,
+
     uploadIntervalMs,
     captureHttpOnlyCookies,
     bypassCSP,
@@ -155,8 +150,8 @@ export const recordLoginFlowSession: RecordLoginFlowSessionFn = async ({
         await bootstrapLoginFlowRecordingPage({
           page: loginDataPage,
           recordingToken,
-          recordingSnippet,
-          earlyNetworkRecorderSnippet,
+          recordingSnippetManualInit,
+
           uploadIntervalMs: uploadIntervalMs,
           captureHttpOnlyCookies: captureHttpOnlyCookies,
           bypassCSP,

--- a/packages/record/src/record/record.ts
+++ b/packages/record/src/record/record.ts
@@ -1,11 +1,9 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
-import {
-  METICULOUS_LOGGER_NAME,
-  RecordSessionFn,
-} from "@alwaysmeticulous/common";
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import log from "loglevel";
-import puppeteer, { Browser, launch, PuppeteerNode } from "puppeteer";
+import puppeteer, { Browser, PuppeteerNode, launch } from "puppeteer";
+import { RecordSessionOptions } from "../types";
 import {
   DEFAULT_NAVIGATION_TIMEOUT_MS,
   DEFAULT_UPLOAD_INTERVAL_MS,
@@ -15,13 +13,12 @@ import { bootstrapPage } from "./record.utils";
 
 const COOKIE_FILENAME = "cookies.json";
 
-export const recordSession: RecordSessionFn = async ({
+export const recordSession = async ({
   recordingToken,
   appCommitHash,
   devTools,
   bypassCSP,
-  recordingSnippet,
-  earlyNetworkRecorderSnippet,
+  recordingSnippetManualInit,
   width,
   height,
   uploadIntervalMs,
@@ -30,7 +27,7 @@ export const recordSession: RecordSessionFn = async ({
   debugLogger,
   onDetectedSession,
   captureHttpOnlyCookies,
-}) => {
+}: RecordSessionOptions) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
   logger.info("Opening browser...");
@@ -41,7 +38,7 @@ export const recordSession: RecordSessionFn = async ({
     appCommitHash,
     devTools,
     bypassCSP,
-    recordingSnippet,
+    recordingSnippetManualInit,
     width,
     height,
     uploadIntervalMs,
@@ -118,8 +115,7 @@ export const recordSession: RecordSessionFn = async ({
     page,
     recordingToken,
     appCommitHash,
-    recordingSnippet,
-    earlyNetworkRecorderSnippet,
+    recordingSnippetManualInit,
     uploadIntervalMs: uploadIntervalMs || DEFAULT_UPLOAD_INTERVAL_MS,
     captureHttpOnlyCookies: captureHttpOnlyCookies ?? true,
   });

--- a/packages/record/src/types.ts
+++ b/packages/record/src/types.ts
@@ -1,12 +1,11 @@
-import type { DebugLogger } from "../logger/debug-logger";
+import { DebugLogger } from "@alwaysmeticulous/common";
 
 export interface RecordSessionOptions {
   recordingToken: string;
   appCommitHash: string;
   devTools?: boolean | null | undefined;
   bypassCSP?: boolean | null | undefined;
-  recordingSnippet: string;
-  earlyNetworkRecorderSnippet: string;
+  recordingSnippetManualInit: string;
   width?: number | null | undefined;
   height?: number | null | undefined;
   uploadIntervalMs?: number | null | undefined;
@@ -25,9 +24,3 @@ export type RecordLoginFlowOptions = Omit<
   | "debugLogger"
   | "onDetectedSession"
 >;
-
-export type RecordSessionFn = (options: RecordSessionOptions) => Promise<void>;
-
-export type RecordLoginFlowSessionFn = (
-  options: RecordLoginFlowOptions
-) => Promise<void>;


### PR DESCRIPTION
Simplifies the injection of recorder scripts by injecting 'v1/meticulous-manual-init.js' and only initializing in intended frames, instead of installing the early network recorder, and then later only injecting 'v1/meticulous.js' in intended frames.

Note that `.on('frame_navigated', frame => frame.evaluate(...))` does not guarantee that the injected code is executed before any other code on the page (and in practice often evaluates it after), which is why the early network recorder used to be required. In contrast evaluateOnNewDocument does provide this guarantee.

This simplification also works around a potential bug in Chrome for Testing, where the combination of the 'v1/meticulous.js' AND the early network recorder javascript AND Chrome for Testing (instead of the older versions of Chrome used by older Puppeteer) lead to an 'Aw Snap!' error at the point in time when the early network recorder javascript is injected into some sub-iframes (for example when navigating from google.com to google images). This bug does not happen when one of these three elements is not present, and has not been fully root caused. Full details in Linear issue ENG-803.