### PR TITLE
Wait for base before uploading assets

### DIFF
--- a/packages/cli/src/commands/upload-assets-and-execute-test-run-in-cloud/upload-assets-and-execute-test-run-in-cloud.command.ts
+++ b/packages/cli/src/commands/upload-assets-and-execute-test-run-in-cloud/upload-assets-and-execute-test-run-in-cloud.command.ts
@@ -14,6 +14,7 @@ interface Options {
   commitSha?: string | undefined;
   appDirectory: string;
   rewrites?: string;
+  waitForBase: boolean;
 }
 
 const handler: (options: Options) => Promise<void> = async ({
@@ -21,6 +22,7 @@ const handler: (options: Options) => Promise<void> = async ({
   commitSha: commitSha_,
   appDirectory,
   rewrites,
+  waitForBase,
 }) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   const commitSha = await getCommitSha(commitSha_);
@@ -40,6 +42,7 @@ const handler: (options: Options) => Promise<void> = async ({
       commitSha,
       appDirectory,
       rewrites: parseRewrites(rewrites),
+      waitForBase,
     });
   } catch (error) {
     if (isOutOfDateClientError(error)) {
@@ -115,6 +118,13 @@ export const uploadAssetsAndExecuteTestRunInCloudCommand = buildCommand(
       default: "[]",
       description:
         "URL rewrite rules. This string should be a valid JSON array in the format described at https://github.com/vercel/serve-handler?tab=readme-ov-file#rewrites-array",
+    },
+    waitForBase: {
+      demandOption: false,
+      boolean: true,
+      default: true,
+      description:
+        "If true, the launcher will try to wait for a base test run to be created before triggering a test run. If that is not found, it will trigger a test run without waiting for a base test run.",
     },
   } as const)
   .handler(handler);

--- a/packages/client/src/api/project-deployments.api.ts
+++ b/packages/client/src/api/project-deployments.api.ts
@@ -15,10 +15,12 @@ export interface CompleteAssetUploadParams {
   uploadId: string;
   commitSha: string;
   rewrites: AssetUploadMetadata["rewrites"];
+  mustHaveBase: boolean;
 }
 
 export interface CompleteAssetUploadResponse {
   testRun?: TestRun;
+  baseNotFound?: boolean;
 }
 
 export interface DownloadDeploymentResponse {
@@ -36,6 +38,19 @@ export const requestAssetUpload = async ({
     RequestAssetUploadParams,
     { data: RequestAssetUploadResponse }
   >("project-deployments/request-asset-upload", params);
+  return data;
+};
+
+export const triggerRunOnDeployment = async ({
+  client,
+  ...params
+}: CompleteAssetUploadParams & {
+  client: AxiosInstance;
+}): Promise<CompleteAssetUploadResponse> => {
+  const { data } = await client.post<
+    CompleteAssetUploadParams,
+    { data: CompleteAssetUploadResponse }
+  >("project-deployments/trigger-run", params);
   return data;
 };
 

--- a/packages/remote-replay-launcher/src/types.ts
+++ b/packages/remote-replay-launcher/src/types.ts
@@ -49,5 +49,10 @@ export interface UploadAssetsAndTriggerTestRunOptions {
   apiToken: string | null | undefined;
   appDirectory: string;
   commitSha: string;
+  /**
+   * If true, before triggering a test run, the launcher will wait for a base test run to be created. If that is not found,
+   * it will trigger a test run without waiting for a base test run.
+   */
+  waitForBase: boolean;
   rewrites?: AssetUploadMetadata["rewrites"];
 }

--- a/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
+++ b/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
@@ -80,6 +80,7 @@ export const uploadAssetsAndTriggerTestRun = async ({
   appDirectory,
   commitSha,
   rewrites,
+  waitForBase,
 }: UploadAssetsAndTriggerTestRunOptions): Promise<ExecuteRemoteTestRunResult> => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
 
@@ -112,7 +113,7 @@ export const uploadAssetsAndTriggerTestRun = async ({
       client,
       uploadId,
       commitSha,
-      mustHaveBase: true,
+      mustHaveBase: waitForBase,
       rewrites: rewrites ?? [],
     });
     logger.info(`Deployment assets ${uploadId} marked as uploaded`);

--- a/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
+++ b/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
@@ -38,16 +38,16 @@ export const tryCompleteAssetUpload = async (
   while (!testRun && baseNotFound) {
     const timeElapsed = Date.now() - startTime;
     if (timeElapsed > POLL_FOR_BASE_TEST_RUN_MAX_TIMEOUT_MS) {
-      logger.log(
+      logger.warn(
         `Timed out after ${
           POLL_FOR_BASE_TEST_RUN_MAX_TIMEOUT_MS / 1000
         } seconds waiting for test run`
       );
       break;
     }
-    if (timeElapsed - lastTimeElapsed >= 30000) {
+    if (lastTimeElapsed == 0 || timeElapsed - lastTimeElapsed >= 30_000) {
       // Log at most once every 30 seconds
-      logger.log(
+      logger.info(
         `Waiting for base test run to be created. Time elapsed: ${timeElapsed}ms`
       );
       lastTimeElapsed = timeElapsed;
@@ -61,7 +61,7 @@ export const tryCompleteAssetUpload = async (
   }
 
   if (baseNotFound) {
-    // Trigger a test run without waiting for base
+    logger.info(`Base test run not found, proceeding without it.`);
     testRun = (
       await triggerRunOnDeployment({
         ...completeAssetUploadArgs,


### PR DESCRIPTION
This PR enables potentially waiting for base before executing a static assets deployment. If the deployment is not a pull request, we'll not wait (the logics is in the internal end-point)