### PR TITLE
Recorder Middleware API

### DIFF
--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -3,6 +3,7 @@ export {
   MeticulousWindowConfig,
   NetworkResponseSanitizer,
 } from "./record/record-settings";
+export * from "./record/middleware";
 export {
   ReplayAndStoreResultsOptions,
   ReplayTarget,

--- a/packages/sdk-bundles-api/src/record/middleware.ts
+++ b/packages/sdk-bundles-api/src/record/middleware.ts
@@ -103,9 +103,9 @@ export interface RecorderMiddleware {
    * See JSDoc for {@link RecorderMiddleware} before implementing.
    */
   transformNetworkRequest?: (
-    request: HarRequest,
+    request: Omit<HarRequest, "queryString">,
     metadata: NetworkRequestMetadata
-  ) => HarRequest | null;
+  ) => Omit<HarRequest, "queryString"> | null;
 
   /**
    * Transforms network requests before they are sent to Meticulous's servers.

--- a/packages/sdk-bundles-api/src/record/middleware.ts
+++ b/packages/sdk-bundles-api/src/record/middleware.ts
@@ -1,0 +1,150 @@
+import {
+  Cookie,
+  HarRequest,
+  HarResponse,
+  IDBObjectStoreWithEntries,
+  StorageEntry,
+  WebSocketConnectionData,
+} from "@alwaysmeticulous/api";
+
+/**
+ * Transformations that are applied to a recorder payload before it is sent to Meticulous's servers. This is
+ * useful for redacting sensitive information from the payload before it is sent.
+ *
+ * Notes:
+ *  - For each of these transforms returning `null` will cause that value to be dropped from the payload.
+ *  - The sanitized responses should be designed such that the app can still correctly function at replay time.
+ *    For example, if you want to sanitize email addresses, replace them with a dummy email address
+ *    of a current format. That will ensure that the email address will still pass any validation the application may have.
+ *  - Please ensure that these functions are fast to run, and handle errors gracefully, since they'll be applied to all
+ *    data. Some of the data, such as network response bodies, may be very large.
+ *  - Please do not mutate the objects. Instead return a new object with the desired changes.
+ *  - New fields may be added to objects in future. This means that:
+ *
+ *      `transformLocalStorageEntry: ({ key, value }) => ({ key, value: "REDACTED" })`
+ *
+ *    Is unsafe. While:
+ *
+ *      `transformLocalStorageEntry: ({ value, ...rest }) => ({ ...rest, value: "REDACTED" })`
+ *
+ *    Is safe.
+ */
+export interface RecorderMiddleware {
+  // Storage
+  // -------
+
+  /**
+   * Transforms local storage entries before they are sent to Meticulous's servers.
+   *
+   * Returning null will cause the entry to be dropped from the payload.
+   *
+   * See JSDoc for {@link RecorderMiddleware} before implementing.
+   */
+  transformLocalStorageEntry?: (entry: StorageEntry) => StorageEntry | null;
+
+  /**
+   * Transforms session storage entries before they are sent to Meticulous's servers.
+   *
+   * Returning null will cause the entry to be dropped from the payload.
+   *
+   * See JSDoc for {@link RecorderMiddleware} before implementing.
+   */
+  transformSessionStorageEntry?: (entry: StorageEntry) => StorageEntry | null;
+
+  /**
+   * Transforms IndexedDB entries before they are sent to Meticulous's servers.
+   *
+   * Returning null will cause the entry to be dropped from the payload.
+   *
+   * Please note that the entries for a single database may be split across multiple payloads.
+   *
+   * See JSDoc for {@link RecorderMiddleware} before implementing.
+   */
+  transformIndexedDBEntries?: (
+    entries: IndexedDBStoreEntries
+  ) => IndexedDBStoreEntries | null;
+
+  /**
+   * Transforms cookies before they are sent to Meticulous's servers.
+   *
+   * Returning null will cause the cookie to be dropped from the payload.
+   *
+   * See JSDoc for {@link RecorderMiddleware} before implementing.
+   */
+  transformCookie?: (cookie: Cookie) => Cookie | null;
+
+  // Network
+  // -------
+
+  /**
+   * Transforms network requests before they are sent to Meticulous's servers.
+   *
+   * Please note if redacting the network request enough unique information must be preserved to allow
+   * Meticulous to correctly match a request that is performed at replay time by your application with
+   * the correct corresponding saved request stored in the recording / recorded session.
+   *
+   * Returning null will cause the request and the corresponding response to be dropped from the payload.
+   * If the request/response is dropped from the payload but at replay time your application still makes
+   * the request then Meticulous will look for another closely matching recorded request, and replay that,
+   * or if none can be found it will fail the request with 'net::ERR_FAILED'/'Failed to fetch'.
+   *
+   * See JSDoc for {@link RecorderMiddleware} before implementing.
+   */
+  transformNetworkRequest?: (
+    request: HarRequest,
+    metadata: NetworkRequestMetadata
+  ) => HarRequest | null;
+
+  /**
+   * Transforms network requests before they are sent to Meticulous's servers.
+   *
+   * Returning null will cause the request and the response to be dropped from the payload.
+   * If the request/response is dropped from the payload but at replay time your application still makes
+   * the request then Meticulous will look for another closely matching recorded request, and replay that,
+   * or if none can be found it will fail the request with 'net::ERR_FAILED'/'Failed to fetch'.
+   *
+   * See JSDoc for {@link RecorderMiddleware} before implementing.
+   */
+  transformNetworkResponse?: (
+    response: HarResponse,
+    metadata: NetworkResponseMetadata
+  ) => HarResponse | null;
+
+  /**
+   * Transforms WebSocket messages before they are sent to Meticulous's servers.
+   *
+   * Returning null will cause the data to be dropped from the payload.
+   *
+   * Please note that the messages sent across a connection to a single URL may be split across multiple payloads.
+   *
+   * See JSDoc for {@link RecorderMiddleware} before implementing.
+   */
+  transformWebSocketConnectionData?: (
+    entry: Omit<WebSocketConnectionData, "id">
+  ) => Omit<WebSocketConnectionData, "id"> | null;
+}
+
+export interface IndexedDBStoreEntries {
+  databaseName: string;
+  objectStoreName: string;
+  entries: IDBObjectStoreWithEntries["entries"];
+}
+
+export interface NetworkRequestMetadata {
+  /**
+   * Milliseconds since unix epoch when the request was sent
+   */
+  requestStartedAt: number;
+}
+
+export interface NetworkResponseMetadata {
+  /**
+   * Milliseconds since unix epoch when the request was sent
+   */
+  requestStartedAt: number;
+
+  /**
+   * Milliseconds since unix epoch when the response was received
+   */
+  responseReceivedAt: number;
+}

--- a/packages/sdk-bundles-api/src/record/middleware.ts
+++ b/packages/sdk-bundles-api/src/record/middleware.ts
@@ -148,8 +148,12 @@ export interface IndexedDBStoreEntries {
 export interface NetworkRequestMetadata {
   /**
    * Milliseconds since unix epoch when the request was sent
+   *
+   * Note: this is only defined at record time, not when we redact the requests at replay time
+   * for matching with the stored redacted requests in the original recording. See JSDoc on
+   * {@link RecorderMiddleware.transformNetworkRequest} for more information.
    */
-  requestStartedAt: number;
+  requestStartedAt?: number;
 }
 
 export interface NetworkResponseMetadata {

--- a/packages/sdk-bundles-api/src/record/record-settings.ts
+++ b/packages/sdk-bundles-api/src/record/record-settings.ts
@@ -1,5 +1,7 @@
 // Settings sent from the recorder-loader to the recorder bundle
 
+import { NetworkResponseMetadata, RecorderMiddleware } from "./middleware";
+
 export interface MeticulousWindowConfig {
   METICULOUS_RECORDING_TOKEN?: string;
   METICULOUS_UPLOAD_INTERVAL_MS?: number;
@@ -8,6 +10,7 @@ export interface MeticulousWindowConfig {
   METICULOUS_FORCE_RECORDING?: boolean;
   METICULOUS_IS_PRODUCTION_ENVIRONMENT?: boolean;
   METICULOUS_NETWORK_RESPONSE_SANITIZERS?: NetworkResponseSanitizer[];
+  METICULOUS_RECORDER_MIDDLEWARE_V1: RecorderMiddleware[];
 }
 
 /**
@@ -29,16 +32,4 @@ export interface NetworkResponseSanitizer {
    * of a current format. That will ensure that the email address will still pass any validation the application may have.
    */
   sanitizeBody: (body: string, metadata: NetworkResponseMetadata) => string;
-}
-
-export interface NetworkResponseMetadata {
-  /**
-   * Milliseconds since unix epoch when the request was sent
-   */
-  requestStartedAt: number;
-
-  /**
-   * Milliseconds since unix epoch when the response was received
-   */
-  responseReceivedAt: number;
 }


### PR DESCRIPTION
A new API to allow more comprehensive and flexible redaction of session data than the current redaction API.

We plan to create an open source package to provide higher level utility functions (e.g. `redactJSONResponse<T>(...)`, `redactJWTTokens()`, `redactAuthorizationHeaders()`, `redactJSONPaths(...)`, `asterixOut(...)` etc.) that utilizes the underlying API in this PR. `window.METICULOUS_RECORDER_MIDDLEWARE_V1` will be automatically set by `tryLoadAndStartRecorder` if a middleware option is passed.

Example usage of the _raw_ API (though we expect most users will not use this directly):

```
window.METICULOUS_RECORDER_MIDDLEWARE_V1 = [
          {
            transformNetworkResponse: (response, metadata) => ({
                ...response,
                content: {
                  ...response.content,
                  ...(response.content.text
                    ? {
                        text: response.content.text?.replace(
                          "This is very secret",
                          "__REDACTED__"
                        ),
                      }
                    : {}),
                },
            })
          },
];
```