### PR TITLE
Add new session relevance for A/B testing

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -7,6 +7,7 @@ export enum SessionRelevance {
   IsPrAuthor = "is-pr-author", // Recent session recorded from the author of the PR. This is used to tag sessions before they are executed.
   IsPrAuthorRelevant = "is-pr-author-relevant", // Recent session recorded from the author of the PR, but relevant to the PR
   IsPrAuthorNotRelevant = "is-pr-author-not-relevant", // Recent session recorded from the author of the PR, but not relevant to the PR
+  IsRelevantBeta = "is-relevant-beta", // Similar to IsRelevant, but used by beta relevance algorithm for A/B testing and internal evaluation
   IsRelevant = "is-relevant",
   NotRelevant = "not-relevant",
   MaybeRelevant = "maybe-relevant",


### PR DESCRIPTION
This is useful to iterate between different session relevance algorithms, and to do A/B testing / shadowing