### PR TITLE
Pass through config in PUT and POST

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -166,25 +166,27 @@ export const createClient: (options: ClientOptions) => MeticulousClient = ({
     post: <T = any, R = Response<T>, D = any>(
       url: string,
       data?: D,
+      config?: RequestConfig<any>,
     ): Promise<R> => {
       const body = data !== undefined ? JSON.stringify(data) : undefined;
       const requestOptions: RequestInit = { method: "POST" };
       if (body !== undefined) {
         requestOptions.body = body;
       }
-      return makeRequestWithToken<T>(url, requestOptions) as Promise<R>;
+      return makeRequestWithToken<T>(url, requestOptions, config) as Promise<R>;
     },
 
     put: <T = any, R = Response<T>, D = any>(
       url: string,
       data?: D,
+      config?: RequestConfig<any>,
     ): Promise<R> => {
       const body = data !== undefined ? JSON.stringify(data) : undefined;
       const requestOptions: RequestInit = { method: "PUT" };
       if (body !== undefined) {
         requestOptions.body = body;
       }
-      return makeRequestWithToken<T>(url, requestOptions) as Promise<R>;
+      return makeRequestWithToken<T>(url, requestOptions, config) as Promise<R>;
     },
   };
 };

--- a/packages/client/src/types/client.types.ts
+++ b/packages/client/src/types/client.types.ts
@@ -19,7 +19,15 @@ export interface MeticulousClient {
     config?: RequestConfig<any>,
   ): Promise<R>;
 
-  post<T = any, R = Response<any>>(url: string, data?: T): Promise<R>;
+  post<T = any, R = Response<any>>(
+    url: string,
+    data?: T,
+    config?: RequestConfig<any>,
+  ): Promise<R>;
 
-  put<T = any, R = Response<any>>(url: string, data?: T): Promise<R>;
+  put<T = any, R = Response<any>>(
+    url: string,
+    data?: T,
+    config?: RequestConfig<any>,
+  ): Promise<R>;
 }


### PR DESCRIPTION
We were already doing this for GET, but the internal repo needs this for the other methods too.