### PR TITLE
Move sdk-bundles-api to dependencies

### DIFF
--- a/packages/recorder-loader/package.json
+++ b/packages/recorder-loader/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "eslint \"src/**/*.{js,ts,tsx}\"  --cache --fix",
     "depcheck": "depcheck --ignore-patterns=dist"
   },
-  "devDependencies": {
+  "dependencies": {
     "@alwaysmeticulous/sdk-bundles-api": "^2.189.0"
   },
   "author": {

--- a/packages/sdk-bundles-api/package.json
+++ b/packages/sdk-bundles-api/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint \"src/**/*.{js,ts,tsx}\"  --cache --fix",
     "depcheck": "depcheck --ignore-patterns=dist"
   },
-  "devDependencies": {
+  "dependencies": {
     "@alwaysmeticulous/api": "^2.189.0"
   },
   "author": {

--- a/packages/sdk-bundles-api/package.json
+++ b/packages/sdk-bundles-api/package.json
@@ -21,14 +21,6 @@
   "devDependencies": {
     "@alwaysmeticulous/api": "^2.189.0"
   },
-  "peerDependencies": {
-    "loglevel": "^1.8.0"
-  },
-  "peerDependenciesMeta": {
-    "loglevel": {
-      "optional": true
-    }
-  },
   "author": {
     "name": "The Meticulous Team",
     "email": "eng@meticulous.ai",

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-replay.ts
@@ -6,8 +6,8 @@ import {
   ScreenshotDiffOptions,
   ScreenshottingEnabledOptions,
 } from "@alwaysmeticulous/api";
-import { LogLevelNumbers } from "loglevel";
 import { BeforeUserEventResult } from "../bundle-to-sdk/execute-replay";
+import { LogLevelNumbers } from "./loglevel";
 
 export interface ReplayAndStoreResultsOptions {
   chromeExecutablePath?: string;

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/execute-test-run.ts
@@ -2,9 +2,9 @@ import {
   ScreenshotAssertionsEnabledOptions,
   TestRunEnvironment,
 } from "@alwaysmeticulous/api";
-import { LogLevelNumbers } from "loglevel";
 import { RunningTestRunExecution } from "../bundle-to-sdk/execute-test-run";
 import { ReplayExecutionOptions } from "./execute-replay";
+import { LogLevelNumbers } from "./loglevel";
 
 export interface ExecuteTestRunOptions {
   chromeExecutablePath?: string;

--- a/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/loglevel.ts
+++ b/packages/sdk-bundles-api/src/replay-orchestrator/sdk-to-bundle/loglevel.ts
@@ -1,0 +1,6 @@
+/**
+ * The log levels that can be used in the SDK.
+ *
+ * Similar to the LogLevelNumbers in the `loglevel` package.
+ */
+export type LogLevelNumbers = 0 | 1 | 2 | 3 | 4 | 5;


### PR DESCRIPTION
`@alwaysmeticulous/sdk-bundles-api` and its deps are needed at runtime for users of the recorder-loader package.