### PR TITLE
Also download per-screenshot coverage during post processing

### DIFF
--- a/packages/downloading-helpers/src/scripts/replays.ts
+++ b/packages/downloading-helpers/src/scripts/replays.ts
@@ -83,7 +83,8 @@ const DOWNLOAD_SCOPE_TO_FILES_TO_DOWNLOAD: Record<DownloadScope, RegExp> = {
   everything: /.*/,
   "screenshots-only": /^screenshots/,
   "timeline-only": /^timeline/,
-  "post-test-run-processing-files-only": /^(mappedCoverage|timeline)/,
+  "post-test-run-processing-files-only":
+    /^(mappedCoverage|timeline|mappedPerScreenshotJsCoverage)/,
 };
 
 const shouldDownloadFile = (


### PR DESCRIPTION
This will be used by the post processing phase to match per-screenshot coverage source maps to paths in code repositories