### PR TITLE
Implement multi-threaded tunnel client

### DIFF
--- a/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
+++ b/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
@@ -253,7 +253,8 @@ export const runAllTestsInCloudCommand = buildCommand("run-all-tests-in-cloud")
     },
     http2Connections: {
       number: true,
-      description: "Number of HTTP2 connections to establish for multiplexing",
+      description:
+        "Number of HTTP2 connections to establish for multiplexing (defaults to number of CPU cores)",
     },
   } as const)
   .handler(handler);

--- a/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
+++ b/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
@@ -176,7 +176,8 @@ export const startLocalTunnelCommand = buildCommand("start-local-tunnel")
       default: false,
     },
     http2Connections: {
-      describe: "Number of HTTP2 connections to establish for multiplexing",
+      describe:
+        "Number of HTTP2 connections to establish for multiplexing (defaults to number of CPU cores)",
       number: true,
     },
   })

--- a/packages/tunnel-client/package.json
+++ b/packages/tunnel-client/package.json
@@ -18,6 +18,7 @@
     "depcheck": "depcheck --ignore-patterns=dist"
   },
   "dependencies": {
+    "@alwaysmeticulous/common": "^2.229.0",
     "agentkeepalive": "^4.5.0",
     "cacheable-lookup": "^6.1.0",
     "loglevel": "^1.8.0",

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -1,2 +1,4 @@
 export { localtunnel } from "./localtunnel";
 export { LocalTunnelOptions, IncomingRequestEvent } from "./types";
+export { TunnelHTTP2Cluster } from "./lib/tunnel-http2-cluster";
+export { openSocket } from "./utils/open-socket";

--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -5,9 +5,9 @@ import path from "path";
 import { Logger } from "loglevel";
 import fetch from "node-fetch";
 import TypedEmitter from "typed-emitter";
+import { WorkerInitOptions } from "../tunnel-worker.entrypoint";
 import { IncomingRequestEvent, LocalTunnelOptions, TunnelInfo } from "../types";
 import { getProxyAgent } from "../utils/get-proxy-agent";
-import { WorkerInitOptions } from "./worker-entrypoint";
 
 const DEFAULT_HOST = "https://tunnels.meticulous.ai";
 
@@ -240,12 +240,14 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
     );
 
     const numWorkers = http2Connections || DEFAULT_HTTP2_NUMBER_OF_CONNECTIONS;
-    const workerPath = path.resolve(__dirname, "./worker-entrypoint.js");
+    const workerPath = path.resolve(
+      __dirname,
+      "../tunnel-worker.entrypoint.js",
+    );
 
     cluster.setupPrimary({
       exec: workerPath,
       silent: false,
-      execArgv: ["--max-old-space-size=2048"],
     });
 
     for (let i = 1; i <= numWorkers; i++) {
@@ -267,9 +269,7 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
         enableDnsCache,
       };
 
-      const worker = cluster.fork({
-        WORKER_OPTIONS: JSON.stringify(workerOptions),
-      });
+      const worker = cluster.fork();
 
       worker.on("exit", (code) => {
         if (code !== 0 && !this.closed) {
@@ -279,6 +279,11 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
             new Error(`Worker ${i} stopped with exit code ${code}`),
           );
         }
+      });
+
+      worker.send({
+        type: "init",
+        options: workerOptions,
       });
 
       this.workers.push(worker);

