### PR TITLE
Downgrade cacheable-lookup

### DIFF
--- a/packages/tunnel-client/package.json
+++ b/packages/tunnel-client/package.json
@@ -21,7 +21,7 @@
     "agentkeepalive": "^4.5.0",
     "axios": "^1.7.9",
     "axios-retry": "^4.5.0",
-    "cacheable-lookup": "^7.0.0",
+    "cacheable-lookup": "^6.1.0",
     "loglevel": "^1.8.0"
   },
   "author": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4405,10 +4405,10 @@ cacache@^18.0.0:
     tar "^6.1.11"
     unique-filename "^3.0.0"
 
-cacheable-lookup@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz#3476a8215d046e5a3202a9209dd13fec1f933a27"
-  integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
+cacheable-lookup@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz#0330a543471c61faa4e9035db583aad753b36385"
+  integrity sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==
 
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
v7 is pure ESM, so let's use the last v6 version instead to support customers running without ESM.