### PR TITLE
Mark Meticulous super user usage as development

### DIFF
--- a/packages/cli/src/command-utils/common-options.ts
+++ b/packages/cli/src/command-utils/common-options.ts
@@ -12,8 +12,8 @@
 import {
   DEFAULT_EXECUTION_OPTIONS,
   DEFAULT_SCREENSHOTTING_OPTIONS,
+  IS_METICULOUS_SUPER_USER,
 } from "@alwaysmeticulous/common";
-import { IS_METICULOUS_SUPER_USER } from "../utils/constants";
 
 // Used in tips in console output
 export const HEADLESS_FLAG = "--headless";

--- a/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
+++ b/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 
 import { getApiToken } from "@alwaysmeticulous/client";
-import { defer, METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import {
+  defer,
+  IS_METICULOUS_SUPER_USER,
+  METICULOUS_LOGGER_NAME,
+} from "@alwaysmeticulous/common";
 import {
   IncomingRequestEvent,
   localtunnel,
 } from "@alwaysmeticulous/tunnels-client";
 import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
-import { IS_METICULOUS_SUPER_USER } from "../../utils/constants";
 
 interface Options {
   apiToken: string | undefined;

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,3 +1,1 @@
 export const RECORDING_SNIPPET_PATH = "v1/meticulous.js";
-
-export const IS_METICULOUS_SUPER_USER = !!process.env["METICULOUS_SUPER_USER"];

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -3,6 +3,8 @@ import { ReplayExecutionOptions } from "@alwaysmeticulous/sdk-bundles-api";
 
 export const BASE_SNIPPETS_URL = "https://snippet.meticulous.ai/";
 
+export const IS_METICULOUS_SUPER_USER = !!process.env["METICULOUS_SUPER_USER"];
+
 export const DEFAULT_EXECUTION_OPTIONS: ReplayExecutionOptions = {
   headless: true,
   devTools: false,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,6 +20,7 @@ export {
   DEFAULT_SCREENSHOTTING_OPTIONS,
   BASE_SNIPPETS_URL,
   COMMON_CHROMIUM_FLAGS,
+  IS_METICULOUS_SUPER_USER,
 } from "./constants";
 export { getMeticulousVersion } from "./version.utils";
 export { getCommitSha } from "./commit-sha.utils";

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -19,6 +19,7 @@
     "depcheck": "depcheck --ignore-patterns=dist"
   },
   "dependencies": {
+    "@alwaysmeticulous/common": "^2.116.0",
     "@sentry/node": "^7.36.0",
     "@sentry/tracing": "^7.36.0",
     "luxon": "^3.2.1"

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -1,3 +1,4 @@
+import { IS_METICULOUS_SUPER_USER } from "@alwaysmeticulous/common";
 import * as Sentry from "@sentry/node";
 import { addExtensionMethods } from "@sentry/tracing";
 import { Duration } from "luxon";
@@ -28,7 +29,10 @@ export const initSentry: (
     release: meticulousVersion,
 
     tracesSampleRate: tracesSampleRateOverride ?? getTracesSampleRate(),
-    environment: __filename.endsWith(".ts") ? "development" : "production",
+    environment:
+      __filename.endsWith(".ts") || IS_METICULOUS_SUPER_USER
+        ? "development"
+        : "production",
   });
 
   addExtensionMethods();


### PR DESCRIPTION
This will prevent stuff ending up in our prod
Sentry when testing stuff locally.