--- a/packages/tunnel-client/src/lib/worker-entrypoint.ts
+++ b/packages/tunnel-client/src/lib/worker-entrypoint.ts
@@ -1,0 +1,90 @@
+import cluster from "node:cluster";
+import { initLogger } from "@alwaysmeticulous/common";
+import { openSocket } from "../utils/open-socket";
+import { TunnelHTTP2Cluster } from "./tunnel-http2-cluster";
+
+export interface WorkerInitOptions {
+  workerId: number;
+  useTls: boolean;
+  remoteHost: string;
+  multiplexingRemotePort: number;
+  tunnelPassphrase: string;
+  localHost: string;
+  localPort: number;
+  localHttps: boolean;
+  allowInvalidCert: boolean;
+  proxyAllUrls: boolean;
+  rewriteHostnameToAppUrl: boolean;
+  enableDnsCache: boolean;
+  localCert?: string;
+  localKey?: string;
+  localCa?: string;
+}
+
+const startClusterWorker = async () => {
+  const logger = initLogger();
+
+  if (!cluster.isWorker) {
+    throw new Error("This code must be run as a cluster worker");
+  }
+
+  if (!process.env.WORKER_OPTIONS) {
+    throw new Error(
+      "Worker options must be provided via WORKER_OPTIONS environment variable",
+    );
+  }
+
+  const options = JSON.parse(process.env.WORKER_OPTIONS) as WorkerInitOptions;
+
+  try {
+    const socket = await openSocket({
+      useTls: options.useTls,
+      remoteHost: options.remoteHost,
+      multiplexingRemotePort: options.multiplexingRemotePort,
+      tunnelPassphrase: options.tunnelPassphrase,
+      sendAuthOkAck: true,
+      logger,
+      onError: (err) => {
+        logger.error("Socket error:", err);
+        process.send?.({ type: "error", data: err.message });
+        process.exit(1);
+      },
+      onClose: () => {
+        logger.warn("Remote connection was closed unexpectedly");
+        process.send?.({
+          type: "error",
+          data: "Remote connection was closed unexpectedly",
+        });
+        process.exit(1);
+      },
+    });
+
+    const tunnelCluster = new TunnelHTTP2Cluster({
+      logger,
+      localHost: options.localHost,
+      localPort: options.localPort,
+      localHttps: options.localHttps,
+      allowInvalidCert: options.allowInvalidCert,
+      proxyAllUrls: options.proxyAllUrls,
+      rewriteHostnameToAppUrl: options.rewriteHostnameToAppUrl,
+      enableDnsCache: options.enableDnsCache,
+      localCert: options.localCert,
+      localKey: options.localKey,
+      localCa: options.localCa,
+      sockets: [socket],
+      getHost: () => options.remoteHost,
+    });
+    tunnelCluster.startListening();
+    logger.info(
+      `Cluster worker ${options.workerId} is now listening for requests`,
+    );
+  } catch (error) {
+    logger.error(`Cluster worker ${options.workerId} failed to start:`, error);
+    process.exit(1);
+  }
+};
+
+startClusterWorker().catch((error) => {
+  console.error("Failed to start cluster worker:", error);
+  process.exit(1);
+});

