### PR TITLE
Default or missing port throws an error

### DIFF
--- a/packages/remote-replay-launcher/package.json
+++ b/packages/remote-replay-launcher/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint src --ext=ts,tsx,js --cache",
     "lint:commit": "eslint --cache $(git diff --relative --name-only --diff-filter=ACMRTUXB master | grep  -E \"(.js$|.ts$|.tsx$)\")",
     "lint:fix": "eslint src --ext=ts,tsx,js --cache --fix",
-    "depcheck": "depcheck --ignore-patterns=dist"
+    "depcheck": "depcheck --ignore-patterns=dist",
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@alwaysmeticulous/client": "^2.121.0",
@@ -40,5 +41,22 @@
   },
   "bugs": {
     "url": "https://github.com/alwaysmeticulous/meticulous-sdk/issues"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
   }
 }

--- a/packages/remote-replay-launcher/src/__tests__/url.utils.spec.ts
+++ b/packages/remote-replay-launcher/src/__tests__/url.utils.spec.ts
@@ -1,0 +1,18 @@
+import { getPort } from "../url.utils";
+
+describe("getPort", () => {
+  it("returns the port when the port is defined", () => {
+    const url = new URL("http://localhost:3000");
+    expect(getPort(url)).toEqual(3000);
+  });
+
+  it("returns the port when the port is not", () => {
+    const url = new URL("http://localhost");
+    expect(getPort(url)).toEqual(80);
+  });
+
+  it("returns the port when the port matches the default for the protocol", () => {
+    const url = new URL("https://localhost:443");
+    expect(getPort(url)).toEqual(443);
+  });
+});

--- a/packages/remote-replay-launcher/src/index.ts
+++ b/packages/remote-replay-launcher/src/index.ts
@@ -13,6 +13,7 @@ import {
   ExecuteRemoteTestRunOptions,
   ExecuteRemoteTestRunResult,
 } from "./types";
+import { getPort } from "./url.utils";
 
 const PROGRESS_UPDATE_INTERVAL_MS = 5_000; // 5 seconds
 
@@ -44,11 +45,16 @@ export const executeRemoteTestRun = async ({
     throw new Error(`Invalid app URL: ${appUrl}`);
   }
 
+  const port = getPort(url);
+  if (port === -1) {
+    throw new Error(`Invalid app URL port: ${appUrl}`);
+  }
+
   const tunnel = await localtunnel({
     logger,
     apiToken,
     localHost: url.hostname,
-    port: parseInt(url.port, 10),
+    port,
     localHttps: false,
     allowInvalidCert: false,
   });

--- a/packages/remote-replay-launcher/src/url.utils.ts
+++ b/packages/remote-replay-launcher/src/url.utils.ts
@@ -1,0 +1,26 @@
+export function getPort(url: URL): number {
+  //https://developer.mozilla.org/en-US/docs/Web/API/URL/port
+  //Port is an empty string, if the default port for the protocol is used
+
+  if (url.port === "") {
+    switch (url.protocol) {
+      case "http:":
+      case "ws:":
+        return 80;
+      case "https:":
+      case "wss:":
+        return 443;
+      case "ftp:":
+        return 21;
+      default:
+        return -1;
+    }
+  }
+
+  const port = parseInt(url.port, 10);
+  if (isNaN(port)) {
+    return -1;
+  }
+
+  return port;
+}


### PR DESCRIPTION
Fix for when a URL's port matches the default for the protocol, the url.port object is an empty string.
This also happens when a port is not provided in the URL.

See note on:
https://developer.mozilla.org/en-US/docs/Web/API/URL/port

Received the error whilst attempting to run the Github cloud action, with a vanilla url (eg "https://pr.somedomain.com"). The URL parsed to a port of "", where parseInt returned NaN. 

<img width="1178" alt="image" src="https://github.com/alwaysmeticulous/meticulous-sdk/assets/78453244/8b5bdeb1-dc69-45a7-ab0c-f1fb43d9d113">
