### PR TITLE
Middleware API fix

### DIFF
--- a/packages/sdk-bundles-api/src/record/middleware.ts
+++ b/packages/sdk-bundles-api/src/record/middleware.ts
@@ -119,19 +119,17 @@ export interface RecorderMiddleware {
   ) => Omit<HarRequest, "queryString"> | null;
 
   /**
-   * Transforms network requests before they are sent to Meticulous's servers.
+   * Transforms network responses before they are sent to Meticulous's servers.
    *
-   * Returning null will cause the request and the response to be dropped from the payload.
-   * If the request/response is dropped from the payload but at replay time your application still makes
-   * the request then Meticulous will look for another closely matching recorded request, and replay that,
-   * or if none can be found it will fail the request with 'net::ERR_FAILED'/'Failed to fetch'.
+   * If you wish to drop a network response entirely please implement transformNetworkRequest
+   * instead and return null for the corresponding request.
    *
    * See JSDoc for {@link RecorderMiddleware} before implementing.
    */
   transformNetworkResponse?: (
     response: HarResponse,
     metadata: NetworkResponseMetadata
-  ) => HarResponse | null;
+  ) => HarResponse;
 
   /**
    * Transforms WebSocket messages before they are sent to Meticulous's servers.


### PR DESCRIPTION
Just realised allowing network requests to be dropped within transformNetworkResponse would make this behaviour hard to implement:

> Returning null will cause the request and the corresponding response to be dropped from the payload.
At replay time if there is no exact match for a request that is transformed to null **then the request
will be failed with 'net::ERR_FAILED'/'Failed to fetch' rather than automatically trying to find a
'closest match' in the recorded session.**

This is an API break, but this API is not being used yet, so safe to change.