### PR TITLE
Allow overriding default redaction policies

### DIFF
--- a/packages/redaction/src/generic/__tests__/redact-nested-fields.spec.ts
+++ b/packages/redaction/src/generic/__tests__/redact-nested-fields.spec.ts
@@ -104,6 +104,7 @@ describe("redactNestedFields", () => {
         strings: {
           tag: doNotRedact,
           media_key: doNotRedact,
+          expanded_url: doNotRedact,
         },
       });
 
@@ -159,7 +160,7 @@ describe("redactNestedFields", () => {
           "urls": [
             {
               "display_url": "https://redacted.com/",
-              "expanded_url": "https://redacted.com/",
+              "expanded_url": "https://example.com",
               "url": "https://redacted.com/",
             },
           ],

--- a/packages/redaction/src/generic/redact-nested-fields/common-redactors.ts
+++ b/packages/redaction/src/generic/redact-nested-fields/common-redactors.ts
@@ -18,7 +18,9 @@ import {
  */
 export const NAME_REDACTORS = PatternBasedRedactorSet.create<string>()
   .with(redactKey("name", redactString))
-  .with(redactKeysEndingWith("_name", redactString))
+  .with(redactKeysEndingWith("first_name", redactString))
+  .with(redactKeysEndingWith("last_name", redactString))
+  .with(redactKeysEndingWith("full_name", redactString))
   .with(redactKeysEndingWith("ullName", redactString))
   .with(redactKeysEndingWith("irstname", redactString))
   .with(redactKeysEndingWith("astname", redactString));

--- a/packages/redaction/src/generic/redact-nested-fields/redact-nested-fields.ts
+++ b/packages/redaction/src/generic/redact-nested-fields/redact-nested-fields.ts
@@ -95,10 +95,14 @@ export class NestedFieldsRedactor<
   /**
    * Type safety: forces a redaction policy to be set for every unique nested string field name in the object.
    * Leaves redaction of dates, numbers and bigints as optional.
+   *
+   * Note: if a redactor is provided for a property x that already has a default redaction policy then that
+   * redactor will be used for property x rather than the default redaction policy.
    */
   public createRedactor<T>(opts: {
-    strings: Omit<RedactorsFor<T>, HANDLED_STRING_KEY_TYPES>;
-    dates?: Omit<Partial<RedactorsFor<T, Date>>, HANDLED_DATE_KEY_TYPES>;
+    strings: Omit<RedactorsFor<T>, HANDLED_STRING_KEY_TYPES> &
+      Partial<RedactorsFor<T>>;
+    dates?: Partial<RedactorsFor<T, Date>>;
     numbers?: Partial<RedactorsFor<T, number>>;
     bigints?: Partial<RedactorsFor<T, bigint>>;
     defaultStringRedactor?: Redactor<string>;
@@ -115,10 +119,15 @@ export class NestedFieldsRedactor<
   /**
    * Type safety: forces a redaction policy to be set for every unique nested string, date, number and bigint
    * field name in the object.
+   *
+   * Note: if a redactor is provided for a property x that already has a default redaction policy then that
+   * redactor will be used for property x rather than the default redaction policy.
    */
   public createRedactorStrict<T>(opts: {
-    strings: Omit<RedactorsFor<T>, HANDLED_STRING_KEY_TYPES>;
-    dates: Omit<RedactorsFor<T, Date>, HANDLED_DATE_KEY_TYPES>;
+    strings: Omit<RedactorsFor<T>, HANDLED_STRING_KEY_TYPES> &
+      Partial<RedactorsFor<T>>;
+    dates: Omit<RedactorsFor<T, Date>, HANDLED_DATE_KEY_TYPES> &
+      Partial<RedactorsFor<T, Date>>;
     numbers: RedactorsFor<T, number>;
     bigints: RedactorsFor<T, bigint>;
     defaultStringRedactor?: Redactor<string>;
@@ -132,6 +141,12 @@ export class NestedFieldsRedactor<
     } as any as MultiTypeRedactors<T>);
   }
 
+  /**
+   * Type safety: does not force a redaction policy to be set of any field.
+   *
+   * Note: if a redactor is provided for a property x that already has a default redaction policy then that
+   * redactor will be used for property x rather than the default redaction policy.
+   */
   public createRedactorLax = <T>(opts: {
     strings: Record<string, Redactor<string>>;
     dates?: Record<string, Redactor<Date>>;


### PR DESCRIPTION
`${string}_name` is too wide a policy since `xyz_name` can often be used for type unions (e.g. `retry_strategy_name` etc.).

This PR makes two changes:
 1. Update the typings to allow overriding the default policies
 2. Switching from redacting `${string}_name` to just `${string}first_name`, `${string}last_name`, `${string}full_name` etc.
 
 The second change is a breaking change, so will do an appropriate version bump. When clients upgrade if they have any `_name` properties that are not [`${string}first_name`, `${string}last_name`, `${string}full_name`] then they will be forced by compile time checks to now specify an explicit redaction policy for them.