### PR TITLE
Connect to specific tunnel server when establishing tunnel connections

### DIFF
--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -78,9 +78,9 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
 
     // Drop the client ID (first part of the subdomain) from the URL to get the remote host to establish tunnel connections to.
     // TODO: Use the host & scheme from the response body.
-    const urlParts = url.split(".");
-    urlParts.shift();
-    const remoteHost = urlParts.join(".");
+    const hostParts = parsedHost.hostname.split(".");
+    hostParts.shift();
+    const remoteHost = hostParts.join(".");
 
     // determine if we should use tls for the connection to the local server
     // TODO: Don't use parse, use `useTls` from the the response body.

--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -74,17 +74,23 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
     const { port: localPort, localHost } = this.opts;
     const { localHttps, localCert, localKey, localCa, allowInvalidCert } =
       this.opts;
-    const parsedHost = new URL(this.host);
+    const parsedHost = new URL(url);
+
+    // Drop the client ID (first part of the subdomain) from the URL to get the remote host to establish tunnel connections to.
+    // TODO: Use the host & scheme from the response body.
+    const urlParts = url.split(".");
+    urlParts.shift();
+    const remoteHost = urlParts.join(".");
 
     // determine if we should use tls for the connection to the local server
-    // TODO: Don't use parse, use `useTls` from the the response body after migration to the new API endpoint.
+    // TODO: Don't use parse, use `useTls` from the the response body.
     const useTls = parsedHost.protocol === "https:";
 
     return {
       name: id,
       url,
       maxConn: max_conn_count || 1,
-      remoteHost: parsedHost.hostname,
+      remoteHost: remoteHost,
       remotePort: port,
       multiplexingRemotePort: multiplexing_port,
       useTls,


### PR DESCRIPTION
Previously we used `tunnels.metiuclous.ai` to establish tunnel connections rather than `tunnel-X.tunnels.metiuclous.ai`. This is okay at the moment as both point to the same host but won't be the case in the future.

This change is temporary and assumes that the tunnel URL is a subdomain of the correct host to connect to (e.g `tunnel-1.meticulous.ai` for a tunnel with URL `slug.tunnel-1.meticulous.ai`) which is the case currently. The host and scheme will become BE-driven in future versions