### PR TITLE
Fix local API port

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "cli": "node dist/main.js",
     "cli:debug": "echo '\n\nVisit chrome://inspect in Chrome and attach the debugger\n\n' && node --inspect-brk dist/main.js",
     "cli:dev": "ts-node src/main.ts",
-    "cli:dev-localhost": "METICULOUS_API_URL=http://localhost:3001/api/ ts-node src/main.ts",
+    "cli:dev-localhost": "METICULOUS_API_URL=http://localhost:3000/api/ ts-node src/main.ts",
     "cli:dev-staging": "METICULOUS_API_URL=https://staging-backend.alb.meticulous.ai/api/ ts-node src/main.ts",
     "test": "jest --passWithNoTests",
     "depcheck": "depcheck --ignore-patterns=dist"


### PR DESCRIPTION
`3001` works when running the frontend in dev mode (I guess it proxied to 3000 somehow?) but doesn't work when running the frontend in prod mode. `3000` is the correct port and works for both modes.