### PR TITLE
Add API for record/replay of custom events

### DIFF
--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
@@ -151,8 +151,11 @@ export type IDBObjectStoreWithEntries = Omit<
 
 export type CustomUserEvent = {
   type: string;
+  /**
+   * The timestamp based on performance.now() in the browser when the event was recorded.
+   */
   timestamp: number;
-  data: any;
+  data: string;
 };
 
 export type CustomData = {

--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
@@ -149,7 +149,14 @@ export type IDBObjectStoreWithEntries = Omit<
   entries: { key?: SerializedIDBValidKey; value: string }[];
 };
 
+export type CustomUserEvent = {
+  type: string;
+  timestamp: number;
+  data: any;
+};
+
 export type CustomData = {
   singletons: Record<string, string>;
   arrays: Record<string, string[]>;
+  events: CustomUserEvent[];
 };

--- a/packages/sdk-bundles-api/src/window-api/public-window-api.ts
+++ b/packages/sdk-bundles-api/src/window-api/public-window-api.ts
@@ -44,7 +44,10 @@ export interface MeticulousPublicReplayApi {
   /**
    * Call this method to add a listener for a custom event that was recorded during the test run.
    */
-  addCustomEventListener(type: string, callback: (data: any) => void): void;
+  addCustomEventListener(
+    type: string,
+    callback: (serializedData: string) => void | Promise<void>
+  ): void;
 }
 
 export interface MeticulousPublicRecordApi {
@@ -69,5 +72,5 @@ export interface MeticulousPublicRecordApi {
    * at the same timestamp as when it was recorde. To listen for these events at replay
    * time see the addCustomEventListener method in the replay API.
    */
-  recordCustomEvent(type: string, data: any): { success: boolean };
+  recordCustomEvent(type: string, serializedData: string): { success: boolean };
 }

--- a/packages/sdk-bundles-api/src/window-api/public-window-api.ts
+++ b/packages/sdk-bundles-api/src/window-api/public-window-api.ts
@@ -40,6 +40,11 @@ export interface MeticulousPublicReplayApi {
    * Call this method to retrieve an array of custom data that was recorded during the test run.
    */
   retrieveCustomDataArray(arrayId: string): string[];
+
+  /**
+   * Call this method to add a listener for a custom event that was recorded during the test run.
+   */
+  addCustomEventListener(type: string, callback: (data: any) => void): void;
 }
 
 export interface MeticulousPublicRecordApi {
@@ -58,4 +63,11 @@ export interface MeticulousPublicRecordApi {
     arrayId: string,
     valueToAppend: string
   ): { success: boolean };
+
+  /**
+   * Call this method to record a custom event to replay when replaying this session
+   * at the same timestamp as when it was recorde. To listen for these events at replay
+   * time see the addCustomEventListener method in the replay API.
+   */
+  recordCustomEvent(type: string, data: any): { success: boolean };
 }


### PR DESCRIPTION
This will unblock one of our customers who wants to record files being dropped onto the browser which isn't something our recorder captures at the moment. The biggest open question is whether we allow an async function as a listener and `await` it.