### PR TITLE
Start enforcing no floating promises

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,13 +2,22 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint", "import"],
+  parserOptions: {
+    project: "tsconfig.json",
+  },
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
     "plugin:import/typescript",
   ],
+  ignorePatterns: [
+    "jest.config.js",
+    "webpack.config.js",
+    "/packages/*/dist/**/*",
+  ],
   rules: {
+    "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-explicit-any": "off",
     "import/no-unresolved": "error",
     "import/order": [

--- a/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
+++ b/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
@@ -54,7 +54,7 @@ export const openStepThroughDebuggerUI = async ({
 
   // Create page for the debugger UI
   const debuggerPage = (await browser.pages())[0];
-  debuggerPage.setViewport({
+  await debuggerPage.setViewport({
     width: 0,
     height: 0,
   });

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -30,7 +30,7 @@ export const main: () => void = async () => {
   const meticulousVersion = await getMeticulousVersion(packageJsonPath);
   await initSentry(meticulousVersion);
 
-  yargs
+  await yargs
     .scriptName("meticulous")
     .usage(
       `$0 <command>

--- a/packages/downloading-helpers/src/scripts/replay-assets.ts
+++ b/packages/downloading-helpers/src/scripts/replay-assets.ts
@@ -68,7 +68,7 @@ const fetchAndCacheFile = async (
 
     if (entry && etag !== "" && etag === entry.etag) {
       logger.debug(`${urlToDownloadFrom} already present`);
-      releaseLock();
+      await releaseLock();
       return filePath;
     }
 
@@ -85,10 +85,10 @@ const fetchAndCacheFile = async (
       });
     }
     await saveAssetMetadata(assetMetadata);
-    releaseLock();
+    await releaseLock();
     return filePath;
   } catch (err) {
-    releaseLock();
+    await releaseLock();
     logger.error(`Error fetching asset from ${urlToDownloadFrom}`);
     throw err;
   }

--- a/packages/record/src/record/record.ts
+++ b/packages/record/src/record/record.ts
@@ -123,7 +123,7 @@ export const recordSession = async ({
     captureHttpOnlyCookies: captureHttpOnlyCookies ?? true,
   });
 
-  page.goto(appUrl ?? INITIAL_METICULOUS_RECORD_DOCS_URL);
+  await page.goto(appUrl ?? INITIAL_METICULOUS_RECORD_DOCS_URL);
 
   logger.info("Browser ready");
 

--- a/packages/record/src/record/utils/provide-cookie-access.ts
+++ b/packages/record/src/record/utils/provide-cookie-access.ts
@@ -19,7 +19,7 @@ export const provideCookieAccess = async (page: Page) => {
 
   // The Meticulous recorder accesses the function via window.__meticulous.getAllCookies,
   // let's expose it there:
-  page.evaluateOnNewDocument(() => {
+  await page.evaluateOnNewDocument(() => {
     const meticulousObject = (window as ModifiedWindow).__meticulous ?? {};
     meticulousObject.getAllCookies = (
       window as ModifiedWindow

--- a/packages/recorder-loader/src/install-meticulous-intercepts.ts
+++ b/packages/recorder-loader/src/install-meticulous-intercepts.ts
@@ -123,7 +123,7 @@ export const tryInstallMeticulousIntercepts = async (
     })
     .finally(() => {
       if (requestedToStopIntercepting) {
-        stopIntercepting();
+        void stopIntercepting();
       }
     });
 };

--- a/packages/remote-replay-launcher/src/index.ts
+++ b/packages/remote-replay-launcher/src/index.ts
@@ -124,7 +124,7 @@ export const executeRemoteTestRun = async ({
     }
 
     if (keepTunnelOpenPromise) {
-      keepTunnelOpenPromise.then(() => {
+      void keepTunnelOpenPromise.then(() => {
         tunnel.close();
 
         testRunCompleted.resolve(completedTestRun);

--- a/packages/replay-debugger-ui/src/components/replay-debugger/replay-debugger.tsx
+++ b/packages/replay-debugger-ui/src/components/replay-debugger/replay-debugger.tsx
@@ -14,11 +14,11 @@ const ReplayDebuggerWrapped: FunctionComponent = () => {
   const { events, index, loading } = state;
 
   const onCheckNextEventTarget = useCallback(() => {
-    dispatchEvent("check-next-target", null);
+    void dispatchEvent("check-next-target", null);
   }, [dispatchEvent]);
 
   const onPlayNextEvent = useCallback(() => {
-    dispatchEvent("play-next-event", null);
+    void dispatchEvent("play-next-event", null);
   }, [dispatchEvent]);
 
   return (

--- a/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
+++ b/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
@@ -81,11 +81,11 @@ const EventListItem: FunctionComponent<EventListItemProps> = ({
   }, [current]);
 
   const onPlayNextEvent = useCallback(() => {
-    dispatchEvent("play-next-event", null);
+    void dispatchEvent("play-next-event", null);
   }, [dispatchEvent]);
 
   const onSetIndex = useCallback(() => {
-    dispatchEvent("set-index", { index });
+    void dispatchEvent("set-index", { index });
   }, [dispatchEvent, index]);
 
   return (
@@ -209,7 +209,7 @@ const EndOfReplayItem: FunctionComponent<{ current?: boolean }> = ({
   const { loading } = state;
 
   const onReset = useCallback(() => {
-    dispatchEvent("set-index", { index: 0 });
+    void dispatchEvent("set-index", { index: 0 });
   }, [dispatchEvent]);
 
   return (

--- a/packages/replay-debugger-ui/src/lib/replay-debugger/replay-debugger.provider.tsx
+++ b/packages/replay-debugger-ui/src/lib/replay-debugger/replay-debugger.provider.tsx
@@ -30,7 +30,7 @@ export const ReplayDebuggerProvider: FunctionComponent<{
 
   useEffect(() => {
     if (dispatchEvent) {
-      dispatchEvent("ready", null);
+      void dispatchEvent("ready", null);
     }
   }, [dispatchEvent]);
 


### PR DESCRIPTION
Existing promises are marked with an `await` where possible/appropriate and `void` otherwise.