### PR TITLE
Fix broken ETag check

### DIFF
--- a/packages/downloading-helpers/src/scripts/replay-assets.ts
+++ b/packages/downloading-helpers/src/scripts/replay-assets.ts
@@ -79,7 +79,7 @@ const fetchAndCacheFile = async (
     } else {
       logger.debug(`${urlToDownloadFrom} downloaded`);
       assetMetadata.assets.push({
-        fileName: urlToDownloadFrom,
+        fileName: fileNameToDownloadAs,
         etag,
         fetchUrl: urlToDownloadFrom,
       });


### PR DESCRIPTION
Looks like I broke this some time ago in https://github.com/alwaysmeticulous/meticulous-sdk/pull/551/ so we've been re-downloading the snippets even if we didn't need to.