### PR TITLE
Update custom events typing to reflect older sessions

### DIFF
--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
@@ -284,5 +284,8 @@ export type CustomData = {
   singletons: Record<string, string> &
     Partial<CustomDataSingletonInternalValues>;
   arrays: Record<string, string[]>;
-  events: CustomUserEvent[];
+  /**
+   * Only present on recordings since ~November 2024.
+   */
+  events?: CustomUserEvent[];
 };


### PR DESCRIPTION
Matches the pattern for other fields we've added to existing session data objects ([e.g.](https://github.com/alwaysmeticulous/meticulous-sdk/blob/main/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts#L59)), and this typing would have prevented the issue [here](https://github.com/alwaysmeticulous/meticulous/pull/5049). Makes sure we won't hit a similar issue again although most sessions that would have fallen into this category are probably deselected by now.