### PR TITLE
Tunnel client logic for HTTP2 multiplexing

### DIFF
--- a/packages/tunnel-client/package.json
+++ b/packages/tunnel-client/package.json
@@ -18,6 +18,7 @@
     "depcheck": "depcheck --ignore-patterns=dist"
   },
   "dependencies": {
+    "agentkeepalive": "^4.5.0",
     "axios": "^1.2.6",
     "axios-retry": "^4.1.0",
     "bpmux": "^8.2.1",

--- a/packages/tunnel-client/src/lib/tunnel-http2-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-http2-cluster.ts
@@ -1,0 +1,145 @@
+import EventEmitter from "events";
+import { readFileSync } from "fs";
+import { request } from "http";
+import * as net from "net";
+import { createServer, Http2Server } from "node:http2";
+import { pipeline } from "stream";
+import Agent from "agentkeepalive";
+import { Logger } from "loglevel";
+import TypedEmitter from "typed-emitter";
+import { TunnelClusterEvents, TunnelClusterOpts } from "./tunnel-cluster.types";
+
+// Increase the default HTTP2 window size to 32MB.
+// The default is 64KB which is too small for our use case.
+// The window size here dictates how much data can be sent before receiving a window update from the other side.
+// nghttp2 (which is used by Node.js) sends a window update when the remaining buffer hits 50% of the window size.
+// With 64KB window size and latency of 100ms, the maximum throughput is 64KB / 0.1s = 640KB/s throughput which is too low.
+// See https://github.com/nodejs/node/issues/38426.
+const HTTP2_WINDOW_SIZE = 1024 * 1024 * 32; // 32MB
+
+const HTTP2_MAX_SESSION_MEMORY = 256; // MB
+
+interface TunnelHTTP2ClusterOpts extends TunnelClusterOpts {
+  sockets: net.Socket[];
+}
+
+/**
+ * TunnelHTTP2Cluster manages a few, sometimes one,
+ * HTTP2 (over TLS) tunnel connection to a remote server and multiplexes multiple request over those HTTP2 connections.
+ * This cluster listening for incoming HTTP2 connections and forwards them to a local server.
+ *
+ * Under the hood it uses the Node.js HTTP2 server, where each of the tunnel server connections is a separate HTTP2 session
+ * within this HTTP2 server.
+ */
+export class TunnelHTTP2Cluster extends (EventEmitter as new () => TypedEmitter<TunnelClusterEvents>) {
+  private readonly logger: Logger;
+  private readonly opts: TunnelClusterOpts;
+  private readonly sockets: net.Socket[];
+  private readonly server: Http2Server;
+
+  constructor(opts: TunnelHTTP2ClusterOpts) {
+    super();
+    this.logger = opts.logger;
+    this.opts = opts;
+
+    this.sockets = opts.sockets;
+
+    this.server = createServer({
+      settings: {
+        initialWindowSize: HTTP2_WINDOW_SIZE,
+      },
+      maxSessionMemory: HTTP2_MAX_SESSION_MEMORY,
+    });
+
+    this.server.on("session", (session) => {
+      session.once("remoteSettings", () => {
+        session.setLocalWindowSize(HTTP2_WINDOW_SIZE);
+      });
+    });
+  }
+
+  startListening() {
+    const opt = this.opts;
+
+    const localHost = opt.localHost;
+    const localPort = opt.localPort;
+    const localProtocol = opt.localHttps ? "https" : "http";
+
+    const allowInvalidCert = opt.allowInvalidCert;
+    const localCertOpts =
+      localProtocol === "http" || allowInvalidCert
+        ? { rejectUnauthorized: false }
+        : {
+            cert: readFileSync(opt.localCert as string),
+            key: readFileSync(opt.localKey as string),
+            ca: opt.localCa ? [readFileSync(opt.localCa)] : undefined,
+          };
+
+    const agent = new Agent();
+
+    this.server.on("request", (req, res) => {
+      this.emit("request", {
+        method: req.method ?? "unknown",
+        path: req.url ?? "unknown",
+      });
+
+      // Drop host & connection header from the original request. Let Node handle it.
+      const { host, connection, ..._headersToForward } = req.headers;
+
+      // Also drop HTTP2 pseudo headers
+      const headersToForward = Object.keys(_headersToForward).reduce(
+        (acc, key) => {
+          if (!key.startsWith(":")) {
+            acc[key] = _headersToForward[key];
+          }
+          return acc;
+        },
+        {} as Record<string, string | string[] | undefined>
+      );
+
+      // Forward the request to the local server
+      const clientReq = request(
+        {
+          agent,
+          host: localHost,
+          port: localPort,
+          path: req.url,
+          method: req.method,
+          headers: headersToForward,
+          ...localCertOpts,
+        },
+        (clientRes) => {
+          // Drop HTTP1 specific headers
+          const {
+            connection,
+            "keep-alive": _,
+            ...headersToForward
+          } = clientRes.headers;
+
+          res.writeHead(clientRes.statusCode as number, headersToForward);
+
+          pipeline(clientRes, res, (err) => {
+            if (err) {
+              this.logger.error("Response pipeline error", err);
+            }
+          });
+        }
+      );
+
+      pipeline(req, clientReq, (err) => {
+        if (err) {
+          this.logger.error("Request pipeline error", err);
+        }
+      });
+    });
+
+    this.sockets.forEach((socket) => {
+      this.server.emit("connection", socket);
+      socket.resume();
+    });
+  }
+
+  close() {
+    this.server.close();
+  }
+}

--- a/packages/tunnel-client/src/lib/tunnel-http2-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-http2-cluster.ts
@@ -113,6 +113,7 @@ export class TunnelHTTP2Cluster extends (EventEmitter as new () => TypedEmitter<
           const {
             connection,
             "keep-alive": _,
+            "transfer-encoding": __,
             ...headersToForward
           } = clientRes.headers;
 

--- a/packages/tunnel-client/src/lib/tunnel-http2-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-http2-cluster.ts
@@ -135,6 +135,10 @@ export class TunnelHTTP2Cluster extends (EventEmitter as new () => TypedEmitter<
     });
 
     this.sockets.forEach((socket) => {
+      // By default the server doesn't listen to anything, but we can
+      // emit connection events which will make the server listen to any
+      // requests sent over those connections
+      // See: https://nodejs.org/api/http2.html#event-connection
       this.server.emit("connection", socket);
       socket.resume();
     });

--- a/packages/tunnel-client/src/lib/tunnel-multiplexing-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-multiplexing-cluster.ts
@@ -194,4 +194,8 @@ export class TunnelMultiplexingCluster extends (EventEmitter as new () => TypedE
       this.emit("open", stream);
     });
   }