--- a/packages/tunnel-client/src/utils/open-socket.ts
+++ b/packages/tunnel-client/src/utils/open-socket.ts
@@ -1,0 +1,171 @@
+import net from "net";
+import tls from "tls";
+import { Logger } from "loglevel";
+import { TunnelInfo } from "../types";
+
+interface OpenSocketOptions
+  extends Pick<
+    TunnelInfo,
+    "useTls" | "remoteHost" | "multiplexingRemotePort" | "tunnelPassphrase"
+  > {
+  sendAuthOkAck?: boolean;
+  logger: Logger;
+  onError?: (error: Error) => void;
+  onClose?: () => void;
+}
+
+const createProxyConnection = async (
+  proxyUrl: string,
+  targetHost: string,
+  targetPort: number,
+  useTls: boolean,
+): Promise<net.Socket> => {
+  const url = new URL(proxyUrl);
+  if (url.protocol === "https:") {
+    throw new Error("HTTPS proxy is not supported!");
+  }
+  const proxyHost = url.hostname;
+  const proxyPort = parseInt(url.port) || 80;
+
+  const proxySocket = net.connect({
+    host: proxyHost,
+    port: proxyPort,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    proxySocket.once("connect", () => {
+      const connectRequest = [
+        `CONNECT ${targetHost}:${targetPort} HTTP/1.1`,
+        `Host: ${targetHost}:${targetPort}`,
+        `Proxy-Connection: keep-alive`,
+        "",
+        "",
+      ].join("\r\n");
+
+      proxySocket.write(connectRequest);
+
+      const onData = (data: Buffer) => {
+        const response = data.toString();
+        if (
+          response.includes("200 Connection established") ||
+          response.includes("200 OK")
+        ) {
+          proxySocket.removeListener("data", onData);
+          resolve();
+        } else {
+          proxySocket.removeListener("data", onData);
+          reject(
+            new Error(`Proxy CONNECT failed: ${response.split("\r\n")[0]}`),
+          );
+        }
+      };
+
+      proxySocket.on("data", onData);
+    });
+
+    proxySocket.once("error", reject);
+  });
+
+  if (useTls) {
+    return tls.connect({
+      socket: proxySocket,
+      servername: targetHost,
+      rejectUnauthorized: true,
+      ALPNProtocols: ["meticulous-tunnel"],
+    });
+  }
+
+  return proxySocket;
+};
+
+export const openSocket = async ({
+  useTls,
+  remoteHost,
+  multiplexingRemotePort,
+  tunnelPassphrase,
+  sendAuthOkAck,
+  logger,
+  onError,
+  onClose,
+}: OpenSocketOptions): Promise<net.Socket | tls.TLSSocket> => {
+  let socket: net.Socket | tls.TLSSocket;
+
+  const proxyUrl = process.env.HTTPS_PROXY;
+  if (proxyUrl) {
+    socket = await createProxyConnection(
+      proxyUrl,
+      remoteHost,
+      multiplexingRemotePort,
+      useTls,
+    );
+  } else if (useTls) {
+    socket = tls.connect({
+      host: remoteHost,
+      port: multiplexingRemotePort,
+      rejectUnauthorized: true,
+      ALPNProtocols: ["meticulous-tunnel"],
+    });
+  } else {
+    socket = net.connect({
+      host: remoteHost,
+      port: multiplexingRemotePort,
+    });
+  }
+
+  socket.setNoDelay(true);
+
+  socket.on("error", (err: NodeJS.ErrnoException) => {
+    logger.debug("got remote connection error", err.message);
+
+    if (err.code === "ECONNREFUSED") {
+      const connectionError = new Error(
+        `connection refused: ${remoteHost}:${multiplexingRemotePort} (check your firewall settings)`,
+      );
+      if (onError) {
+        onError(connectionError);
+      }
+    }
+
+    socket.end();
+  });
+
+  socket.on("close", () => {
+    if (onClose) {
+      onClose();
+    }
+  });
+
+  const connectEvent = useTls ? "secureConnect" : "connect";
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once(connectEvent, () => {
+      socket.write(`AUTH ${tunnelPassphrase}`);
+
+      socket.once("data", (data) => {
+        if (data.toString() != "AUTH OK") {
+          const authError = new Error("Tunnel auth failed");
+          if (onError) {
+            onError(authError);
+          }
+          socket.end();
+          reject(authError);
+          return;
+        }
+
+        socket.pause();
+
+        if (sendAuthOkAck) {
+          socket.write("AUTH OK ACK", () => {
+            resolve();
+          });
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    socket.once("error", reject);
+  });
+
+  return socket;
+};


### PR DESCRIPTION
This changes the tunnel client to run multi-threaded. This seems to improve performance, see some results of a local load test below (left=before, right=after). In particular, the rate of errors at this high load is reduced by over an order of magnitude (from 24.2% to 1.5%).

<img width="1883" height="911" alt="Screenshot 2025-09-01 at 16 49 13" src="https://github.com/user-attachments/assets/059e67ee-5602-418c-b3f3-3d8230b6d0fc" />
