### PR TITLE
Rename field to mark relevant test cases

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -2,7 +2,7 @@ import { ScreenshotDiffOptions } from "../sdk-bundle-api/sdk-to-bundle/screensho
 
 export interface TestCase {
   sessionId: string;
-  selected?: boolean;
+  isRelevantToPR?: boolean;
   title?: string;
   options?: TestCaseReplayOptions;
 }


### PR DESCRIPTION
Let's rename the field, to avoid confusion between "Session Selection" and "Relevant Session Execution at PR time". This is a breaking change, but most likely nobody is using this new field yet, so IMO worth to do it now rather than just deprecating the old field.