### PR TITLE
Add truncated message to DivergenceConsoleError

### DIFF
--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/replay-divergence.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/replay-divergence.ts
@@ -36,8 +36,10 @@ export interface DivergenceConsoleError {
   idx: number;
   /**
    * Truncated to the first 50 characters to avoid sending large payloads
+   *
+   * Not present in divergences prior to Nov 15, 2024
    */
-  truncatedMessage: string;
+  truncatedMessage?: string;
   numHeadAppearances: number;
   numBaseAppearances: number;
 }

--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/replay-divergence.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/replay-divergence.ts
@@ -34,6 +34,10 @@ export interface InitialNavigationDivergenceIndicator {
 
 export interface DivergenceConsoleError {
   idx: number;
+  /**
+   * Truncated to the first 50 characters to avoid sending large payloads
+   */
+  truncatedMessage: string;
   numHeadAppearances: number;
   numBaseAppearances: number;
 }


### PR DESCRIPTION
Can be useful context prior to loading the full timeline data.

Used in https://github.com/alwaysmeticulous/meticulous/pull/3892