### PR TITLE
Clarify warning for downloadAndExtractFile

### DIFF
--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -89,7 +89,8 @@ export const downloadFile = async (
  *
  * Returns a list of the extracted files.
  *
- * Warning: this function is not thread safe. Do not try downloading a file to a tmpZipFilePath that may already be in use by another process.
+ * Warning: this function is not thread safe. Do not try downloading a file to a `tmpZipFilePath`
+ * that may already be in use by another process.
  */
 export const downloadAndExtractFile: (
   fileUrl: string,

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -95,8 +95,6 @@ export const downloadFile = async (
  * Do not try extracting to a dir that may already be in use by another process b/c overlapping
  * file names can cause data corruption.
  * @returns The list of the extracted files.
- *
- *
  */
 export const downloadAndExtractFile: (
   fileUrl: string,

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -89,23 +89,23 @@ export const downloadFile = async (
  *
  * Returns a list of the extracted files.
  *
- * Warning: this function is not thread safe. Do not try downloading a file to an extractPath that may already be in use by another process.
+ * Warning: this function is not thread safe. Do not try downloading a file to a tmpZipFilePath that may already be in use by another process.
  */
 export const downloadAndExtractFile: (
   fileUrl: string,
   tmpZipFilePath: string,
   extractPath: string
-) => Promise<string[]> = async (fileUrl, filePath, extractPath) => {
-  await downloadFile(fileUrl, filePath);
+) => Promise<string[]> = async (fileUrl, tmpZipFilePath, extractPath) => {
+  await downloadFile(fileUrl, tmpZipFilePath);
   const entries: string[] = [];
 
   try {
-    await extract(filePath, {
+    await extract(tmpZipFilePath, {
       dir: extractPath,
       onEntry: (entry) => entries.push(entry.fileName),
     });
   } finally {
-    await rm(filePath);
+    await rm(tmpZipFilePath);
   }
 
   return entries;

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -84,9 +84,9 @@ export const downloadFile = async (
 };
 
 /**
- * __Warning__: this function is not thread safe.
  * Download a file from a URL and extract it to a directory.
  * The zip file will be deleted after extraction, keeping only the extracted files.
+ * __Warning__: this function is not thread safe.
  *
  * @param fileUrl The URL of the file to download.
  * @param tmpZipFilePath The path to save the downloaded file. Do not try downloading a file to a

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -84,13 +84,19 @@ export const downloadFile = async (
 };
 
 /**
+ * __Warning__: this function is not thread safe.
  * Download a file from a URL and extract it to a directory.
  * The zip file will be deleted after extraction, keeping only the extracted files.
  *
- * Returns a list of the extracted files.
+ * @param fileUrl The URL of the file to download.
+ * @param tmpZipFilePath The path to save the downloaded file. Do not try downloading a file to a
+ * `tmpZipFilePath` that may already be in use by another process b/c this can corrupt the data.
+ * @param extractPath The path to a directory which we will extract files from a gzip into.
+ * Do not try extracting to a dir that may already be in use by another process b/c overlapping
+ * file names can cause data corruption.
+ * @returns The list of the extracted files.
  *
- * Warning: this function is not thread safe. Do not try downloading a file to a `tmpZipFilePath`
- * that may already be in use by another process.
+ *
  */
 export const downloadAndExtractFile: (
   fileUrl: string,


### PR DESCRIPTION
Based on the comment for downloadFile, it seems like we need to worry about thread safety for the file where we download the gzip rather than the directory where we unpack the gzip. I hit a bug in https://github.com/alwaysmeticulous/meticulous/pull/3181 because I didn't realize this, so I'm modifying the comment here to make it more clear.