### PR TITLE
Add delay between retries

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -29,7 +29,10 @@ export const createClient: (options: ClientOptions) => AxiosInstance = ({
     // 60 seconds default timeout
     timeout: 60_000,
   });
-  axiosRetry(client, { retries: 3 });
+  axiosRetry(client, {
+    retries: 3,
+    retryDelay: (retryCount) => retryCount * 1000,
+  });
 
   return client;
 };


### PR DESCRIPTION
Currently a short blip would make the three retries all fail quickly.