### PR TITLE
Add new field to mark selected test cases

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -2,6 +2,7 @@ import { ScreenshotDiffOptions } from "../sdk-bundle-api/sdk-to-bundle/screensho
 
 export interface TestCase {
   sessionId: string;
+  selected?: boolean;
   title?: string;
   options?: TestCaseReplayOptions;
 }


### PR DESCRIPTION
This PR enables marking test cases as selected. It will be used in the future to optimise session selection just before execution.