### PR TITLE
Set port in host header transformer

### DIFF
--- a/packages/tunnel-client/src/lib/header-host-transformer.ts
+++ b/packages/tunnel-client/src/lib/header-host-transformer.ts
@@ -1,12 +1,17 @@
-import { Transform, TransformCallback } from "stream";
+import { Transform, TransformCallback, TransformOptions } from "stream";
+
+type HeaderHostTransformerOptions = TransformOptions & {
+  host: string;
+  port: number;
+};
 
 export class HeaderHostTransformer extends Transform {
   private readonly host: string;
   private replaced: boolean;
 
-  constructor(opts: any) {
+  constructor(opts: HeaderHostTransformerOptions) {
     super(opts);
-    this.host = opts.host || "localhost";
+    this.host = `${opts.host}:${opts.port}`;
     this.replaced = false;
   }
 

--- a/packages/tunnel-client/src/lib/tunnel-connection-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-connection-cluster.ts
@@ -182,7 +182,10 @@ export class TunnelConnectionCluster extends (EventEmitter as new () => TypedEmi
         if (opt.localHost) {
           this.logger.debug("transform Host header to %s", opt.localHost);
           stream = remote.pipe(
-            new HeaderHostTransformer({ host: opt.localHost })
+            new HeaderHostTransformer({
+              host: opt.localHost,
+              port: opt.localPort,
+            })
           );
         }
 

--- a/packages/tunnel-client/src/lib/tunnel-multiplexing-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-multiplexing-cluster.ts
@@ -126,7 +126,10 @@ export class TunnelMultiplexingCluster extends (EventEmitter as new () => TypedE
         if (opt.localHost) {
           this.logger.debug("transform Host header to %s", opt.localHost);
           stream = remote.pipe(
-            new HeaderHostTransformer({ host: opt.localHost })
+            new HeaderHostTransformer({
+              host: opt.localHost,
+              port: opt.localPort,
+            })
           );
         }
 


### PR DESCRIPTION
A request to a service running on localhost:8080 would've previously resulted in a request with `Host: localhost` being made. The "default" behaviour is to include the non-standard port as well.