+
+  close() {
+    // no-op
+  }
 }

--- a/packages/tunnel-client/src/lib/tunnel-multiplexing-pooling-cluster.ts
+++ b/packages/tunnel-client/src/lib/tunnel-multiplexing-pooling-cluster.ts
@@ -158,4 +158,8 @@ export class TunnelMultiplexingPoolingCluster extends (EventEmitter as new () =>
     remote.pause();
     connLocal();
   }
+
+  close() {
+    // no-op
+  }
 }

--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -453,14 +453,16 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
             socket.end();
           }
 
-          if (sendAuthOkAck) {
-            // Some tunnel implementations require an ACK after the AUTH OK message.
-            socket.write("AUTH OK ACK");
-          }
-
           socket.pause();
 
-          resolve();
+          if (sendAuthOkAck) {
+            // Some tunnel implementations require an ACK after the AUTH OK message.
+            socket.write("AUTH OK ACK", () => {
+              resolve();
+            });
+          } else {
+            resolve();
+          }
         });
       });
     });

--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -8,6 +8,7 @@ import { Logger } from "loglevel";
 import TypedEmitter from "typed-emitter";
 import { TUNNEL_HIGH_WATER_MARK } from "../consts";
 import { IncomingRequestEvent, LocalTunnelOptions, TunnelInfo } from "../types";
+import { TunnelHTTP2Cluster } from "./tunnel-http2-cluster";
 import { TunnelMultiplexingCluster } from "./tunnel-multiplexing-cluster";
 import { TunnelMultiplexingPoolingCluster } from "./tunnel-multiplexing-pooling-cluster";
 
