### PR TITLE
Expose function to check if an asset is outdated

### DIFF
--- a/packages/downloading-helpers/src/index.ts
+++ b/packages/downloading-helpers/src/index.ts
@@ -8,7 +8,7 @@ export {
   getOrFetchRecordedSession,
   getOrFetchRecordedSessionData,
 } from "./file-downloads/sessions";
-export { fetchAsset } from "./scripts/replay-assets";
+export { fetchAsset, checkIfAssetOutdated } from "./scripts/replay-assets";
 export {
   downloadFile,
   downloadAndExtractFile,

--- a/packages/downloading-helpers/src/index.ts
+++ b/packages/downloading-helpers/src/index.ts
@@ -8,7 +8,7 @@ export {
   getOrFetchRecordedSession,
   getOrFetchRecordedSessionData,
 } from "./file-downloads/sessions";
-export { fetchAsset, checkIfAssetOutdated } from "./scripts/replay-assets";
+export { fetchAsset, checkIfAssetsOutdated } from "./scripts/replay-assets";
 export {
   downloadFile,
   downloadAndExtractFile,


### PR DESCRIPTION
Tested via Node console:

```
> await helpers.checkIfAssetsOutdated(["replay/v2/browser-scripts.bundle.js","replay/v2/snippet-playback.bundle.js"])
{
  'replay/v2/browser-scripts.bundle.js': true,
  'replay/v2/snippet-playback.bundle.js': true
}
> await helpers.fetchAsset("replay/v2/browser-scripts.bundle.js")
> await helpers.checkIfAssetsOutdated(["replay/v2/browser-scripts.bundle.js","replay/v2/snippet-playback.bundle.js"])
{
  'replay/v2/browser-scripts.bundle.js': false,
  'replay/v2/snippet-playback.bundle.js': true
}
> await helpers.fetchAsset("replay/v2/snippet-playback.bundle.js")
> await helpers.checkIfAssetsOutdated(["replay/v2/browser-scripts.bundle.js","replay/v2/snippet-playback.bundle.js"])
{
  'replay/v2/browser-scripts.bundle.js': false,
  'replay/v2/snippet-playback.bundle.js': false
}
> 
```