### PR TITLE
Fix handling of not found errors for trigger test run

### DIFF
--- a/packages/client/src/api/test-run.api.ts
+++ b/packages/client/src/api/test-run.api.ts
@@ -4,7 +4,7 @@ import {
   TestCaseResult,
   TestRunStatus,
 } from "@alwaysmeticulous/api";
-import { AxiosError, AxiosInstance, isAxiosError } from "axios";
+import { AxiosError, AxiosInstance } from "axios";
 import { maybeEnrichAxiosError } from "../errors";
 
 export interface TestRun {


### PR DESCRIPTION
This paves the way towards having it return a good error if you pass an commit SHA that doesn't exist / can't be found (I hit this when testing for the no-tty stuff)