@@ -15,9 +16,9 @@ const DEFAULT_HOST = "https://tunnels.meticulous.ai";
 
 interface CreateTunnelResponse {
   id: string;
-  port?: number | undefined;
-  multiplexing_port?: number | undefined;
+  multiplexing_port: number;
   use_no_pool_multiplexing?: boolean | undefined;
+  use_http2_multiplexing?: boolean | undefined;
   url: string;
   max_conn_count: number;
   tunnel_passphrase: string;
@@ -64,9 +65,9 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
   _getInfo(body: CreateTunnelResponse): TunnelInfo {
     const {
       id,
-      port,
       multiplexing_port,
       use_no_pool_multiplexing,
+      use_http2_multiplexing,
       url,
       max_conn_count,
       tunnel_passphrase,
@@ -93,9 +94,9 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
       url,
       maxConn: max_conn_count || 1,
       remoteHost: remoteHost,
-      remotePort: port,
       multiplexingRemotePort: multiplexing_port,
       useNoPoolMultiplexing: use_no_pool_multiplexing,
+      useHTTP2ForMultiplexing: use_http2_multiplexing,
       useTls,
       tunnelPassphrase: tunnel_passphrase,
       basicAuthUser: basic_auth_user,
@@ -122,10 +123,8 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
         Authorization: opt.apiToken,
       },
       params: {
-        // Older versions of the client don't support multiplexing.
-        // Temporary until all clients support multiplexing.
-        supportsMultiplexing: true,
         supportsNoMultiplexingPool: true,
+        supportsHTTP2Multiplexing: true,
         new: true,
       },
     };
@@ -179,15 +178,22 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
       throw new Error("multiplexingRemotePort must be set");
     }
 
-    this.logger.debug(
-      `using multiplexing ${
-        info.useNoPoolMultiplexing ? "no-pooling" : "pooling"
-      } agent`
-    );
+    if (info.useHTTP2ForMultiplexing && info.useNoPoolMultiplexing) {
+      throw new Error("Can either use HTTP2 or no-pool multiplexing, not both");
+    }
+
+    const agentType = info.useHTTP2ForMultiplexing
+      ? "http2 multiplexing"
+      : info.useNoPoolMultiplexing
+      ? "no pooling multiplexing"
+      : "pool multiplexing";
+
+    this.logger.debug(`using ${agentType} agent`);
     const tunnelCluster = await this._establishMultiplexingCluster({
       ...info,
       multiplexingRemotePort: info.multiplexingRemotePort,
       useNoPoolMultiplexing: info.useNoPoolMultiplexing,
+      useHTTP2ForMultiplexing: info.useHTTP2ForMultiplexing,
     });
 
     // only emit the url the first time
@@ -233,7 +239,7 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
       if (this.closed || !tunnelCluster) {
         return;
       }
-      if (!(tunnelCluster instanceof TunnelMultiplexingCluster)) {
+      if (tunnelCluster instanceof TunnelMultiplexingPoolingCluster) {
         tunnelCluster.open();
       }
     });
@@ -250,12 +256,17 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
     } else {
       tunnelCluster.startListening();
     }
+
+    this.once("close", () => {
+      tunnelCluster.close();
+    });
   }
 
