### PR TITLE
Provide cookie access prior to recorder initialisation

### DIFF
--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -59,6 +59,9 @@ export async function bootstrapPage({
     { recordingToken, appCommitHash, recordingSource, uploadIntervalMs }
   );
   await page.evaluateOnNewDocument(recordingSnippetFile);
+  if (captureHttpOnlyCookies) {
+    await provideCookieAccess(page);
+  }
   await page.evaluateOnNewDocument(
     (forbiddenUrls) => {
       /**
@@ -96,8 +99,4 @@ export async function bootstrapPage({
       METICULOUS_RECORD_LOGIN_FLOW_SAVING_DOCS_URL,
     ]
   );
-
-  if (captureHttpOnlyCookies) {
-    await provideCookieAccess(page);
-  }
 }

--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -7,12 +7,6 @@ import {
 } from "./constants";
 import { provideCookieAccess } from "./utils/provide-cookie-access";
 
-/**
- * The recorder crashes if it tries to initialize on a chrome-error page
- * (Chrome e.g. uses this page for HTTP basic auth popups before the user has authenticated)
- */
-const FORBIDDEN_PROTOCOLS = ["chrome://", "chrome-error://"];
-
 interface MeticulousRecorderWindow {
   METICULOUS_RECORDING_TOKEN?: string;
   METICULOUS_APP_COMMIT_HASH?: string;

--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -7,6 +7,12 @@ import {
 } from "./constants";
 import { provideCookieAccess } from "./utils/provide-cookie-access";
 
+/**
+ * The recorder crashes if it tries to initialize on a chrome-error page
+ * (Chrome e.g. uses this page for HTTP basic auth popups before the user has authenticated)
+ */
+const FORBIDDEN_PROTOCOLS = ["chrome://", "chrome-error://"];
+
 interface MeticulousRecorderWindow {
   METICULOUS_RECORDING_TOKEN?: string;
   METICULOUS_APP_COMMIT_HASH?: string;


### PR DESCRIPTION
`getAllCookies` wasn't defined on the meticulous object when `initMeticulousRecorder` called it which meant we weren't capturing httpOnly cookies properly.

Not sure if there was a reason for providing cookie access after initialising the recorder but this seemed to work from local testing.