### PR TITLE
Break out WebSocket event types into their own interfaces

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -55,10 +55,17 @@ export {
   ApplicationSpecificData,
   StorageEntry,
   EarlyRequest,
+} from "./sdk-bundle-api/sdk-to-bundle/session-data";
+export {
   SequenceNumber,
   WebSocketConnectionData,
   WebSocketConnectionEvent,
-} from "./sdk-bundle-api/sdk-to-bundle/session-data";
+  WebSocketConnectionCreatedEvent,
+  WebSocketConnectionOpenedEvent,
+  WebSocketConnectionMessageEvent,
+  WebSocketConnectionErrorEvent,
+  WebSocketConnectionClosedEvent,
+} from "./sdk-bundle-api/sdk-to-bundle/websocket-data";
 export { Replay } from "./replay/replay.types";
 export {
   ScreenshotAssertionsOptions,

--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
@@ -1,5 +1,6 @@
 import { ReplayableEvent } from "../bidirectional/replayable-event";
 import { HarLog } from "./har-log";
+import { WebSocketConnectionData } from "./websocket-data";
 
 export interface SessionData {
   userEvents: {
@@ -98,26 +99,4 @@ export interface EarlyRequest {
   initiatorType: "fetch" | "xmlhttprequest";
   startTime: number;
   duration: number;
-}
-
-export type SequenceNumber = number;
-
-export interface WebSocketConnectionData {
-  id: SequenceNumber;
-  url: string;
-  events: WebSocketConnectionEvent[];
-}
-
-export interface WebSocketConnectionEvent {
-  /**
-   * The time in milliseconds since the start of the session.
-   * 
-   * During simulations, we consider the "created" event to have been replayed whenever the browser calls 
-   * `new WebSocket()` and all other events are replayed at a time relative to the "created" event's timestamp.
-   * 
-   * E.g. the "opened" event is replayed at ("opened".timestamp - "created".timestamp) milliseconds after the browser calls `new WebSocket()`.
-   */
-  timestamp: number;
-  type: "created" | "opened" | "message-sent" | "message-received" | "closed" | "error";
-  data?: string;
 }

--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/websocket-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/websocket-data.ts
@@ -1,0 +1,59 @@
+export interface WebSocketConnectionData {
+  id: SequenceNumber;
+  url: string;
+  events: WebSocketConnectionEvent[];
+}
+
+export type SequenceNumber = number;
+
+export type WebSocketConnectionEvent =
+  | WebSocketConnectionCreatedEvent
+  | WebSocketConnectionOpenedEvent
+  | WebSocketConnectionMessageEvent
+  | WebSocketConnectionErrorEvent
+  | WebSocketConnectionClosedEvent;
+
+export interface WebSocketConnectionGenericEvent {
+  /**
+   * The time in milliseconds since the start of the session.
+   *
+   * During simulations, we consider the "created" event to have been replayed whenever the browser calls
+   * `new WebSocket()` and all other events are replayed at a time relative to the "created" event's timestamp.
+   *
+   * E.g. the "opened" event is replayed at ("opened".timestamp - "created".timestamp) milliseconds after the browser calls `new WebSocket()`.
+   */
+  timestamp: number;
+  type: unknown;
+  data?: unknown;
+}
+
+export interface WebSocketConnectionCreatedEvent
+  extends WebSocketConnectionGenericEvent {
+  type: "created";
+}
+
+export interface WebSocketConnectionOpenedEvent
+  extends WebSocketConnectionGenericEvent {
+  type: "opened";
+}
+
+export interface WebSocketConnectionMessageEvent
+  extends WebSocketConnectionGenericEvent {
+  type: "message-sent" | "message-received";
+  data: string;
+}
+
+export interface WebSocketConnectionErrorEvent
+  extends WebSocketConnectionGenericEvent {
+  type: "error";
+}
+
+export interface WebSocketConnectionClosedEvent
+  extends WebSocketConnectionGenericEvent {
+  type: "closed";
+  data: {
+    code: number;
+    reason: string;
+    wasClean: boolean;
+  };
+}


### PR DESCRIPTION
Makes it easier to support structured data for specific event types (e.g. "close"), and lays the groundwork for binary message type support.