### PR TITLE
Add CSP warning

### DIFF
--- a/packages/record/src/record/constants.ts
+++ b/packages/record/src/record/constants.ts
@@ -13,8 +13,18 @@ export const INITIAL_METICULOUS_RECORD_LOGIN_FLOW_DOCS_URL =
 export const METICULOUS_RECORD_LOGIN_FLOW_SAVING_DOCS_URL =
   "https://app.meticulous.ai/docs/recording-a-login-flow-saving";
 
+export const METICULOUS_BYPASS_CSP_DOCS_URL =
+  "https://app.meticulous.ai/docs/recorder-errors/re-run-with-bypass-csp";
+
 export const COMMON_RECORD_CHROME_LAUNCH_ARGS = [
   // Unsets navigator.webdriver during recording to provide more consistent behavior
   // between Chrome for Test and Chrome.
   "--disable-blink-features=AutomationControlled",
+];
+
+// We don't require https://snippet.meticulous.ai since the snippet is injected via
+// evaluateOnNewDocument
+export const REQUIRED_CSP_ORIGINS = [
+  "https://cognito-identity.us-west-2.amazonaws.com",
+  "https://user-events-v3.s3-accelerate.amazonaws.com",
 ];


### PR DESCRIPTION
If the URLs required for the recorder get CSP blocked then it'll redirect to:

![image](https://github.com/alwaysmeticulous/meticulous-sdk/assets/793481/b15d6988-379d-413c-a0c6-56b5de31940e)
