### PR TITLE
Support PR author session relevance

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -22,6 +22,7 @@ export {
 } from "./sdk-bundle-api/bundle-to-sdk/screenshot-diff-result";
 export {
   SessionRelevance,
+  isPrAuthorRelevance,
   TestCase,
   TestCaseReplayOptions,
   TestRunStatus,

--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -12,6 +12,20 @@ export enum SessionRelevance {
   MaybeRelevant = "maybe-relevant",
 }
 
+export const isPrAuthorRelevance = (
+  relevance: SessionRelevance | null | undefined
+): boolean => {
+  if (!relevance) {
+    return false;
+  }
+
+  return (
+    relevance === SessionRelevance.IsPrAuthor ||
+    relevance === SessionRelevance.IsPrAuthorRelevant ||
+    relevance === SessionRelevance.IsPrAuthorNotRelevant
+  );
+};
+
 export interface TestCase {
   sessionId: string;
   relevanceToPR?: SessionRelevance;


### PR DESCRIPTION
We add new relevance members to identify whether a PR author session is relevant or not w.r.t the PR