### PR TITLE
Tone down data dir warnings

### DIFF
--- a/packages/common/src/local-data/local-data.ts
+++ b/packages/common/src/local-data/local-data.ts
@@ -7,10 +7,10 @@ let _localDataDir = "";
 export const getMeticulousLocalDataDir: () => string = () => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   if (!_localDataDir) {
-    logger.warn(
-      "Local data dir has not been set by setMeticulousLocalDataDir()!"
-    );
     setMeticulousLocalDataDir();
+    logger.debug(
+      `Local data dir has not been set explictly, so defaulting to ${_localDataDir}`
+    );
   }
   logger.debug(`Meticulous local data dir: ${_localDataDir}`);
   return _localDataDir;

--- a/packages/common/src/local-data/local-data.ts
+++ b/packages/common/src/local-data/local-data.ts
@@ -11,8 +11,9 @@ export const getMeticulousLocalDataDir: () => string = () => {
     logger.debug(
       `Local data dir has not been set explictly, so defaulting to ${_localDataDir}`
     );
+  } else {
+    logger.debug(`Using local data dir at ${_localDataDir}`);
   }
-  logger.debug(`Meticulous local data dir: ${_localDataDir}`);
   return _localDataDir;
 };
 


### PR DESCRIPTION
The local data dir defaults to ~/.meticulous and this is normally what is desired and relied upon. We only explicitly set the data dir if:

1. The user passes the --dataDir flag via the CLI
2. In execute session task handler and replay task handler (and in these cases it just grabs `getMeticulousLocalDataDir()` in the spawner process and sends that string through to the spawned process)