### PR TITLE
Don't download source maps for non-JS files

### DIFF
--- a/packages/downloading-helpers/src/scripts/replay-assets.ts
+++ b/packages/downloading-helpers/src/scripts/replay-assets.ts
@@ -35,7 +35,11 @@ export const fetchAsset = async (path: string): Promise<string> => {
   const assetFileNameAsCjsFile = convertJsExtensionToCJS(assetFileName);
 
   const jsFilePath = await fetchAndCacheFile(fetchUrl, assetFileNameAsCjsFile);
-  if (snippetsBaseUrl.includes("localhost") && process.env.CI !== "true") {
+  if (
+    snippetsBaseUrl.includes("localhost") &&
+    process.env.CI !== "true" &&
+    jsFilePath.endsWith(".js")
+  ) {
     await fetchAndCacheFile(`${fetchUrl}.map`, `${assetFileName}.map`);
   }
 


### PR DESCRIPTION
In an upcoming PR, the snippet server will also start serving a WASM file for parsing sourcemaps. This won't come with a sourcemap so the download for a `.map` file below will fail. To avoid a bunch of retries and 1 minute wait, check the extension is `.js` before we try to download a sourcemap.