### PR TITLE
Download diffs too when downloading a replay

### DIFF
--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
@@ -86,6 +86,12 @@ export interface ScreenshotDiffResultCompared {
   /** Relative path to the replay archive */
   baseScreenshotFile: string;
 
+  /** Relative path to the replay archive */
+  diffThumbnailFile?: string;
+
+  /** Relative path to the replay archive */
+  diffFullFile?: string;
+
   width: number;
   height: number;
   mismatchPixels: number;

--- a/packages/client/src/api/replay.api.ts
+++ b/packages/client/src/api/replay.api.ts
@@ -48,6 +48,10 @@ export type ReplayV3UploadLocations = Record<string, S3UploadLocation> & {
     string,
     { image: S3UploadLocation; metadata?: S3UploadLocation }
   >;
+  diffs?: Record<
+    string,
+    Record<string, { thumbnail: S3UploadLocation; full: S3UploadLocation }>
+  >;
 };
 
 export const getReplayV3DownloadUrls: (

--- a/packages/downloading-helpers/src/scripts/replays.ts
+++ b/packages/downloading-helpers/src/scripts/replays.ts
@@ -166,24 +166,27 @@ const downloadReplayV3Files = async (
     )
   );
 
-  const diffsPromises = Object.values(diffs ?? {}).flatMap((diffsForBase) => {
-    return Object.values(diffsForBase).flatMap((urls) => {
-      return [
-        async () => {
-          await downloadFile(
-            urls.full.signedUrl,
-            join(replayDir, urls.full.filePath)
-          );
-        },
-        async () => {
-          await downloadFile(
-            urls.thumbnail.signedUrl,
-            join(replayDir, urls.thumbnail.filePath)
-          );
-        },
-      ];
-    });
-  });
+  const diffsPromises =
+    downloadScope === "everything"
+      ? Object.values(diffs ?? {}).flatMap((diffsForBase) => {
+          return Object.values(diffsForBase).flatMap((urls) => {
+            return [
+              async () => {
+                await downloadFile(
+                  urls.full.signedUrl,
+                  join(replayDir, urls.full.filePath)
+                );
+              },
+              async () => {
+                await downloadFile(
+                  urls.thumbnail.signedUrl,
+                  join(replayDir, urls.thumbnail.filePath)
+                );
+              },
+            ];
+          });
+        })
+      : [];
 
   const snapshottedAssetsPromises =
     downloadScope === "everything"


### PR DESCRIPTION
This will marginally improve my debugging experience by allowing me to download diff screenshots using the CLI. It also means we handle a return value containing the diffs, which will allow us to start actually returning this from the backend.