-  _establishMultiplexingCluster({
+  async _establishMultiplexingCluster({
     remoteHost,
     multiplexingRemotePort,
     useNoPoolMultiplexing,
+    useHTTP2ForMultiplexing,
     localHost,
     localPort,
     localHttps,
@@ -264,7 +275,15 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
     tunnelPassphrase,
   }: Omit<TunnelInfo, "multiplexingRemotePort"> & {
     multiplexingRemotePort: number;
-  }): Promise<TunnelMultiplexingPoolingCluster | TunnelMultiplexingCluster> {
+  }): Promise<
+    | TunnelMultiplexingPoolingCluster
+    | TunnelMultiplexingCluster
+    | TunnelHTTP2Cluster
+  > {
+    if (useHTTP2ForMultiplexing && useNoPoolMultiplexing) {
+      throw new Error("Can either use HTTP2 or no-pool multiplexing, not both");
+    }
+
     const localProtocol = localHttps ? "https" : "http";
     this.logger.debug(
       "establishing tunnel %s://%s:%s <> %s:%s",
@@ -275,87 +294,59 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
       multiplexingRemotePort
     );
 
-    let sharedSocket: net.Socket | tls.TLSSocket;
+    const commonTunnelOpts = {
+      logger: this.logger,
+      localHost,
+      localPort,
+      localHttps,
+      allowInvalidCert,
+    };
 
-    if (useTls) {
-      sharedSocket = tls.connect({
-        host: remoteHost,
-        port: multiplexingRemotePort,
-        rejectUnauthorized: true,
+    if (!useHTTP2ForMultiplexing) {
+      const sharedSocket = await this.openSocket({
+        useTls,
+        remoteHost,
+        multiplexingRemotePort,
+        useHTTP2ForMultiplexing,
+        tunnelPassphrase,
       });
+
+      sharedSocket.resume();
+
+      const remoteMuxClient = new BPMux(sharedSocket, {
+        highWaterMark: TUNNEL_HIGH_WATER_MARK,
+        peer_multiplex_options: {
+          highWaterMark: TUNNEL_HIGH_WATER_MARK,
+        },
+      });
+
+      const tunnelOpts = {
+        ...commonTunnelOpts,
+        remoteMuxClient,
+      };
+
+      return useNoPoolMultiplexing
+        ? new TunnelMultiplexingCluster(tunnelOpts)
+        : new TunnelMultiplexingPoolingCluster(tunnelOpts);
     } else {
-      sharedSocket = net.connect({
-        host: remoteHost,
-        port: multiplexingRemotePort,
+      const sockets = await Promise.all(
+        Array.from({ length: 2 }).map(() =>
+          this.openSocket({
+            useTls,
+            remoteHost,
+            multiplexingRemotePort,
+            useHTTP2ForMultiplexing,
+            tunnelPassphrase,
+            sendAuthOkAck: true,
+          })
+        )
+      );
+
+      return new TunnelHTTP2Cluster({
+        ...commonTunnelOpts,
+        sockets,
       });
     }
-
-    sharedSocket.setNoDelay(true);
-
-    sharedSocket.on("error", (err: NodeJS.ErrnoException) => {
-      this.logger.debug("got remote connection error", err.message);
-
-      // emit connection refused errors immediately, because they
-      // indicate that the tunnel can't be established.
-      if (err.code === "ECONNREFUSED") {
-        this.emit(
-          "error",
-          new Error(
-            `connection refused: ${remoteHost}:${multiplexingRemotePort} (check your firewall settings)`
-          )
-        );
-      }
-
-      sharedSocket.end();
-    });
-
-    sharedSocket.on("close", () => {
-      if (!this.closed) {
-        this.logger.error(
-          "The remote connection was closed unexpectedly. Please check your network connection and try again."
-        );
-      }
-    });
-
-    const connectEvent = useTls ? "secureConnect" : "connect";
-
-    return new Promise<
-      TunnelMultiplexingCluster | TunnelMultiplexingPoolingCluster
-    >((resolve) => {
-      sharedSocket.once(connectEvent, () => {
-        // Send the tunnel passphrase to the server
-        sharedSocket.write(`AUTH ${tunnelPassphrase}`);
-
-        sharedSocket.once("data", (data) => {
-          if (data.toString() != "AUTH OK") {
-            this.emit("error", new Error("Tunnel auth failed"));
-            sharedSocket.end();
-          }
-
-          const remoteMuxClient = new BPMux(sharedSocket, {
-            highWaterMark: TUNNEL_HIGH_WATER_MARK,
-            peer_multiplex_options: {
-              highWaterMark: TUNNEL_HIGH_WATER_MARK,
-            },
-          });
-
-          const tunnelOpts = {
-            remoteMuxClient,
-            logger: this.logger,
-            localHost,
-            localPort,
-            localHttps,
-            allowInvalidCert,
-          };
-
-          const tunnelCluster = useNoPoolMultiplexing
-            ? new TunnelMultiplexingCluster(tunnelOpts)
-            : new TunnelMultiplexingPoolingCluster(tunnelOpts);
-
-          resolve(tunnelCluster);
-        });
-      });
-    });
   }
 
   open(cb: (err?: Error) => void) {
@@ -382,6 +373,98 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
   close() {
     this.closed = true;
     this.emit("close");
-    this;
+  }
+
+  async openSocket({
+    useTls,
+    remoteHost,
+    multiplexingRemotePort,
+    useHTTP2ForMultiplexing,
+    tunnelPassphrase,
+    sendAuthOkAck,
+  }: Pick<
+    TunnelInfo,
+    | "useTls"
+    | "remoteHost"
+    | "multiplexingRemotePort"
+    | "useHTTP2ForMultiplexing"
+    | "tunnelPassphrase"
+  > & {
+    sendAuthOkAck?: boolean;
+  }): Promise<net.Socket | tls.TLSSocket> {
+    let socket: net.Socket | tls.TLSSocket;
+
+    if (useTls) {
+      socket = tls.connect({
+        host: remoteHost,
+        port: multiplexingRemotePort,
+        rejectUnauthorized: true,
+        // The HTTP2 node implementation requires ALPN set.
+        // See https://github.com/nodejs/node/blob/9a9409ff1f45c968173118de4cd37dea784f8ec9/lib/internal/http2/core.js#L3039.
+        // The server should respond with the ALPN protocol "meticulous-tunnel".
+        ...(useHTTP2ForMultiplexing
+          ? { ALPNProtocols: ["meticulous-tunnel"] }
+          : {}),
+      });
+    } else {
+      socket = net.connect({
+        host: remoteHost,
+        port: multiplexingRemotePort,
+      });
+    }
+
+    socket.setNoDelay(true);
+
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      this.logger.debug("got remote connection error", err.message);
+
+      // emit connection refused errors immediately, because they
+      // indicate that the tunnel can't be established.
+      if (err.code === "ECONNREFUSED") {
+        this.emit(
+          "error",
+          new Error(
+            `connection refused: ${remoteHost}:${multiplexingRemotePort} (check your firewall settings)`
+          )
+        );
+      }
+
+      socket.end();
+    });
+
+    socket.on("close", () => {
+      if (!this.closed) {
+        this.logger.error(
+          "The remote connection was closed unexpectedly. Please check your network connection and try again."
+        );
+      }
+    });
+
+    const connectEvent = useTls ? "secureConnect" : "connect";
+
+    await new Promise<void>((resolve) => {
+      socket.once(connectEvent, () => {
+        // Send the tunnel passphrase to the server
+        socket.write(`AUTH ${tunnelPassphrase}`);
+
+        socket.once("data", (data) => {
+          if (data.toString() != "AUTH OK") {
+            this.emit("error", new Error("Tunnel auth failed"));
+            socket.end();
+          }
+
+          if (sendAuthOkAck) {
+            // Some tunnel implementations require an ACK after the AUTH OK message.
+            socket.write("AUTH OK ACK");
+          }
+
+          socket.pause();
+
+          resolve();
+        });
+      });
+    });
+
+    return socket;
   }
 }

--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -14,6 +14,11 @@ import { TunnelMultiplexingPoolingCluster } from "./tunnel-multiplexing-pooling-
 
 const DEFAULT_HOST = "https://tunnels.meticulous.ai";
 
+/**
+ * Number of connections to establish for HTTP2 multiplexing.
+ */
+const HTTP2_NUMBER_OF_CONNECTIONS = 2;
+
 interface CreateTunnelResponse {
   id: string;
   multiplexing_port: number;
@@ -330,7 +335,7 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
         : new TunnelMultiplexingPoolingCluster(tunnelOpts);
     } else {
       const sockets = await Promise.all(
-        Array.from({ length: 2 }).map(() =>
+        Array.from({ length: HTTP2_NUMBER_OF_CONNECTIONS }).map(() =>
           this.openSocket({
             useTls,
             remoteHost,

--- a/packages/tunnel-client/src/types.ts
+++ b/packages/tunnel-client/src/types.ts
@@ -5,11 +5,11 @@ export interface TunnelInfo {
   url: string;
   maxConn: number;
   remoteHost: string;
-  remotePort?: number | undefined;
   useTls: boolean;
   tunnelPassphrase: string;
-  multiplexingRemotePort?: number | undefined;
+  multiplexingRemotePort: number;
   useNoPoolMultiplexing?: boolean | undefined;
+  useHTTP2ForMultiplexing?: boolean | undefined;
   basicAuthUser: string;
   basicAuthPassword: string;
   localPort: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,6 +3013,13 @@ agentkeepalive@^4.2.1:
     depd "^1.1.2"
     humanize-ms "^1.2.1"
 
+agentkeepalive@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.5.0.tgz#2673ad1389b3c418c5a20c5d7364f93ca04be923"
+  integrity sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==
+  dependencies:
+    humanize-ms "^1.2.1"
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -9340,7 +9347,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9422,7 +9438,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10199,7 +10222,16 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
### Changes

This creates a new secure tunnel server agent which uses HTTP2 under the hood. It is pretty similar to the already existing no-pool multiplexing one but the multiplexing here is done via the native HTTP2 Node implementation rather than an external library.