### PR TITLE
Add cli command to download test run data

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -118,3 +118,4 @@ export {
   UserEventDivergenceIndicator,
 } from "./sdk-bundle-api/bundle-to-sdk/replay-divergence";
 export { AssetUploadMetadata } from "./sdk-bundle-api/sdk-to-bundle/asset-upload-metadata";
+export { S3Location } from "./s3.types";

--- a/packages/api/src/s3.types.ts
+++ b/packages/api/src/s3.types.ts
@@ -1,0 +1,4 @@
+export interface S3Location {
+  filePath: string; // e.g. logs.ndjson.gz
+  signedUrl: string; // signed S3 URL
+}

--- a/packages/cli/src/commands/download-test-run/download-test-run.command.ts
+++ b/packages/cli/src/commands/download-test-run/download-test-run.command.ts
@@ -1,0 +1,40 @@
+import { createClient } from "@alwaysmeticulous/client";
+import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { getOrFetchTestRunData } from "@alwaysmeticulous/downloading-helpers";
+import log from "loglevel";
+import { buildCommand } from "../../command-utils/command-builder";
+
+interface Options {
+  apiToken?: string | null | undefined;
+  testRunId: string;
+}
+
+const handler: (options: Options) => Promise<void> = async ({
+  apiToken,
+  testRunId,
+}) => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const client = createClient({ apiToken });
+
+  const { fileName: testRunDir } = await getOrFetchTestRunData(
+    client,
+    testRunId,
+    "everything"
+  );
+  logger.info(`Downloaded test run data to: ${testRunDir}`);
+};
+
+export const downloadTestRunCommand = buildCommand("download-test-run")
+  .details({
+    describe: "Download a Meticulous test run",
+  })
+  .options({
+    apiToken: {
+      string: true,
+    },
+    testRunId: {
+      string: true,
+      demandOption: true,
+    },
+  })
+  .handler(handler);

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -9,6 +9,7 @@ import { initSentry } from "@alwaysmeticulous/sentry";
 import yargs from "yargs";
 import { downloadReplayCommand } from "./commands/download-replay/download-replay.command";
 import { downloadSessionCommand } from "./commands/download-session/download-session.command";
+import { downloadTestRunCommand } from "./commands/download-test-run/download-test-run.command";
 import { recordCommand } from "./commands/record/record.command";
 import { recordLoginCommand } from "./commands/record-login/record-login.command";
 import { replayCommand } from "./commands/replay/replay.command";
@@ -40,6 +41,7 @@ export const main: () => void = async () => {
     )
     .command(downloadReplayCommand)
     .command(downloadSessionCommand)
+    .command(downloadTestRunCommand)
     .command(recordCommand)
     .command(recordLoginCommand)
     .command(replayCommand)

--- a/packages/client/src/api/replay.api.ts
+++ b/packages/client/src/api/replay.api.ts
@@ -1,4 +1,4 @@
-import { Replay } from "@alwaysmeticulous/api";
+import { Replay, S3Location } from "@alwaysmeticulous/api";
 import { AxiosInstance, isAxiosError } from "axios";
 import { maybeEnrichAxiosError } from "../errors";
 
@@ -37,19 +37,11 @@ export const getReplayDownloadUrl: (
   return data;
 };
 
