### PR TITLE
Improved docs regarding deduped events

### DIFF
--- a/packages/replay-debugger-ui/package.json
+++ b/packages/replay-debugger-ui/package.json
@@ -26,6 +26,7 @@
     "luxon": "^3.2.1"
   },
   "devDependencies": {
+    "@alwaysmeticulous/sdk-bundles-api": "^2.142.0",
     "@heroicons/react": "^2.0.14",
     "@tailwindcss/forms": "0.5.7",
     "@types/express": "^4.17.14",

--- a/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
+++ b/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
@@ -16,9 +16,10 @@ import { Duration } from "luxon";
 import { FunctionComponent, useCallback, useEffect, useRef } from "react";
 import { ReplayableEvent } from "src/lib/event/event.types";
 import { useReplayDebuggerContext } from "src/lib/replay-debugger/replay-debugger.context";
+import { IndexedReplayableEvent } from "@alwaysmeticulous/sdk-bundles-api";
 
 interface EventListItemProps {
-  event: ReplayableEvent;
+  event: IndexedReplayableEvent | ReplayableEvent;
   index: number;
   current?: boolean;
 }
@@ -52,7 +53,7 @@ const EventListItem: FunctionComponent<EventListItemProps> = ({
         return CursorArrowRaysIcon;
       case "mouseenter":
       case "mouseleave":
-        return CursorArrowRippleIcon
+        return CursorArrowRippleIcon;
       case "touchstart":
       case "touchend":
       case "touchmove":
@@ -192,7 +193,7 @@ const EventListItem: FunctionComponent<EventListItemProps> = ({
       </div>
       <div className={cx("ml-2", "my-auto", "flex-1")}>{eventType}</div>
       <div className={cx("my-auto", "text-sm", "font-medium", "text-zinc-600")}>
-        Event Index: {index}
+        Event #{event.originalEventIndex ?? index}
         {" | "}
         <time dateTime={timeTick.toISO()}>
           {timeTick.toFormat("mm:ss.SSS")}

--- a/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
+++ b/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
@@ -1,3 +1,4 @@
+import { IndexedReplayableEvent } from "@alwaysmeticulous/sdk-bundles-api";
 import {
   ArrowDownTrayIcon,
   ArrowsUpDownIcon,
@@ -16,7 +17,6 @@ import { Duration } from "luxon";
 import { FunctionComponent, useCallback, useEffect, useRef } from "react";
 import { ReplayableEvent } from "src/lib/event/event.types";
 import { useReplayDebuggerContext } from "src/lib/replay-debugger/replay-debugger.context";
-import { IndexedReplayableEvent } from "@alwaysmeticulous/sdk-bundles-api";
 
 interface EventListItemProps {
   event: IndexedReplayableEvent | ReplayableEvent;

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -39,5 +39,6 @@ export {
   ReplayAndStoreResultsResult,
   ReplayExecution,
   BeforeUserEventResult,
+  IndexedReplayableEvent,
 } from "./replay-orchestrator/bundle-to-sdk/execute-replay";
 export { ScreenshotDiffData } from "./replay-orchestrator/bundle-to-sdk/execute-replay";

--- a/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
@@ -11,7 +11,11 @@ export interface ReplayExecution {
    */
   finalResult: Promise<ReplayAndStoreResultsResult>;
 
-  eventsBeingReplayed: ReplayableEvent[];
+  /**
+   * The list of events that will actually be replayed. This list is the deduplicated events list,
+   * and so may have fewer events than the raw session data (sessionData.userEvents.event_log).
+   */
+  eventsBeingReplayed: IndexedReplayableEvent[];
 
   /**
    * When called will log the target of the given event to the browser console.
@@ -22,6 +26,14 @@ export interface ReplayExecution {
    * Closes the browser window and stops the replay short.
    */
   closePage: () => Promise<void>;
+}
+
+export interface IndexedReplayableEvent extends ReplayableEvent {
+  /**
+   * The index of the event in the raw session data, before any events were removed,
+   * deduplicated or merged.
+   */
+  originalEventIndex: number;
 }
 
 export interface ReplayAndStoreResultsResult {

--- a/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-replay.ts
@@ -14,6 +14,8 @@ export interface ReplayExecution {
   /**
    * The list of events that will actually be replayed. This list is the deduplicated events list,
    * and so may have fewer events than the raw session data (sessionData.userEvents.event_log).
+   *
+   * These are used for the replay debugger UI.
    */
   eventsBeingReplayed: IndexedReplayableEvent[];
 

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -71,7 +71,11 @@ export interface ReplayAndStoreResultsOptions {
 
 export interface BeforeUserEventOptions {
   /**
-   * The index of the next event in sessionData.userEvents.event_log
+   * The index of the next event in the `eventsBeingReplayed` list returned on the ReplayExecution
+   * object returned by `replayAndStoreResults`.
+   *
+   * Note that this list is the deduplicated events list, and so may have fewer events than the
+   * raw session data (sessionData.userEvents.event_log).
    */
   userEventIndex: number;
 }


### PR DESCRIPTION
The debugger UI deals with event indexes after deduplication (i.e. gets given an event list after deduplication, and sends commands to advance to indexes in the deduplicated list), but we display event numbers to the user as pre-deduplication event numbers, so that they correspond to what they see in the session data.