### PR TITLE
Require an app URL when running all tests

### DIFF
--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -131,9 +131,10 @@ export const runAllTestsCommand = buildCommand("run-all-tests")
         "The base commit to compare test results against for test cases that don't have a baseReplayId specified.",
     },
     appUrl: {
+      demandOption: true,
       string: true,
       description:
-        "The URL to execute the tests against. If left absent here and in the test cases file, then will use the URL the test was originally recorded against.",
+        "The URL to execute the tests against. This parameter is required.",
     },
     githubSummary: {
       boolean: true,


### PR DESCRIPTION
As discussed, this is a potential pitfall because we usually have tests recorded against a number of different URLs that may not be accessible from where we're running them. It's better to avoid this and force the user to pass in an app URL in this case.

Resolves ENG-792.