### PR TITLE
Log when event loop has significant delay on tunnel client

### DIFF
--- a/packages/remote-replay-launcher/src/resource-tracker.ts
+++ b/packages/remote-replay-launcher/src/resource-tracker.ts
@@ -4,9 +4,12 @@ import * as Sentry from "@sentry/node";
 import { Logger } from "loglevel";
 import { mem } from "systeminformation";
 
+const EVENT_LOOP_DELAY_WARNING_THRESHOLD_MS = 100;
+
 export class ResourceTracker {
   private previousCpuUsage: { active: number; idle: number };
-  private haveLoggedWarning: boolean = false;
+  private haveLoggedResourceWarning: boolean = false;
+  private haveLoggedEventLoopWarning: boolean = false;
   private readonly logger: Logger;
   private readonly testRun: TestRun;
 
@@ -17,7 +20,14 @@ export class ResourceTracker {
   }
 
   public async checkUsage() {
-    if (this.haveLoggedWarning) {
+    await Promise.all([
+      this.maybeLogEventLoopWarning(),
+      this.maybeLogResourceWarning(),
+    ]);
+  }
+
+  private async maybeLogResourceWarning() {
+    if (this.haveLoggedResourceWarning) {
       // We only want to log a warning once, so we can stop tracking usage once we've warned.
       return;
     }
@@ -38,7 +48,7 @@ export class ResourceTracker {
           Detected that there may be resource contention on the machine (${cpuUsagePercentage.toFixed()}% CPU usage, ${memoryUsagePercentage.toFixed()}% memory usage).
           Heavy load may result in network requests not being processed and lead to flaky tests.
           We recommend running tests on a machine with more resources.
-          `
+          `,
       );
       Sentry.captureMessage("Detected resource contention on tunnel machine", {
         level: "warning",
@@ -49,7 +59,7 @@ export class ResourceTracker {
           projectId: this.testRun.project.id,
         },
       });
-      this.haveLoggedWarning = true;
+      this.haveLoggedResourceWarning = true;
     }
 
     this.previousCpuUsage = currentCpuUsage;
@@ -61,7 +71,40 @@ export class ResourceTracker {
         active: acc.active + cpu.times.user + cpu.times.nice + cpu.times.sys,
         idle: acc.idle + cpu.times.idle,
       }),
-      { active: 0, idle: 0 }
+      { active: 0, idle: 0 },
     );
+  }
+
+  private async maybeLogEventLoopWarning() {
+    if (this.haveLoggedEventLoopWarning) {
+      // We only want to log a warning once, so we can stop measuring after that.
+      return;
+    }
+
+    const startTime = performance.now();
+    const delay = await new Promise<number>((resolve) => {
+      setTimeout(() => {
+        const endTime = performance.now();
+        resolve(endTime - startTime);
+      }, 0);
+    });
+
+    if (delay > EVENT_LOOP_DELAY_WARNING_THRESHOLD_MS) {
+      this.logger.warn(
+        `
+          Detected event loop delay of ${delay.toFixed(0)}ms.
+          This may indicate that the Node process is overloaded, which could affect test reliability.
+          `,
+      );
+      Sentry.captureMessage("Detected event loop delay on tunnel machine", {
+        level: "warning",
+        extra: {
+          eventLoopDelay: delay,
+          testRunId: this.testRun.id,
+          projectId: this.testRun.project.id,
+        },
+      });
+      this.haveLoggedEventLoopWarning = true;
+    }
   }
 }


### PR DESCRIPTION
This will let us track in addition to whether the resources on the machine are exhausted, whether Node itself is struggling.