### PR TITLE
Create typings for test run chunk execution & expose bundle function for chunked exection

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -26,6 +26,7 @@ export {
   TestCaseResult,
   TestCaseResultStatus,
 } from "./replay/test-run.types";
+export { TestRunChunkStatus } from "./replay/test-run-chunk.types";
 export * from "./sdk-bundle-api/sdk-to-bundle/test-run-environment";
 export { ReplayableEvent } from "./sdk-bundle-api/bidirectional/replayable-event";
 export {

--- a/packages/api/src/replay/test-run-chunk.types.ts
+++ b/packages/api/src/replay/test-run-chunk.types.ts
@@ -1,0 +1,8 @@
+import { TestRunStatus } from "./test-run.types";
+
+/**
+ * Execution of a chunk of a test run chunk.
+ *
+ * The values and their meanings are the same as for {@link TestRunStatus}.
+ */
+export type TestRunChunkStatus = TestRunStatus;

--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -34,6 +34,13 @@ export type TestRunStatus =
   | "Failure"
   | "ExecutionError";
 
+/**
+ * Execution of a chunk of a test run chunk.
+ *
+ * The values and their meanings are the same as for {@link TestRunStatus}.
+ */
+export type TestRunChunkStatus = TestRunStatus;
+
 export type TestCaseResultStatus = "pass" | "fail" | "flake";
 
 export interface TestCaseResult extends TestCase {

--- a/packages/replay-orchestrator-launcher/src/index.ts
+++ b/packages/replay-orchestrator-launcher/src/index.ts
@@ -1,10 +1,12 @@
 import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
 import { fetchAsset } from "@alwaysmeticulous/downloading-helpers";
 import {
+  ExecuteScheduledTestRunChunkOptions,
   ExecuteScheduledTestRunOptions,
   ExecuteTestRunOptions,
   ExecuteTestRunResult,
   InProgressTestRun,
+  InProgressTestRunChunk,
   ReplayAndStoreResultsOptions,
   ReplayExecution,
 } from "@alwaysmeticulous/sdk-bundles-api";
@@ -29,6 +31,9 @@ export const replayAndStoreResults = async (
   });
 };
 
