### PR TITLE
Bound number of connections to 16

### DIFF
--- a/packages/tunnel-client/src/lib/tunnel.ts
+++ b/packages/tunnel-client/src/lib/tunnel.ts
@@ -13,9 +13,9 @@ const DEFAULT_HOST = "https://tunnels.meticulous.ai";
 
 /**
  * Default number of connections to establish for HTTP2 multiplexing.
- * Uses the number of CPU cores available.
+ * Uses the number of CPU cores available, up to a maximum of 16.
  */
-const DEFAULT_HTTP2_NUMBER_OF_CONNECTIONS = cpus().length;
+const DEFAULT_HTTP2_NUMBER_OF_CONNECTIONS = Math.min(cpus().length, 16);
 
 interface CreateTunnelResponse {
   id: string;


### PR DESCRIPTION
We have a customer with a _lot_ of cores opening over 100 connections/worker threads which seems excessive. Let's bound this to 16.