### PR TITLE
Support PUT requests too in MeticulousClient

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -174,6 +174,18 @@ export const createClient: (options: ClientOptions) => MeticulousClient = ({
       }
       return makeRequestWithToken<T>(url, requestOptions) as Promise<R>;
     },
+
+    put: <T = any, R = Response<T>, D = any>(
+      url: string,
+      data?: D,
+    ): Promise<R> => {
+      const body = data !== undefined ? JSON.stringify(data) : undefined;
+      const requestOptions: RequestInit = { method: "PUT" };
+      if (body !== undefined) {
+        requestOptions.body = body;
+      }
+      return makeRequestWithToken<T>(url, requestOptions) as Promise<R>;
+    },
   };
 };
 

--- a/packages/client/src/types/client.types.ts
+++ b/packages/client/src/types/client.types.ts
@@ -20,4 +20,6 @@ export interface MeticulousClient {
   ): Promise<R>;
 
   post<T = any, R = Response<any>>(url: string, data?: T): Promise<R>;
+
+  put<T = any, R = Response<any>>(url: string, data?: T): Promise<R>;
 }


### PR DESCRIPTION
GET and POST is all we use in the two public repos, but the internal monorepo also some has some instances of PUT. So we need to support that in order to bump the SDK internally.