+const EXECUTE_SCHEDULED_TEST_RUN_BUNDLE_PATH =
+  "replay/v3/execute-scheduled-test-run.bundle.js";
+
 export const executeScheduledTestRun = async (
   options: Omit<
     ExecuteScheduledTestRunOptions,
@@ -37,10 +42,28 @@ export const executeScheduledTestRun = async (
 ): Promise<InProgressTestRun> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   const bundleLocation = await fetchAsset(
-    "replay/v3/execute-scheduled-test-run.bundle.js"
+    EXECUTE_SCHEDULED_TEST_RUN_BUNDLE_PATH
   );
 
   return (await require(bundleLocation)).executeTestRunV2({
+    ...options,
+    chromeExecutablePath: getChromiumExecutablePath(),
+    logLevel: logger.getLevel(),
+  });
+};
+
+export const executeScheduledTestRunChunk = async (
+  options: Omit<
+    ExecuteScheduledTestRunChunkOptions,
+    "logLevel" | "chromeExecutablePath"
+  >
+): Promise<InProgressTestRunChunk> => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const bundleLocation = await fetchAsset(
+    EXECUTE_SCHEDULED_TEST_RUN_BUNDLE_PATH
+  );
+
+  return (await require(bundleLocation)).executeTestRunChunk({
     ...options,
     chromeExecutablePath: getChromiumExecutablePath(),
     logLevel: logger.getLevel(),

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -41,6 +41,11 @@ export {
 } from "./replay-orchestrator/bundle-to-sdk/execute-test-run";
 export { InProgressTestRun } from "./replay-orchestrator/bundle-to-sdk/execute-scheduled-test-run";
 export {
+  InProgressTestRunChunk,
+  ExecuteTestRunChunkResult,
+  TestRunChunkExecution,
+} from "./replay-orchestrator/bundle-to-sdk/execute-scheduled-test-run-chunk";
+export {
   ReplayAndStoreResultsResult,
   ReplayExecution,
   BeforeUserEventResult,

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -29,6 +29,7 @@ export {
 } from "./replay-orchestrator/sdk-to-bundle/execute-replay";
 export { ExecuteTestRunOptions } from "./replay-orchestrator/sdk-to-bundle/execute-test-run";
 export { ExecuteScheduledTestRunOptions } from "./replay-orchestrator/sdk-to-bundle/execute-scheduled-test-run";
+export { ExecuteScheduledTestRunChunkOptions } from "./replay-orchestrator/sdk-to-bundle/execute-scheduled-test-run-chunk";
 export {
   ExecuteTestRunResult,
   TestRunExecution,

--- a/packages/sdk-bundles-api/src/index.ts
+++ b/packages/sdk-bundles-api/src/index.ts
@@ -32,6 +32,7 @@ export { ExecuteScheduledTestRunOptions } from "./replay-orchestrator/sdk-to-bun
 export { ExecuteScheduledTestRunChunkOptions } from "./replay-orchestrator/sdk-to-bundle/execute-scheduled-test-run-chunk";
 export {
   ExecuteTestRunResult,
+  ExecutionProgress,
   TestRunExecution,
   RunningTestRunExecution,
   FinishedTestRunExecution,

--- a/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-scheduled-test-run-chunk.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-scheduled-test-run-chunk.ts
@@ -1,0 +1,25 @@
+import { Project, TestRunChunkStatus } from "@alwaysmeticulous/api";
+import { DetailedTestCaseResult, ExecutionProgress } from "./execute-test-run";
+
+export interface ExecuteTestRunChunkResult {
+  testRunChunk: TestRunChunkExecution;
+  testCaseResults: DetailedTestCaseResult[];
+}
+
+export interface TestRunChunkExecution {
+  testRunId: string;
+  chunkNumber: number;
+  status: TestRunChunkStatus;
+  project: Project;
+  progress: ExecutionProgress;
+  testRunUrl: string;
+}
+
+export interface InProgressTestRunChunk {
+  /**
+   * The results of the tests that were executed within a test run chunk.
+   * Resolves when the test run completes.
+   */
+  result: Promise<ExecuteTestRunChunkResult>;
+  markTestRunChunkAsFailed: () => Promise<void>;
+}

--- a/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-test-run.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/bundle-to-sdk/execute-test-run.ts
@@ -10,7 +10,7 @@ export interface TestRunExecution {
   id: string;
   status: TestRunStatus;
   project: Project;
-  progress: TestRunProgress;
+  progress: ExecutionProgress;
   url: string;
 }
 
@@ -34,12 +34,17 @@ export interface TestRunEditedCoverage {
   executableLinesEditedAndCovered: number;
 }
 
-export interface TestRunProgress {
+export interface ExecutionProgress {
   failedTestCases: number;
   flakedTestCases: number;
   passedTestCases: number;
   runningTestCases: number;
 }
+
+/**
+ * @deprecated Use `ExecutionProgress` instead.
+ */
+export type TestRunProgress = ExecutionProgress;
 
 export interface DetailedTestCaseResult extends TestCaseResult {
   screenshotDiffDataByBaseReplayId: Record<string, ScreenshotDiffData>;

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-scheduled-test-run-chunk.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-scheduled-test-run-chunk.ts
@@ -1,0 +1,20 @@
+import { ExecuteTestRunOptions } from "./execute-test-run";
+
+export type ExecuteScheduledTestRunChunkOptions = Pick<
+  ExecuteTestRunOptions,
+  | "chromeExecutablePath"
+  | "apiToken"
+  | "parallelTasks"
+  | "logLevel"
+  | "logicalEnvironmentVersion"
+> & {
+  /**
+   * The ID of the scheduled test run to execute.
+   */
+  testRunId: string;
+
+  /**
+   * The chunk number to execute.
+   */
+  chunkNumber: number;
+};


### PR DESCRIPTION
### Changes

This creates the typings required for test run chunk execution and also exposes `executeTestRunChunk`
in `replay-orchestrator-launcher`.  `executeTestRunChunk` is not part of the bundle yet but there will be no users of it yet.