### PR TITLE
Force close remote secure tunnel connections

### DIFF
--- a/packages/tunnel-client/src/lib/tunnel-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-cluster.ts
@@ -90,7 +90,7 @@ export class TunnelCluster extends (EventEmitter as new () => TypedEmitter<Tunne
         );
       }
 
-      remote.end();
+      remote.destroy();
     });
 
     const connLocal = () => {
@@ -164,7 +164,7 @@ export class TunnelCluster extends (EventEmitter as new () => TypedEmitter<Tunne
         remote.removeListener("close", remoteClose);
 
         if (err.code !== "ECONNREFUSED" && err.code !== "ECONNRESET") {
-          return remote.end();
+          return remote.destroy();
         }
 
         // retrying connection to local server
@@ -191,6 +191,7 @@ export class TunnelCluster extends (EventEmitter as new () => TypedEmitter<Tunne
         // when local closes, also get a new remote
         local.once("close", (hadError) => {
           this.logger.debug("local connection closed [%s]", hadError);
+          remote.destroy();
         });
       });
     };


### PR DESCRIPTION
### Motivation

We're seeing some requests to secure tunnel deployments timing out / tunnels disconnecting. It looks sometimes we get into a state where the reverse proxy connections are not properly closed leading to sockets being 'stuck' in `FIN-WAIT-2` / `WAIT_CLOSE` states. At some point all connections of the pool get stuck in a shutting down state leading to the tunnel not being able to process any more requests and disconnecing.

TImeouts are also possible due to the constraint connection pool capacity.

### Changes

This PR updates the secure tunnel client to forcefully shutdown remote connections on error / after connection to the locally exposed service is closed. This shoukd prevent the pool from saturating and properly close the connections. 