### PR TITLE
wait for DOMContentLoaded rather than network idle

### DIFF
--- a/packages/record/src/record/record-login-flow.ts
+++ b/packages/record/src/record/record-login-flow.ts
@@ -148,7 +148,9 @@ export const recordLoginFlowSession = async ({
         });
 
         // Navigate to the final login flow url and flush any pending payloads
-        await loginDataPage.goto(finalLoginUrl, { waitUntil: "networkidle0" });
+        await loginDataPage.goto(finalLoginUrl, {
+          waitUntil: "domcontentloaded",
+        });
         await loginDataPage.evaluate(() => {
           (window as ModifiedWindow).__meticulous?.flushPendingPayloads?.();
         });


### PR DESCRIPTION
We're interested in capturing the application storage right after navigating to the page so there isn't a need to wait for network idle.

Should fix ENG-816