### PR TITLE
Add request to response transformer metadata

### DIFF
--- a/packages/sdk-bundles-api/src/record/middleware.ts
+++ b/packages/sdk-bundles-api/src/record/middleware.ts
@@ -156,7 +156,11 @@ export interface NetworkRequestMetadata {
   requestStartedAt?: number;
 }
 
-export interface NetworkResponseMetadata {
+export interface NetworkResponseMetadata extends NetworkResponseTimings {
+  request: Omit<HarRequest, "queryString">;
+}
+
+export interface NetworkResponseTimings {
   /**
    * Milliseconds since unix epoch when the request was sent
    */

--- a/packages/sdk-bundles-api/src/record/record-settings.ts
+++ b/packages/sdk-bundles-api/src/record/record-settings.ts
@@ -1,6 +1,6 @@
 // Settings sent from the recorder-loader to the recorder bundle
 
-import { NetworkResponseMetadata, RecorderMiddleware } from "./middleware";
+import { NetworkResponseTimings, RecorderMiddleware } from "./middleware";
 
 export interface MeticulousWindowConfig {
   METICULOUS_RECORDING_TOKEN?: string;
@@ -31,5 +31,5 @@ export interface NetworkResponseSanitizer {
    * at replay time. For example, if you want to sanitize email addresses, replace them with a dummy email address
    * of a current format. That will ensure that the email address will still pass any validation the application may have.
    */
-  sanitizeBody: (body: string, metadata: NetworkResponseMetadata) => string;
+  sanitizeBody: (body: string, metadata: NetworkResponseTimings) => string;
 }


### PR DESCRIPTION
This is important context when performing redaction/transformation (e.g. want to only transform for certain URLs).