### PR TITLE
Revert "Add missing-baseline session relevance (#926)"

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -7,7 +7,6 @@ export enum SessionRelevance {
   IsPrAuthor = "is-pr-author", // Recent session recorded from the author of the PR. This is used to tag sessions before they are executed.
   IsPrAuthorRelevant = "is-pr-author-relevant", // Recent session recorded from the author of the PR, but relevant to the PR
   IsPrAuthorNotRelevant = "is-pr-author-not-relevant", // Recent session recorded from the author of the PR, but not relevant to the PR
-  MissingBaseline = "missing-baseline", // Selected session which lacks a baseline replay for comparison
   IsRelevantBeta = "is-relevant-beta", // Similar to IsRelevant, but used by beta relevance algorithm for A/B testing and internal evaluation
   IsRelevant = "is-relevant",
   NotRelevant = "not-relevant",


### PR DESCRIPTION
This reverts commit 5c4f729a0c52b9f0931f33e73f3caa947808ac39. In fact, we decided to not run these sessions at all, so we don't need to track these explicitly. 