### PR TITLE
Search for worker JS file in multiple directories

### DIFF
--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -1,12 +1,12 @@
 import { EventEmitter } from "events";
 import cluster, { Worker } from "node:cluster";
 import { cpus } from "node:os";
-import path from "path";
 import { Logger } from "loglevel";
 import fetch from "node-fetch";
 import TypedEmitter from "typed-emitter";
 import { WorkerInitOptions } from "../tunnel-worker.entrypoint";
 import { IncomingRequestEvent, LocalTunnelOptions, TunnelInfo } from "../types";
+import { findWorkerFile } from "../utils/find-worker-file";
 import { getProxyAgent } from "../utils/get-proxy-agent";
 
 const DEFAULT_HOST = "https://tunnels.meticulous.ai";
@@ -240,13 +240,9 @@ export class Tunnel extends (EventEmitter as new () => TypedEmitter<TunnelEvents
     );
 
     const numWorkers = http2Connections || DEFAULT_HTTP2_NUMBER_OF_CONNECTIONS;
-    const workerPath = path.resolve(
-      __dirname,
-      "../tunnel-worker.entrypoint.js",
-    );
 
     cluster.setupPrimary({
-      exec: workerPath,
+      exec: findWorkerFile(__dirname),
       silent: false,
     });
 

--- a/packages/tunnel-client/src/utils/find-worker-file.ts
+++ b/packages/tunnel-client/src/utils/find-worker-file.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+const WORKER_FILE_NAME = "tunnel-worker.entrypoint.js";
+const MAX_SEARCH_DEPTH = 2;
+
+export const findWorkerFile = (startDir: string): string => {
+  const workerFileName = WORKER_FILE_NAME;
+
+  for (let i = 0; i <= MAX_SEARCH_DEPTH; i++) {
+    const searchDir =
+      i === 0 ? startDir : path.resolve(startDir, "../".repeat(i));
+    const workerPath = path.join(searchDir, workerFileName);
+
+    if (fs.existsSync(workerPath)) {
+      return workerPath;
+    }
+  }
+
+  throw new Error(
+    `Tunnel worker file ${workerFileName} not found in ${startDir}`,
+  );
+};


### PR DESCRIPTION
This is needed to ship this to the GitHub Action because there all the build outputs are in the `out/` directory so we don't have the nesting that we do here.