### PR TITLE
Output progress for run-all-tests-in-cloud in notty environments

### DIFF
--- a/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
+++ b/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
@@ -64,7 +64,7 @@ const handler: (options: Options) => Promise<void> = async ({
         "{bar}"
       )}| {percentage}% || {value}/{total} tests executed`,
       noTTYOutput: true,
-      notTTYSchedule: 60000,
+      notTTYSchedule: 30000,
     },
     cliProgress.Presets.shades_classic
   );

--- a/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
+++ b/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
@@ -63,6 +63,8 @@ const handler: (options: Options) => Promise<void> = async ({
       format: `Test Run execution progress |${chalk.cyan(
         "{bar}"
       )}| {percentage}% || {value}/{total} tests executed`,
+      noTTYOutput: true,
+      notTTYSchedule: 60000,
     },
     cliProgress.Presets.shades_classic
   );


### PR DESCRIPTION
Some CI runners such as CircleCI will timeout the job early if they see no new output.