### PR TITLE
Warn if no index.html can be found in static assets

### DIFF
--- a/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
+++ b/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
@@ -100,8 +100,7 @@ export const uploadAssetsAndTriggerTestRun = async ({
   // If there are no rewrites, check for an index.html in the root directory
   if (!rewrites || rewrites.length === 0) {
     const indexHtmlPath = join(resolvedAppDirectory, "index.html");
-    const indexHtmPath = join(resolvedAppDirectory, "index.htm");
-    if (!existsSync(indexHtmlPath) && !existsSync(indexHtmPath)) {
+    if (!existsSync(indexHtmlPath)) {
       logger.warn(
         `Warning: No index.html found in the app directory (${resolvedAppDirectory}). ` +
           `This may indicate that your build output is not properly configured for static hosting, unless you expect that the root url is invalid. ` +

--- a/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
+++ b/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
@@ -97,6 +97,20 @@ export const uploadAssetsAndTriggerTestRun = async ({
     throw new Error(`Directory does not exist: ${resolvedAppDirectory}`);
   }
 
+  // If there are no rewrites, check for an index.html in the root directory
+  if (!rewrites || rewrites.length === 0) {
+    const indexHtmlPath = join(resolvedAppDirectory, "index.html");
+    const indexHtmPath = join(resolvedAppDirectory, "index.htm");
+    if (!existsSync(indexHtmlPath) && !existsSync(indexHtmPath)) {
+      logger.warn(
+        `Warning: No index.html found in the app directory (${resolvedAppDirectory}). ` +
+          `This may indicate that your build output is not properly configured for static hosting, unless you expect that the root url is invalid. ` +
+          `If you're using Next.js or another framework that requires server-side rendering, ` +
+          `you should use the \`cloud-compute\` GitHub Action or the \`run-all-tests-in-cloud\` command instead.`
+      );
+    }
+  }
+
   const client = createClient({ apiToken });
 
   const zipPath = join(tmpdir(), `assets-${Date.now()}.zip`);


### PR DESCRIPTION
Static web applications typically have either an index.html file in their root directory. We'll check for both and warn if neither is found.