### PR TITLE
Disable recording replays and change projectId to recordingToken

### DIFF
--- a/packages/recorder-loader/README.md
+++ b/packages/recorder-loader/README.md
@@ -1,6 +1,6 @@
 # Meticulous Recorder loader
 
-Utiliy package used to aid the injection of the Meticulous recorder snippet on web apps.
+Utility package used to aid the injection of the Meticulous recorder snippet on web apps.
 
 ## Installing
 

--- a/packages/recorder-loader/README.md
+++ b/packages/recorder-loader/README.md
@@ -21,7 +21,7 @@ async function startApp() {
     // Start the Meticulous recorder before you initialise your app.
     try {
         await loadAndStartRecorder({
-            projectId: '<project ID>',
+            recordingToken: '<recording token>',
         })
     } catch (err) {
         console.error(`Meticulous failed to initialise ${err}`)

--- a/packages/recorder-loader/src/global.d.ts
+++ b/packages/recorder-loader/src/global.d.ts
@@ -4,6 +4,9 @@ import { MeticulousWindowConfig } from "@alwaysmeticulous/sdk-bundles-api";
 declare global {
   interface Window extends MeticulousWindowConfig {
     __meticulous?: RecordState;
+    Meticulous?: {
+      isRunningAsTest?: boolean;
+    };
   }
 }
 

--- a/packages/recorder-loader/src/loader.ts
+++ b/packages/recorder-loader/src/loader.ts
@@ -9,6 +9,13 @@ const DEFAULT_MAX_MS_TO_BLOCK_FOR = 2_000;
 export const tryLoadAndStartRecorder = async (
   options: LoaderOptions
 ): Promise<void> => {
+  if (window.Meticulous?.isRunningAsTest) {
+    console.debug(
+      "Running as part of a Meticulous test case, so skipping loading the Meticulous recorder."
+    );
+    return;
+  }
+
   // Try to load the recorder and silence any initialisation error.
   await unsafeLoadAndStartRecorder(options).catch((error) => {
     console.error(error);
@@ -17,6 +24,7 @@ export const tryLoadAndStartRecorder = async (
 
 const unsafeLoadAndStartRecorder = ({
   projectId,
+  recordingToken,
   uploadIntervalMs,
   snapshotLinkedStylesheets,
   commitHash,
@@ -45,7 +53,7 @@ const unsafeLoadAndStartRecorder = ({
 
     // Setup configuration
     const typedWindow = window;
-    typedWindow.METICULOUS_RECORDING_TOKEN = projectId;
+    typedWindow.METICULOUS_RECORDING_TOKEN = recordingToken ?? projectId;
 
     if (uploadIntervalMs !== undefined) {
       typedWindow.METICULOUS_UPLOAD_INTERVAL_MS = uploadIntervalMs;

--- a/packages/recorder-loader/src/loader.ts
+++ b/packages/recorder-loader/src/loader.ts
@@ -23,7 +23,6 @@ export const tryLoadAndStartRecorder = async (
 };
 
 const unsafeLoadAndStartRecorder = ({
-  projectId,
   recordingToken,
   uploadIntervalMs,
   snapshotLinkedStylesheets,
@@ -53,7 +52,7 @@ const unsafeLoadAndStartRecorder = ({
 
     // Setup configuration
     const typedWindow = window;
-    typedWindow.METICULOUS_RECORDING_TOKEN = recordingToken ?? projectId;
+    typedWindow.METICULOUS_RECORDING_TOKEN = recordingToken;
 
     if (uploadIntervalMs !== undefined) {
       typedWindow.METICULOUS_UPLOAD_INTERVAL_MS = uploadIntervalMs;

--- a/packages/recorder-loader/src/loader.types.ts
+++ b/packages/recorder-loader/src/loader.types.ts
@@ -1,7 +1,12 @@
 import { NetworkResponseSanitizer } from "@alwaysmeticulous/sdk-bundles-api";
 
 export interface LoaderOptions {
-  projectId: string;
+  /**
+   * @deprecated Renamed to recordingToken. Please use the same value but pass it as the recordingToken instead.
+   */
+  projectId?: string;
+  recordingToken: string;
+
   uploadIntervalMs?: number;
   snapshotLinkedStylesheets?: boolean;
   commitHash?: string;


### PR DESCRIPTION
We already block the script from loading so that we don't record replays but this can lead to a 'Meticulous recorder failed to initialise.' error being logged, which often acts as a red herring leading developers down the wrong path when debugging replay issues.