### PR TITLE
Store changed sections classnames

### DIFF
--- a/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
+++ b/packages/api/src/sdk-bundle-api/bundle-to-sdk/screenshot-diff-result.ts
@@ -175,6 +175,19 @@ export interface ScreenshotDiffResultDifference
    * This can be useful for grouping together diffs that are caused by the same change.
    */
   hashOfChangedSectionsClassNames?: string;
+
+  /**
+   * The set of the first N class names within the DOM sections that have differences.
+   *
+   * Only present on recent replays since Dec 2024.
+   */
+  changedSectionsClassNames?: string[];
+
+  /**
+   * If there are too many class names we truncate the {@link changedSectionsClassNames} list,
+   * and this field will be true, otherwise this field will not be present.
+   */
+  isChangedSectionsClassNamesListTruncated?: true;
 }
 
 /**


### PR DESCRIPTION
See corresponding main repo PR for details of why we are storing these. I think around 2% of comparisons are diffs, so it shouldn't increase data volume too much (no-diffs take up about 350 bytes; these class names I'd expect on average to take up around 150-300 bytes; so maybe looking at a 1-2% increase in data volume). We could hash the classnames to 4 chars long if we wanted to reduce data usage (collisions aren't catastrophic in our case), but for now not hashing to aid debug-ability).