### PR TITLE
Add typings to enable more granular replay analytics

### DIFF
--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/test-run-environment.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/test-run-environment.ts
@@ -87,6 +87,12 @@ export interface TestRunGitLabMergeRequestContext {
 
   /** Merge request URL (web page) */
   webUrl: string;
+
+  /** Git ref for the target branch (/refs/head/<target_branch>). Not defined for merge requests prior to July 2024. */
+  baseRef?: string;
+
+  /** Git ref for the source branch (/refs/head/<source_branch>). Not defined for merge requests prior to July 2024. */
+  headRef?: string;
 }
 
 export interface TestRunGitLabPushContext {
@@ -98,4 +104,7 @@ export interface TestRunGitLabPushContext {
 
   /** Commit hash after the push event */
   afterSha: string;
+
+  /** Git ref for the branch (/refs/head/<branch>). Not defined for pushes prior to July 2024. */
+  ref?: string;
 }

--- a/packages/cli/src/commands/replay/replay.command.ts
+++ b/packages/cli/src/commands/replay/replay.command.ts
@@ -134,6 +134,7 @@ const replayCommandHandler = async ({
       screenshottingOptions,
       apiToken,
       commitSha,
+      gitRef: null,
       cookiesFile,
       sessionId,
       generatedBy: generatedByOption,

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -19,6 +19,12 @@ export interface ReplayAndStoreResultsOptions {
   suppressScreenshotDiffLogging: boolean;
   apiToken: string | null | undefined;
   commitSha: string | null | undefined;
+
+  /**
+   * The git ref used if there was one e.g. refs/head/master
+   */
+  gitRef: string | null | undefined;
+
   sessionId: string;
   /**
    * The ID of the session to use for seeding the application state (cookies, local storage, session storage),


### PR DESCRIPTION
This will enable us to differentiate main branch replays from feature branch replays. Main branch is more useful for tracking changes over time in replay accuracy etc.