### PR TITLE
Add env variable to allow timestamping of logs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,6 @@
     "chalk": "^4.1.2",
     "ci-info": "^4.0.0",
     "cli-progress": "^3.12.0",
-    "loglevel": "^1.8.0",
     "ora": "^5.4.1",
     "puppeteer": "24.14.0",
     "yargs": "^17.5.1"

--- a/packages/cli/src/commands/download-replay/download-replay.command.ts
+++ b/packages/cli/src/commands/download-replay/download-replay.command.ts
@@ -2,12 +2,11 @@ import { access, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { ConsoleMessageWithStackTracePointer } from "@alwaysmeticulous/api";
 import { createClient } from "@alwaysmeticulous/client";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { initLogger } from "@alwaysmeticulous/common";
 import {
   getOrFetchReplay,
   getOrFetchReplayArchive,
 } from "@alwaysmeticulous/downloading-helpers";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 
 interface Options {
@@ -19,19 +18,19 @@ const handler: (options: Options) => Promise<void> = async ({
   apiToken,
   replayId,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const client = createClient({ apiToken });
 
   const { fileName: replayMetadataFileName } = await getOrFetchReplay(
     client,
-    replayId
+    replayId,
   );
   logger.info(`Downloaded replay metadata to: ${replayMetadataFileName}`);
   const { fileName: replayFolderFilePath } = await getOrFetchReplayArchive(
     client,
     replayId,
     "everything",
-    true
+    true,
   );
 
   // Generate logs.concise.txt and logs.determinstic.txt files
@@ -60,11 +59,11 @@ const handler: (options: Options) => Promise<void> = async ({
           } else {
             return `[trace-id: ${log.stackTraceId}] [virtual: ${virtualTime}ms, real: ${log.realTime}ms]${commonPostfix}`;
           }
-        }
+        },
       );
       await writeFile(
         join(replayFolderFilePath, "logs.concise.txt"),
-        conciseLogs.join("\n")
+        conciseLogs.join("\n"),
       );
 
       // Useful for diffing one set of logs against another (excludes the real timestamps, which are non-deterministic)
@@ -99,11 +98,11 @@ const handler: (options: Options) => Promise<void> = async ({
           } else {
             return [`[virtual: ${virtualTime}ms]${commonPostfix}`];
           }
-        }
+        },
       );
       await writeFile(
         join(replayFolderFilePath, "logs.deterministic.txt"),
-        deterministicLogs.join("\n")
+        deterministicLogs.join("\n"),
       );
     } catch (err) {
       logger.error("Error creating concise version of logs file", err);

--- a/packages/cli/src/commands/download-session/download-session.command.ts
+++ b/packages/cli/src/commands/download-session/download-session.command.ts
@@ -1,10 +1,9 @@
 import { createClient } from "@alwaysmeticulous/client";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { initLogger } from "@alwaysmeticulous/common";
 import {
   getOrFetchRecordedSession,
   getOrFetchRecordedSessionData,
 } from "@alwaysmeticulous/downloading-helpers";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 
 interface Options {
@@ -16,7 +15,7 @@ const handler: (options: Options) => Promise<void> = async ({
   apiToken,
   sessionId,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const client = createClient({ apiToken });
 
   const { fileName: sessionMetadataFileName } = await getOrFetchRecordedSession(

--- a/packages/cli/src/commands/download-test-run/download-test-run.command.ts
+++ b/packages/cli/src/commands/download-test-run/download-test-run.command.ts
@@ -1,7 +1,6 @@
 import { createClient } from "@alwaysmeticulous/client";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { initLogger } from "@alwaysmeticulous/common";
 import { getOrFetchTestRunData } from "@alwaysmeticulous/downloading-helpers";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 
 interface Options {
@@ -13,7 +12,7 @@ const handler: (options: Options) => Promise<void> = async ({
   apiToken,
   testRunId,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const client = createClient({ apiToken });
 
   const { fileName: testRunDir } = await getOrFetchTestRunData(

--- a/packages/cli/src/commands/record-login/record-login.command.ts
+++ b/packages/cli/src/commands/record-login/record-login.command.ts
@@ -1,8 +1,7 @@
 import { createClient, getProject } from "@alwaysmeticulous/client";
-import { DebugLogger, METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { DebugLogger, initLogger } from "@alwaysmeticulous/common";
 import { fetchAsset } from "@alwaysmeticulous/downloading-helpers";
 import { recordLoginFlowSession } from "@alwaysmeticulous/record";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 import { COMMON_RECORD_OPTIONS } from "../../command-utils/common-options";
 import { RECORDING_SNIPPET_PATH } from "../../utils/constants";
@@ -32,7 +31,7 @@ export const recordLoginFlowCommandHandler: (
   captureHttpOnlyCookies,
   appUrl,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const debugLogger = trace ? await DebugLogger.create() : null;
   debugLogger?.log("Record options:");
   debugLogger?.logObject({

--- a/packages/cli/src/commands/record/record.command.ts
+++ b/packages/cli/src/commands/record/record.command.ts
@@ -9,11 +9,10 @@ import {
   DebugLogger,
   getCommitSha,
   getMeticulousLocalDataDir,
-  METICULOUS_LOGGER_NAME,
+  initLogger,
 } from "@alwaysmeticulous/common";
 import { fetchAsset } from "@alwaysmeticulous/downloading-helpers";
 import { recordSession } from "@alwaysmeticulous/record";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 import {
   COMMON_RECORD_OPTIONS,
@@ -52,7 +51,7 @@ export const recordCommandHandler: (
   appUrl,
   maxPayloadSize,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const debugLogger = trace ? await DebugLogger.create() : null;
   debugLogger?.log("Record options:");
   debugLogger?.logObject({

--- a/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
+++ b/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
@@ -1,11 +1,10 @@
 import { ReplayableEvent } from "@alwaysmeticulous/api";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { initLogger } from "@alwaysmeticulous/common";
 import { startUIServer } from "@alwaysmeticulous/replay-debugger-ui";
 import {
   BeforeUserEventOptions,
   BeforeUserEventResult,
 } from "@alwaysmeticulous/sdk-bundles-api";
-import log from "loglevel";
 import { launch, Browser, Page } from "puppeteer";
 
 export interface ReplayDebuggerState {
@@ -41,7 +40,7 @@ export const openStepThroughDebuggerUI = async ({
   onLogEventTarget,
   replayableEvents,
 }: ReplayDebuggerUIOptions): Promise<StepThroughDebuggerUI> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   // Start the UI server
   const uiServer = await startUIServer();

--- a/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
+++ b/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
@@ -3,7 +3,7 @@ import { IN_PROGRESS_TEST_RUN_STATUS } from "@alwaysmeticulous/client";
 import {
   defer,
   getCommitSha,
-  METICULOUS_LOGGER_NAME,
+  initLogger,
 } from "@alwaysmeticulous/common";
 import {
   executeRemoteTestRun,
@@ -12,7 +12,6 @@ import {
 } from "@alwaysmeticulous/remote-replay-launcher";
 import chalk from "chalk";
 import cliProgress from "cli-progress";
-import log from "loglevel";
 import ora from "ora";
 import { buildCommand } from "../../command-utils/command-builder";
 import { OPTIONS } from "../../command-utils/common-options";
@@ -61,7 +60,7 @@ const handler: (options: Options) => Promise<void> = async ({
   companionAssetsFolder,
   companionAssetsRegex,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const commitSha = await getCommitSha(commitSha_);
 
   if (!!companionAssetsFolder !== !!companionAssetsRegex) {

--- a/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
+++ b/packages/cli/src/commands/run-all-tests/run-all-tests.command.ts
@@ -3,11 +3,10 @@ import {
   ScreenshotDiffOptions,
   StoryboardOptions,
 } from "@alwaysmeticulous/api";
-import { getCommitSha, METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { getCommitSha, initLogger } from "@alwaysmeticulous/common";
 import { executeTestRun } from "@alwaysmeticulous/replay-orchestrator-launcher";
 import { ReplayExecutionOptions } from "@alwaysmeticulous/sdk-bundles-api";
 import chalk from "chalk";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 import {
   COMMON_REPLAY_OPTIONS,
@@ -97,7 +96,7 @@ const handler: (options: Options) => Promise<void> = async ({
     storyboardOptions,
   };
 
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   if (!noParallelize && headless) {
     logger.info(

--- a/packages/cli/src/commands/show-project/show-project.command.ts
+++ b/packages/cli/src/commands/show-project/show-project.command.ts
@@ -1,6 +1,5 @@
 import { getProject, createClient } from "@alwaysmeticulous/client";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import log from "loglevel";
+import { initLogger } from "@alwaysmeticulous/common";
 import { buildCommand } from "../../command-utils/command-builder";
 
 interface Options {
@@ -8,7 +7,7 @@ interface Options {
 }
 
 const handler: (options: Options) => Promise<void> = async ({ apiToken }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const client = createClient({ apiToken });
   const project = await getProject(client);
   if (!project) {

--- a/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
+++ b/packages/cli/src/commands/start-local-tunnel/start-local-tunnel.command.ts
@@ -4,13 +4,12 @@ import { getApiToken } from "@alwaysmeticulous/client";
 import {
   defer,
   IS_METICULOUS_SUPER_USER,
-  METICULOUS_LOGGER_NAME,
+  initLogger,
 } from "@alwaysmeticulous/common";
 import {
   IncomingRequestEvent,
   localtunnel,
 } from "@alwaysmeticulous/tunnels-client";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 
 interface Options {
@@ -32,7 +31,7 @@ interface Options {
 }
 
 const handler = async (argv: Options) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const apiToken = getApiToken(argv.apiToken);
   if (!apiToken) {

--- a/packages/cli/src/commands/upload-assets-and-execute-test-run-in-cloud/upload-assets-and-execute-test-run-in-cloud.command.ts
+++ b/packages/cli/src/commands/upload-assets-and-execute-test-run-in-cloud/upload-assets-and-execute-test-run-in-cloud.command.ts
@@ -1,7 +1,6 @@
 import { AssetUploadMetadata } from "@alwaysmeticulous/api";
-import { getCommitSha, METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { getCommitSha, initLogger } from "@alwaysmeticulous/common";
 import { uploadAssetsAndTriggerTestRun } from "@alwaysmeticulous/remote-replay-launcher";
-import log from "loglevel";
 import { buildCommand } from "../../command-utils/command-builder";
 import { OPTIONS } from "../../command-utils/common-options";
 import {
@@ -24,7 +23,7 @@ const handler: (options: Options) => Promise<void> = async ({
   rewrites,
   waitForBase,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const commitSha = await getCommitSha(commitSha_);
 
   if (!commitSha) {
@@ -56,7 +55,7 @@ const handler: (options: Options) => Promise<void> = async ({
 const parseRewrites = (
   rewritesString?: string,
 ): AssetUploadMetadata["rewrites"] => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   let parsedRewrites: unknown;
   try {
     parsedRewrites = JSON.parse(rewritesString ?? "[]");

--- a/packages/cli/src/utils/sentry.utils.ts
+++ b/packages/cli/src/utils/sentry.utils.ts
@@ -1,8 +1,7 @@
 import { isFetchError } from "@alwaysmeticulous/client";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { initLogger } from "@alwaysmeticulous/common";
 import { SENTRY_FLUSH_TIMEOUT } from "@alwaysmeticulous/sentry";
 import * as Sentry from "@sentry/node";
-import log from "loglevel";
 
 export const setOptions: (options: any) => void = (options) => {
   Sentry.setContext("invoke-options", options);
@@ -41,7 +40,7 @@ export const wrapHandler = function wrapHandler_<T>(
 };
 
 const reportHandlerError: (error: unknown) => Promise<void> = async (error) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   logger.info("");
   if (isFetchError(error)) {
     logger.error(error.message);

--- a/packages/client/src/api-token.utils.ts
+++ b/packages/client/src/api-token.utils.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import log from "loglevel";
+import { initLogger } from "@alwaysmeticulous/common";
 
 const PERSONAL_CONFIG_FILE_PATH = ".meticulous/config.json";
 
@@ -13,7 +12,7 @@ interface PersonalConfig {
 export const getApiToken = (
   apiToken: string | null | undefined
 ): string | null => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   if (apiToken) {
     return apiToken;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,5 +1,5 @@
 import {
-  METICULOUS_LOGGER_NAME,
+  initLogger,
   executeWithRetry,
   defaultShouldRetry,
 } from "@alwaysmeticulous/common";
@@ -124,7 +124,7 @@ export const makeRequest = async <T>(
 export const createClient: (options: ClientOptions) => MeticulousClient = ({
   apiToken: apiToken_,
 }) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const apiToken = getApiToken(apiToken_);
   if (!apiToken) {
     logger.error(

--- a/packages/common/src/commit-sha.utils.ts
+++ b/packages/common/src/commit-sha.utils.ts
@@ -1,6 +1,5 @@
 import { exec } from "child_process";
-import log from "loglevel";
-import { METICULOUS_LOGGER_NAME } from "./logger/console-logger";
+import { initLogger } from "./logger/console-logger";
 
 const getGitRevParseHead: () => Promise<string> = () => {
   return new Promise((resolve, reject) => {
@@ -15,13 +14,13 @@ const getGitRevParseHead: () => Promise<string> = () => {
 };
 
 export const getCommitSha: (
-  commitSha: string | null | undefined
+  commitSha: string | null | undefined,
 ) => Promise<string> = async (commitSha_) => {
   if (commitSha_) {
     return commitSha_;
   }
 
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   try {
     const gitCommitSha = (await getGitRevParseHead()).trim();

--- a/packages/common/src/local-data/local-data.ts
+++ b/packages/common/src/local-data/local-data.ts
@@ -1,11 +1,10 @@
 import { join, normalize } from "path";
-import log from "loglevel";
-import { METICULOUS_LOGGER_NAME } from "../logger/console-logger";
+import { initLogger } from "../logger/console-logger";
 
 let _localDataDir = "";
 
 export const getMeticulousLocalDataDir: () => string = () => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   if (!_localDataDir) {
     setMeticulousLocalDataDir();
     logger.debug(
@@ -20,7 +19,7 @@ export const getMeticulousLocalDataDir: () => string = () => {
 export const setMeticulousLocalDataDir: (
   localDataDir?: string | null | undefined
 ) => void = (localDataDir) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   if (_localDataDir) {
     logger.warn(
       "Meticulous local data dir has already been set by a prior call to setMeticulousLocalDataDir()"

--- a/packages/common/src/logger/console-logger.ts
+++ b/packages/common/src/logger/console-logger.ts
@@ -2,15 +2,31 @@ import log from "loglevel";
 
 export const METICULOUS_LOGGER_NAME = "@alwaysmeticulous";
 
+// loglevel caches the logger instance, so if this method is called multiple times,
+// we should only apply the timestamps the first time to avoid duplicate timestamps.
+let timestampsApplied = false;
+
 export const initLogger: () => log.Logger = () => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   logger.setDefaultLevel(log.levels.INFO);
+
+  if (process.env.METICULOUS_TIMESTAMP_LOGS === "true" && !timestampsApplied) {
+    const originalFactory = logger.methodFactory;
+    logger.methodFactory = (methodName, logLevel, loggerName) => {
+      const rawMethod = originalFactory(methodName, logLevel, loggerName);
+      return (...args) => {
+        const timestamp = new Date().toISOString();
+        rawMethod(`[${timestamp}]`, ...args);
+      };
+    };
+    timestampsApplied = true;
+  }
 
   return logger;
 };
 
 export const setLogLevel: (logLevel: string | undefined) => void = (
-  logLevel
+  logLevel,
 ) => {
   const logger = log.getLogger(METICULOUS_LOGGER_NAME);
   switch ((logLevel || "").toLocaleLowerCase()) {

--- a/packages/downloading-helpers/package.json
+++ b/packages/downloading-helpers/package.json
@@ -26,7 +26,6 @@
     "axios": "^1.7.9",
     "axios-retry": "^4.5.0",
     "extract-zip": "^2.0.1",
-    "loglevel": "^1.8.0",
     "luxon": "^3.2.1",
     "p-limit": "^3.1.0",
     "proper-lockfile": "^4.1.2"

--- a/packages/downloading-helpers/src/file-downloads/local-data.utils.ts
+++ b/packages/downloading-helpers/src/file-downloads/local-data.utils.ts
@@ -1,7 +1,6 @@
 import { access, mkdir, readFile, writeFile } from "fs/promises";
 import { dirname, join } from "path";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import log from "loglevel";
+import { initLogger } from "@alwaysmeticulous/common";
 import { Duration } from "luxon";
 import { lock, LockOptions } from "proper-lockfile";
 
@@ -32,7 +31,7 @@ export const getOrDownloadJsonFile = async <T>({
   downloadJson,
   dataDescription,
 }: LoadOrDownloadJsonFileOptions<T>): Promise<T | null> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   await mkdir(dirname(filePath), { recursive: true });
 

--- a/packages/downloading-helpers/src/file-downloads/sessions.ts
+++ b/packages/downloading-helpers/src/file-downloads/sessions.ts
@@ -7,16 +7,15 @@ import {
 } from "@alwaysmeticulous/client";
 import {
   getMeticulousLocalDataDir,
-  METICULOUS_LOGGER_NAME,
+  initLogger,
 } from "@alwaysmeticulous/common";
-import log from "loglevel";
 import { getOrDownloadJsonFile, sanitizeFilename } from "./local-data.utils";
 
 export const getOrFetchRecordedSession = async (
   client: MeticulousClient,
   sessionId: string,
 ): Promise<{ fileName: string; data: any }> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const sessionFile = join(
     getMeticulousLocalDataDir(),
@@ -43,7 +42,7 @@ export const getOrFetchRecordedSessionData = async (
   client: MeticulousClient,
   sessionId: string,
 ): Promise<{ fileName: string; data: SessionData }> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const sessionFile = join(
     getMeticulousLocalDataDir(),

--- a/packages/downloading-helpers/src/file-downloads/test-runs.ts
+++ b/packages/downloading-helpers/src/file-downloads/test-runs.ts
@@ -7,9 +7,8 @@ import {
 } from "@alwaysmeticulous/client";
 import {
   getMeticulousLocalDataDir,
-  METICULOUS_LOGGER_NAME,
+  initLogger,
 } from "@alwaysmeticulous/common";
-import log from "loglevel";
 import { downloadAndExtractFile } from "./download-file";
 import {
   fileExists,
@@ -51,7 +50,7 @@ export const getOrFetchTestRunData = async (
   testRunId: string,
   downloadScope: TestRunDownloadScope = "everything",
 ): Promise<{ fileName: string; data: TestRunDataLocations }> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const testRunDir = join(
     getMeticulousLocalDataDir(),

--- a/packages/downloading-helpers/src/scripts/replay-assets.ts
+++ b/packages/downloading-helpers/src/scripts/replay-assets.ts
@@ -2,11 +2,10 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { basename, join } from "path";
 import {
   getMeticulousLocalDataDir,
-  METICULOUS_LOGGER_NAME,
+  initLogger,
 } from "@alwaysmeticulous/common";
 import axios from "axios";
 import axiosRetry from "axios-retry";
-import log from "loglevel";
 import {
   getSnippetsBaseUrl,
   isCustomSnippetsBaseUrl,
@@ -117,7 +116,7 @@ const fetchAndCacheFile = async (
   urlToDownloadFrom: string,
   fileNameToDownloadAs: string
 ): Promise<string> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const client = axios.create({ timeout: 60_000 });
   axiosRetry(client, { retries: 3 });
 

--- a/packages/downloading-helpers/src/scripts/replays.ts
+++ b/packages/downloading-helpers/src/scripts/replays.ts
@@ -7,9 +7,8 @@ import {
 } from "@alwaysmeticulous/client";
 import {
   getMeticulousLocalDataDir,
-  METICULOUS_LOGGER_NAME,
+  initLogger,
 } from "@alwaysmeticulous/common";
-import log from "loglevel";
 import pLimit from "p-limit";
 import {
   downloadAndExtractFile,
@@ -45,7 +44,7 @@ export const getOrFetchReplay = async (
   client: MeticulousClient,
   replayId: string,
 ): Promise<{ fileName: string }> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const replayFile = join(getReplayDir(replayId), `${replayId}.json`);
 
@@ -105,7 +104,7 @@ export const getOrFetchReplayArchive = async (
   downloadScope: DownloadScope = "everything",
   formatJsonFiles: boolean = false,
 ): Promise<{ fileName: string }> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const replayDir = getReplayDir(replayId);
   await mkdir(replayDir, { recursive: true });

--- a/packages/record/src/record/record-login-flow.ts
+++ b/packages/record/src/record/record-login-flow.ts
@@ -1,6 +1,6 @@
-import { defer, METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { defer, initLogger } from "@alwaysmeticulous/common";
 import chalk from "chalk";
-import log, { Logger } from "loglevel";
+import { Logger } from "loglevel";
 import { Browser, launch, Page } from "puppeteer";
 import { RecordLoginFlowOptions } from "../types";
 import {
@@ -74,7 +74,7 @@ export const recordLoginFlowSession = async ({
   captureHttpOnlyCookies,
   appUrl,
 }: RecordLoginFlowOptions) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   logger.info("Opening browser...");
 

--- a/packages/record/src/record/record.ts
+++ b/packages/record/src/record/record.ts
@@ -1,7 +1,6 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import log from "loglevel";
+import { initLogger } from "@alwaysmeticulous/common";
 import puppeteer, { Browser, launch, PuppeteerNode } from "puppeteer";
 import { RecordSessionOptions } from "../types";
 import {
@@ -31,7 +30,7 @@ export const recordSession = async ({
   appUrl,
   maxPayloadSize,
 }: RecordSessionOptions) => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   logger.info("Opening browser...");
 

--- a/packages/remote-replay-launcher/src/asset-upload-utils.ts
+++ b/packages/remote-replay-launcher/src/asset-upload-utils.ts
@@ -14,9 +14,8 @@ import {
   getProxyAgent,
 } from "@alwaysmeticulous/client";
 import { triggerRunOnDeployment } from "@alwaysmeticulous/client/dist/api/project-deployments.api";
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { initLogger } from "@alwaysmeticulous/common";
 import archiver from "archiver";
-import log from "loglevel";
 
 const POLL_FOR_BASE_TEST_RUN_INTERVAL_MS = 10_000;
 const POLL_FOR_BASE_TEST_RUN_MAX_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -49,7 +48,7 @@ export const uploadAssets = async ({
   warnIfNoIndexHtml = false,
   createDeployment = true,
 }: UploadAssetsOptions): Promise<UploadAssetsResult> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const apiToken = getApiToken(apiToken_);
   if (!apiToken) {
@@ -206,7 +205,7 @@ const uploadFileToSignedUrl = async (
   expectedFileSize: number,
 ): Promise<void> => {
   const fileStream = createReadStream(filePath);
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const fileStats = await stat(filePath);
   const fileSize = fileStats.size;
   if (fileSize !== expectedFileSize) {

--- a/packages/remote-replay-launcher/src/execute-remote-test-run.ts
+++ b/packages/remote-replay-launcher/src/execute-remote-test-run.ts
@@ -7,9 +7,8 @@ import {
   TestRun,
   getIsLocked,
 } from "@alwaysmeticulous/client";
-import { defer, METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { defer, initLogger } from "@alwaysmeticulous/common";
 import { localtunnel } from "@alwaysmeticulous/tunnels-client";
-import log from "loglevel";
 import { ResourceTracker } from "./resource-tracker";
 import {
   ExecuteRemoteTestRunOptions,
@@ -43,7 +42,7 @@ export const executeRemoteTestRun = async ({
   enableDnsCache = false,
   http2Connections,
 }: ExecuteRemoteTestRunOptions): Promise<ExecuteRemoteTestRunResult> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const apiToken = getApiToken(apiToken_);
   if (!apiToken) {

--- a/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
+++ b/packages/remote-replay-launcher/src/upload-assets-and-trigger-test-run.ts
@@ -1,5 +1,4 @@
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
-import log from "loglevel";
+import { initLogger } from "@alwaysmeticulous/common";
 import { uploadAssets } from "./asset-upload-utils";
 import {
   UploadAssetsAndTriggerTestRunOptions,
@@ -13,7 +12,7 @@ export const uploadAssetsAndTriggerTestRun = async ({
   rewrites,
   waitForBase,
 }: UploadAssetsAndTriggerTestRunOptions): Promise<ExecuteRemoteTestRunResult> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
 
   const result = await uploadAssets({
     apiToken,

--- a/packages/replay-orchestrator-launcher/package.json
+++ b/packages/replay-orchestrator-launcher/package.json
@@ -22,7 +22,6 @@
     "@alwaysmeticulous/common": "^2.235.2",
     "@alwaysmeticulous/downloading-helpers": "^2.236.0",
     "@alwaysmeticulous/sdk-bundles-api": "^2.235.2",
-    "loglevel": "^1.8.0",
     "puppeteer": "24.14.0"
   },
   "author": {

--- a/packages/replay-orchestrator-launcher/src/index.ts
+++ b/packages/replay-orchestrator-launcher/src/index.ts
@@ -1,4 +1,4 @@
-import { METICULOUS_LOGGER_NAME } from "@alwaysmeticulous/common";
+import { initLogger } from "@alwaysmeticulous/common";
 import { fetchAsset } from "@alwaysmeticulous/downloading-helpers";
 import {
   ExecuteScheduledTestRunChunkOptions,
@@ -10,7 +10,6 @@ import {
   ReplayAndStoreResultsOptions,
   ReplayExecution,
 } from "@alwaysmeticulous/sdk-bundles-api";
-import log from "loglevel";
 import { executablePath } from "puppeteer";
 
 export const replayAndStoreResults = async (
@@ -19,7 +18,7 @@ export const replayAndStoreResults = async (
     "logLevel" | "chromeExecutablePath" | "projectId"
   >,
 ): Promise<ReplayExecution> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const bundleLocation = await fetchAsset(
     "replay/v3/replay-and-store-results.bundle.js",
   );
@@ -43,7 +42,7 @@ export const executeScheduledTestRun = async (
     executeScheduledTestRunBundlePath?: string;
   },
 ): Promise<InProgressTestRun> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const bundleLocation =
     options.executeScheduledTestRunBundlePath ??
     (await fetchAsset(EXECUTE_SCHEDULED_TEST_RUN_BUNDLE_PATH));
@@ -64,7 +63,7 @@ export const executeScheduledTestRunChunk = async (
     executeScheduledTestRunBundlePath?: string;
   },
 ): Promise<InProgressTestRunChunk> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const bundleLocation =
     options.executeScheduledTestRunBundlePath ??
     (await fetchAsset(EXECUTE_SCHEDULED_TEST_RUN_BUNDLE_PATH));
@@ -80,7 +79,7 @@ export const executeScheduledTestRunChunk = async (
 export const executeTestRun = async (
   options: Omit<ExecuteTestRunOptions, "logLevel" | "chromeExecutablePath">,
 ): Promise<ExecuteTestRunResult> => {
-  const logger = log.getLogger(METICULOUS_LOGGER_NAME);
+  const logger = initLogger();
   const bundleLocation = await fetchAsset(
     "replay/v3/execute-test-run.bundle.js",
   );


### PR DESCRIPTION
Particularly useful for customers running in custom CI environments where they don't have timestamps. This also makes sure every call uses `initLogger` which previously we were not always doing.