### PR TITLE
Add a single simulationProxyUrl option to replay and store results

### DIFF
--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -17,7 +17,11 @@ export interface ReplayAndStoreResultsOptions {
   generatedBy: GeneratedBy;
   testRunId: string | null;
   suppressScreenshotDiffLogging: boolean;
-  disableAssetCache: boolean;
+
+  /**
+   * @deprecated Use `simulationProxyUrl` instead.
+   */
+  disableAssetCache?: boolean;
   apiToken: string | null | undefined;
   commitSha: string | null | undefined;
 
@@ -68,6 +72,11 @@ export interface ReplayAndStoreResultsOptions {
    * Chromium, or the version of Puppeteer.
    */
   logicalEnvironmentVersion?: number;
+
+  /**
+   * If present, requests for assets during simulation will be proxied through this URL
+   */
+  simulationProxyUrl?: string;
 }
 
 export interface BeforeUserEventOptions {


### PR DESCRIPTION
This moves the responsibility for setting correct simulation proxy to the caller. Because of this we can also deprecate `disableAssetCache` as callers can just unset the simulation proxy if needed.