### PR TITLE
Use enum for SessionRelevance

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -21,7 +21,7 @@ export {
   RedactedScreenshotsComparison,
 } from "./sdk-bundle-api/bundle-to-sdk/screenshot-diff-result";
 export {
-  SessionRelevance,
+SessionRelevance,
   TestCase,
   TestCaseReplayOptions,
   TestRunStatus,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -21,7 +21,7 @@ export {
   RedactedScreenshotsComparison,
 } from "./sdk-bundle-api/bundle-to-sdk/screenshot-diff-result";
 export {
-SessionRelevance,
+  SessionRelevance,
   TestCase,
   TestCaseReplayOptions,
   TestRunStatus,

--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -3,7 +3,11 @@ import { ScreenshotDiffOptions } from "../sdk-bundle-api/sdk-to-bundle/screensho
 /**
  * Relevance of a session
  */
-export type SessionRelevance = "is-relevant" | "not-relevant" | "maybe-relevant"; 
+export enum SessionRelevance {
+  IsRelevant = "is-relevant",
+  NotRelevant = "not-relevant", 
+  MaybeRelevant = "maybe-relevant"
+}
 
 export interface TestCase {
   sessionId: string;


### PR DESCRIPTION
ORM is not compatible with typescript union types, so let's use enum to guarantee better type safety in our data layer

This change and particularly ORM compatibility has been tested via `yarn link`