### PR TITLE
Separate asset caches for alternate base URLs

### DIFF
--- a/packages/downloading-helpers/src/config/snippets.ts
+++ b/packages/downloading-helpers/src/config/snippets.ts
@@ -14,6 +14,10 @@ export const getSnippetsBaseUrl = (): string => {
   }
 };
 
+export const isCustomSnippetsBaseUrl = (): boolean => {
+  return !!process.env["METICULOUS_SNIPPETS_BASE_URL"];
+};
+
 export class ConfigurationError extends Error {
   constructor(message: string) {
     super(message);


### PR DESCRIPTION
Allows running tests comparing multiple versions of snippets simultaneously without them clobbering each other / overwriting each other's cached assets.