### PR TITLE
Support more granular session relevance tagging

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -21,6 +21,7 @@ export {
   RedactedScreenshotsComparison,
 } from "./sdk-bundle-api/bundle-to-sdk/screenshot-diff-result";
 export {
+  SessionRelevance,
   TestCase,
   TestCaseReplayOptions,
   TestRunStatus,

--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -1,8 +1,13 @@
 import { ScreenshotDiffOptions } from "../sdk-bundle-api/sdk-to-bundle/screenshotting-options";
 
+/**
+ * Relevance of a session
+ */
+export type SessionRelevance = "is-relevant" | "not-relevant" | "maybe-relevant"; 
+
 export interface TestCase {
   sessionId: string;
-  isRelevantToPR?: boolean;
+  relevanceToPR?: SessionRelevance;
   title?: string;
   options?: TestCaseReplayOptions;
 }


### PR DESCRIPTION
We want to support more granular tagging to express different confidences.