### PR TITLE
Don't add comma after tunnel URL

### DIFF
--- a/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
+++ b/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
@@ -69,7 +69,7 @@ const handler = async (argv: Options) => {
   });
 
   logger.info(
-    `Your url is: ${tunnel.url}, user: ${tunnel.basicAuthUser}, password: ${tunnel.basicAuthPassword}`
+    `Your url is: ${tunnel.url} \nuser: ${tunnel.basicAuthUser}, password: ${tunnel.basicAuthPassword}`
   );
 
   if (argv.printRequests) {


### PR DESCRIPTION
Chrome thinks the comma is part of the URL, so, when you click on it, the navigation won't work properly. I think putting user and password on their own line makes them more visible as well.