### PR TITLE
Better handling for Axios errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
     "@alwaysmeticulous/sdk-bundles-api": "^2.97.0",
     "@alwaysmeticulous/sentry": "^2.72.0",
     "@sentry/node": "^7.36.0",
+    "axios": "^1.2.6",
     "loglevel": "^1.8.0",
     "puppeteer": "21.9.0",
     "yargs": "^17.5.1"


### PR DESCRIPTION
Previously this would print:

```
Request failed with status code 400
```

Which isn't very informative.

Now it prints:

```
Request failed with status code 400
Session 2024-01-31T18%3A06%<redacted> does not exist
```