-export interface S3UploadLocation {
-  filePath: string; // e.g. logs.ndjson.gz
-  signedUrl: string; // signed S3 URL
-}
-
-export type ReplayV3UploadLocations = Record<string, S3UploadLocation> & {
-  screenshots: Record<
-    string,
-    { image: S3UploadLocation; metadata?: S3UploadLocation }
-  >;
+export type ReplayV3UploadLocations = Record<string, S3Location> & {
+  screenshots: Record<string, { image: S3Location; metadata?: S3Location }>;
   diffs?: Record<
     string,
-    Record<string, { thumbnail: S3UploadLocation; full: S3UploadLocation }>
+    Record<string, { thumbnail: S3Location; full: S3Location }>
   >;
 };
 

--- a/packages/client/src/api/test-run.api.ts
+++ b/packages/client/src/api/test-run.api.ts
@@ -1,11 +1,24 @@
 import {
   Project,
+  S3Location,
   TestCase,
   TestCaseResult,
   TestRunStatus,
 } from "@alwaysmeticulous/api";
 import { AxiosError, AxiosInstance } from "axios";
 import { maybeEnrichAxiosError } from "../errors";
+export interface TestRunDataLocations {
+  coverage: S3Location;
+  coverageStats: S3Location;
+  coveragePr: S3Location;
+  coverageStatsPr: S3Location;
+  coverageReplaysByFile?: S3Location;
+  coverageReplaysByFileUnmapped?: S3Location;
+  coverageScreenshotReplaysByFile?: S3Location;
+  coverageScreenshotReplaysByFileUnmapped?: S3Location;
+  coverageByReplayPr?: S3Location;
+  relevantReplayContexts: S3Location;
+}
 
 export interface TestRun {
   id: string;
@@ -68,6 +81,16 @@ export const getTestRun: (options: {
 }) => Promise<TestRun> = async ({ client, testRunId }) => {
   const { data } = await client.get<unknown, { data: TestRun }>(
     `test-runs/${testRunId}`
+  );
+  return data;
+};
+
+export const getTestRunData: (options: {
+  client: AxiosInstance;
+  testRunId: string;
+}) => Promise<TestRunDataLocations> = async ({ client, testRunId }) => {
+  const { data } = await client.get<unknown, { data: TestRunDataLocations }>(
+    `test-runs/${testRunId}/data`
   );
   return data;
 };

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./api/github-cloud-replay.api";
 export { getProject, getRepoUrl } from "./api/project.api";
+export type { TestRunDataLocations } from "./api/test-run.api";
 export {
   getReplay,
   getReplayDownloadUrl,
@@ -15,6 +16,7 @@ export {
   ExecuteSecureTunnelTestRunOptions,
   executeSecureTunnelTestRun,
   getTestRun,
+  getTestRunData,
   GetLatestTestRunOptions,
   getLatestTestRunResults,
   TestRun,

--- a/packages/downloading-helpers/src/file-downloads/test-runs.ts
+++ b/packages/downloading-helpers/src/file-downloads/test-runs.ts
@@ -1,0 +1,147 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { join } from "path";
+import { getTestRunData, TestRunDataLocations } from "@alwaysmeticulous/client";
+import {
+  getMeticulousLocalDataDir,
+  METICULOUS_LOGGER_NAME,
+} from "@alwaysmeticulous/common";
+import { AxiosInstance } from "axios";
+import log from "loglevel";
+import { downloadAndExtractFile } from "./download-file";
+import {
+  fileExists,
+  sanitizeFilename,
+  waitToAcquireLockOnDirectory,
+} from "./local-data.utils";
+
+/**
+ * Download scope for test run data:
+ * - `everything`: Download all available test run data
+ * - `coverageByReplayPrOnly`: Download only coverageByReplayPr
+ */
+export const DOWNLOAD_SCOPES = [
+  "everything",
+  "coverage-by-replay-pr-only",
+] as const;
+
+export type TestRunDownloadScope = (typeof DOWNLOAD_SCOPES)[number];
+
+const DOWNLOAD_SCOPE_TO_FILES_TO_DOWNLOAD: Record<
+  TestRunDownloadScope,
+  RegExp
+> = {
+  everything: /.*/,
+  "coverage-by-replay-pr-only": /^coverageByReplayPr/,
+};
+
+const shouldDownloadFile = (
+  fileType: string,
+  downloadScope: TestRunDownloadScope
+): boolean => {
+  return DOWNLOAD_SCOPE_TO_FILES_TO_DOWNLOAD[downloadScope].test(fileType);
+};
+
+const TEST_RUN_PREVIOUSLY_DOWNLOADED_FILE_NAME = "previously-downloaded.txt";
+
+export const getOrFetchTestRunData = async (
+  client: AxiosInstance,
+  testRunId: string,
+  downloadScope: TestRunDownloadScope = "everything"
+): Promise<{ fileName: string; data: TestRunDataLocations }> => {
+  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+
+  const testRunDir = join(
+    getMeticulousLocalDataDir(),
+    "test-runs",
+    sanitizeFilename(testRunId)
+  );
+
+  await mkdir(testRunDir, { recursive: true });
+  const releaseLock = await waitToAcquireLockOnDirectory(testRunDir);
+
+  try {
+    const previouslyDownloadedFile = join(
+      testRunDir,
+      TEST_RUN_PREVIOUSLY_DOWNLOADED_FILE_NAME
+    );
+
+    // Check what we have already downloaded. This is passed to the downloading function
+    // to avoid downloading the same thing twice. This is particularly important because
+    // a concurrent process might be using the previously downloaded data, so we don't
+    // want to overwrite it while it's being read.
+    let previouslyDownloadedScope: TestRunDownloadScope | undefined = undefined;
+    if (await fileExists(previouslyDownloadedFile)) {
+      const fileContents = await readFile(previouslyDownloadedFile, "utf-8");
+      if (DOWNLOAD_SCOPES.includes(fileContents as TestRunDownloadScope)) {
+        previouslyDownloadedScope = fileContents as TestRunDownloadScope;
+        if (
+          previouslyDownloadedScope === downloadScope ||
+          previouslyDownloadedScope === "everything"
+        ) {
+          logger.debug(`Test run data already downloaded at ${testRunDir}`);
+          const testRunData = await getTestRunData({ client, testRunId });
+          return { fileName: testRunDir, data: testRunData };
+        } else {
+          // Instead of trying to reason about how to combine the two scopes, let's bump
+          // to downloading everything which is guaranteed to be a superset.
+          logger.debug(
+            `Test run data is partially downloaded at ${testRunDir}, will now download everything`
+          );
+          downloadScope = "everything";
+        }
+      } else {
+        throw new Error(
+          `Error: Unknown previously download scope "${fileContents}"`
+        );
+      }
+    }
+
+    logger.info("Fetching test run data locations...");
+    const testRunData = await getTestRunData({ client, testRunId });
+
+    if (!testRunData) {
+      logger.error(
+        "Error: Could not retrieve test run data. This may be an invalid test run"
+      );
+      process.exit(1);
+    }
+
+    logger.info("Downloading test run data...");
+    const downloadPromises = Object.entries(testRunData)
+      .filter(([fileType]) => shouldDownloadFile(fileType, downloadScope))
+      .map(([fileType, location]) => {
+        if (location == null) {
+          return null;
+        }
+        const url = location.signedUrl;
+        const filePath = location.filePath;
+        if (typeof url !== "string" || typeof filePath !== "string") {
+          return null;
+        }
+
+        return async () => {
+          logger.info(`Downloading and extracting ${fileType}...`);
+          await downloadAndExtractFile(
+            location.signedUrl,
+            filePath,
+            testRunDir
+          );
+          if (filePath.endsWith(".json")) {
+            const fileContents = await readFile(filePath, "utf-8");
+            const json = JSON.parse(fileContents);
+            await writeFile(filePath, JSON.stringify(json, null, 2), "utf-8");
+          }
+        };
+      })
+      .filter((promise): promise is () => Promise<void> => promise !== null);
+
+    await Promise.all(downloadPromises.map((fn) => fn()));
+
+    await writeFile(previouslyDownloadedFile, downloadScope, "utf-8");
+    logger.info("Test run data downloaded.");
+
+    return { fileName: testRunDir, data: testRunData };
+  } finally {
+    await releaseLock();
+  }
+};

--- a/packages/downloading-helpers/src/index.ts
+++ b/packages/downloading-helpers/src/index.ts
@@ -8,6 +8,11 @@ export {
   getOrFetchRecordedSession,
   getOrFetchRecordedSessionData,
 } from "./file-downloads/sessions";
+export {
+  getOrFetchTestRunData,
+  type TestRunDownloadScope,
+  DOWNLOAD_SCOPES as TEST_RUN_DOWNLOAD_SCOPES,
+} from "./file-downloads/test-runs";
 export { fetchAsset, checkIfAssetsOutdated } from "./scripts/replay-assets";
 export {
   downloadFile,


### PR DESCRIPTION
This adds a command to download test run data from S3, similarly to how we are already doing for simulations.