### PR TITLE
Fix getIsLocked

### DIFF
--- a/packages/client/src/api/deployment-lock.api.ts
+++ b/packages/client/src/api/deployment-lock.api.ts
@@ -11,12 +11,11 @@ export const getIsLocked = async ({
   deploymentId,
 }: GetIsLockedOptions): Promise<boolean> => {
   const { data } = await client
-    .get<unknown, { data: boolean }>("deployment-locks/is-locked", {
+    .get<unknown, { data: string }>("deployment-locks/is-locked", {
       params: { deploymentId },
     })
     .catch((error) => {
       throw maybeEnrichFetchError(error);
     });
-
-  return data;
+  return data === "true";
 };


### PR DESCRIPTION
`axios` was doing some magic here to turn the strings `"true"` and `"false"` into `boolean`s but `node-fetch` does _not_ do this so currently in the false case we get back the string `"false"` which if used in an `if` is truthy.