### PR TITLE
Don't redact passwords when recording a login

### DIFF
--- a/packages/cli/src/commands/record-login/record-login.command.ts
+++ b/packages/cli/src/commands/record-login/record-login.command.ts
@@ -84,7 +84,8 @@ export const recordLoginFlowCommandHandler: (
 
 export const recordLoginCommand = buildCommand("record-login")
   .details({
-    describe: "Record a login flow session",
+    describe:
+      "Record a login flow session (warning: sessions recorded with this command will store credentials)",
   })
   .options({
     ...COMMON_RECORD_OPTIONS,

--- a/packages/record/src/record/record-login-flow.ts
+++ b/packages/record/src/record/record-login-flow.ts
@@ -59,6 +59,7 @@ const bootstrapLoginFlowRecordingPage = async ({
     uploadIntervalMs: uploadIntervalMs || DEFAULT_UPLOAD_INTERVAL_MS,
     captureHttpOnlyCookies: captureHttpOnlyCookies ?? true,
     recordingSource,
+    disablePasswordRedaction: true,
   });
 };
 

--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -30,6 +30,7 @@ export async function bootstrapPage({
   uploadIntervalMs,
   captureHttpOnlyCookies,
   recordingSource = "cli",
+  disablePasswordRedaction,
 }: {
   page: Page;
   recordingToken: string;
@@ -38,6 +39,7 @@ export async function bootstrapPage({
   uploadIntervalMs: number | null;
   captureHttpOnlyCookies: boolean;
   recordingSource?: string;
+  disablePasswordRedaction?: boolean;
 }): Promise<void> {
   const recordingSnippetFile = await readFile(recordingSnippet, "utf8");
 
@@ -53,7 +55,7 @@ export async function bootstrapPage({
       if (uploadIntervalMs != null) {
         recorderWindow["METICULOUS_UPLOAD_INTERVAL_MS"] = uploadIntervalMs;
       }
-      if (recordingSource === "cli-login-flow") {
+      if (disablePasswordRedaction) {
         recorderWindow["METICULOUS_REDACT_PASSWORDS"] = false;
       }
     },

--- a/packages/record/src/record/record.utils.ts
+++ b/packages/record/src/record/record.utils.ts
@@ -14,6 +14,7 @@ interface MeticulousRecorderWindow {
   METICULOUS_RECORDING_SOURCE?: string;
   METICULOUS_UPLOAD_INTERVAL_MS?: number;
   METICULOUS_ENABLE_RRWEB_PLUGIN_NODE_DATA?: boolean;
+  METICULOUS_REDACT_PASSWORDS?: boolean;
 
   __meticulous?: {
     initialiseRecorder?: () => void;
@@ -51,6 +52,9 @@ export async function bootstrapPage({
 
       if (uploadIntervalMs != null) {
         recorderWindow["METICULOUS_UPLOAD_INTERVAL_MS"] = uploadIntervalMs;
+      }
+      if (recordingSource === "cli-login-flow") {
+        recorderWindow["METICULOUS_REDACT_PASSWORDS"] = false;
       }
     },
     { recordingToken, appCommitHash, recordingSource, uploadIntervalMs }


### PR DESCRIPTION
After a matching internal PR is merged, we'll respect this environment variable in the recorder to avoid redacting passwords if we were invoked by the `record-login` CLI command.