### PR TITLE
Fix record login flow 

### DIFF
--- a/packages/record/src/record/record-login-flow.ts
+++ b/packages/record/src/record/record-login-flow.ts
@@ -89,17 +89,6 @@ export const recordLoginFlowSession = async ({
 
   const loginFlowPage = await context.newPage();
 
-  await bootstrapLoginFlowRecordingPage({
-    page: loginFlowPage,
-    recordingToken,
-    recordingSnippetManualInit,
-
-    uploadIntervalMs,
-    captureHttpOnlyCookies,
-    bypassCSP,
-    recordingSource: LOGIN_FLOW_SESSION_RECORDING_SOURCE,
-  });
-
   let isRecordingComplete = false;
   let onDataSessionSaved = false;
   let startedLoginSessionRecording = false;
@@ -178,6 +167,17 @@ export const recordLoginFlowSession = async ({
     loginFlowPage,
     "__meticulousFinishRecording"
   );
+
+  await bootstrapLoginFlowRecordingPage({
+    page: loginFlowPage,
+    recordingToken,
+    recordingSnippetManualInit,
+
+    uploadIntervalMs,
+    captureHttpOnlyCookies,
+    bypassCSP,
+    recordingSource: LOGIN_FLOW_SESSION_RECORDING_SOURCE,
+  });
 
   await loginFlowPage.goto(INITIAL_METICULOUS_RECORD_LOGIN_FLOW_DOCS_URL);
 

--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -1,6 +1,4 @@
 import { readFile } from "fs/promises";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import log from "loglevel";
 import { Page } from "puppeteer";
 import {
   INITIAL_METICULOUS_RECORD_DOCS_URL,


### PR DESCRIPTION
Previously would always give a 'Invalid arguments: should be exactly one string' on Meticulous initialization. I think you get this if you call a Puppeteer exploreFunction while it's still initialising, and the evaluateOnNewDocument must have been happening while `__meticulous_onBeginRecording` was being attached or something. This shifts the ordering to ensure the methods are guaranteed to be bound before they are called.