### PR TITLE
Add gip field to nextjs-specific application data

### DIFF
--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
@@ -89,6 +89,7 @@ export interface ApplicationSpecificData {
     buildId?: string;
     isFallback?: boolean;
     gsp?: boolean;
+    gip?: boolean;
     scriptLoader?: Record<string, unknown>;
     locale?: string;
   };


### PR DESCRIPTION
GIP set if a page has `getInitialProps`