### PR TITLE
Wire through --postComment

### DIFF
--- a/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
+++ b/packages/cli/src/commands/run-all-tests-in-cloud/run-all-tests-in-cloud.command.ts
@@ -41,6 +41,7 @@ interface Options {
   companionAssetsRegex?: string | undefined;
   hadPreparedForTests: boolean;
   triggerScript?: string | undefined;
+  postComment?: boolean | undefined;
 }
 
 const environmentToString: (environment: Environment) => string = (
@@ -68,6 +69,7 @@ const handler: (options: Options) => Promise<void> = async ({
   companionAssetsRegex,
   hadPreparedForTests,
   triggerScript,
+  postComment,
 }) => {
   const logger = initLogger();
   const commitSha = await getCommitSha(commitSha_);
@@ -241,6 +243,7 @@ const handler: (options: Options) => Promise<void> = async ({
       rewriteHostnameToAppUrl,
       enableDnsCache,
       http2Connections,
+      ...(postComment ? { postComment } : {}),
       ...(companionAssetsFolder && companionAssetsRegex
         ? {
             companionAssets: {
@@ -386,6 +389,12 @@ export const runAllTestsInCloudCommand = buildCommand("run-all-tests-in-cloud")
       description:
         "Path to script that triggers the generation of a Meticulous test run on a specific commit in case base test run is not available. The script will be called with the commit SHA as an argument.",
       default: undefined,
+    },
+    postComment: {
+      boolean: true,
+      description:
+        "Post comments on the pull request, even if comments are still disabled for the project.",
+      default: false,
     },
   } as const)
   .handler(handler);

--- a/packages/client/src/api/test-run.api.ts
+++ b/packages/client/src/api/test-run.api.ts
@@ -44,6 +44,7 @@ export interface ExecuteSecureTunnelTestRunOptions {
   isLockable: boolean;
   companionAssetsInfo?: CompanionAssetsInfo;
   pullRequestHostingProviderId?: string;
+  postComment?: boolean;
 }
 
 export interface ExecuteSecureTunnelTestRunResponse {
@@ -62,6 +63,7 @@ export const executeSecureTunnelTestRun = async ({
   isLockable,
   companionAssetsInfo,
   pullRequestHostingProviderId,
+  postComment,
 }: ExecuteSecureTunnelTestRunOptions): Promise<ExecuteSecureTunnelTestRunResponse> => {
   const { data } = await client
     .post("test-runs/trigger-secure-tunnel-test-run-v2", {
@@ -71,6 +73,7 @@ export const executeSecureTunnelTestRun = async ({
       basicAuthPassword,
       environment,
       isLockable,
+      ...(postComment ? { postComment } : {}),
       ...(companionAssetsInfo ? { companionAssetsInfo } : {}),
       ...(pullRequestHostingProviderId ? { pullRequestHostingProviderId } : {}),
     })

--- a/packages/remote-replay-launcher/src/execute-remote-test-run.ts
+++ b/packages/remote-replay-launcher/src/execute-remote-test-run.ts
@@ -43,6 +43,7 @@ export const executeRemoteTestRun = async ({
   rewriteHostnameToAppUrl = false,
   enableDnsCache = false,
   http2Connections,
+  postComment = false,
 }: ExecuteRemoteTestRunOptions): Promise<ExecuteRemoteTestRunResult> => {
   const logger = initLogger();
 
@@ -125,6 +126,7 @@ export const executeRemoteTestRun = async ({
     basicAuthPassword: tunnel.basicAuthPassword,
     environment,
     isLockable,
+    postComment,
     ...(companionAssetsInfo ? { companionAssetsInfo } : {}),
     ...(pullRequestHostingProviderId ? { pullRequestHostingProviderId } : {}),
   });

--- a/packages/remote-replay-launcher/src/types.ts
+++ b/packages/remote-replay-launcher/src/types.ts
@@ -49,6 +49,11 @@ export interface ExecuteRemoteTestRunOptions {
     folder: string;
     regex: string;
   };
+
+  /**
+   * Post a comment for this test run, even if comments are still disabled for the project.
+   */
+  postComment?: boolean;
 }
 
 export interface ExecuteRemoteTestRunResult {


### PR DESCRIPTION
In conjunction with the backend PR in our monorepo, this lets pilot customers selectively enable comments for certain users without having to send us a list that needs to be updated manually.