### PR TITLE
Fix replay debugger UI layout and improve text selection

### DIFF
--- a/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
+++ b/packages/cli/src/commands/replay/utils/replay-debugger.ui.ts
@@ -57,10 +57,8 @@ export const openStepThroughDebuggerUI = async ({
 
   // Create page for the debugger UI
   const debuggerPage = (await browser.pages())[0];
-  await debuggerPage.setViewport({
-    width: 0,
-    height: 0,
-  });
+  // Disable viewport emulation to use the actual window size
+  await debuggerPage.setViewport(null);
 
   /**
    * The index the page is in the process of advancing to. Equal to the current index

--- a/packages/replay-debugger-ui/src/components/replay-debugger/replay-debugger.tsx
+++ b/packages/replay-debugger-ui/src/components/replay-debugger/replay-debugger.tsx
@@ -95,7 +95,8 @@ const ReplayDebuggerWrapped: FunctionComponent = () => {
               "py-5",
               "border-b",
               "border-zinc-200",
-              "sm:px-6"
+              "sm:px-6",
+              "select-none"
             )}
           >
             <h3
@@ -119,7 +120,8 @@ const ReplayDebuggerWrapped: FunctionComponent = () => {
               "bg-zinc-100",
               "text-zinc-900",
               "font-mono",
-              "sm:px-6"
+              "sm:px-6",
+              "select-all"
             )}
           >
             <code className="language-json">

--- a/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
+++ b/packages/replay-debugger-ui/src/components/replay-debugger/user-events.tsx
@@ -124,7 +124,8 @@ const EventListItem: FunctionComponent<EventListItemProps> = ({
               "justify-center",
               "items-center",
               "text-base",
-              "font-bold"
+              "font-bold",
+              "select-none"
             )}
             aria-hidden="true"
           >
@@ -365,7 +366,8 @@ export const ReplayUserEvents: FunctionComponent = () => {
               "leading-6",
               "text-base",
               "font-medium",
-              "text-zinc-900"
+              "text-zinc-900",
+              "select-none"
             )}
           >
             Event data
@@ -375,7 +377,8 @@ export const ReplayUserEvents: FunctionComponent = () => {
               "max-h-64",
               "overflow-auto",
               "text-zinc-900",
-              "font-mono"
+              "font-mono",
+              "select-all"
             )}
           >
             <code>


### PR DESCRIPTION
  - Fix viewport issue causing content to appear off-screen on initial load by disabling viewport emulation (setting viewport to null instead of 0x0)
  - Make question mark icons and section headers non-selectable (select-none)
  - Make JSON code blocks fully selectable with select-all for easier copying