### PR TITLE
Add types to upload new diversity measures

### DIFF
--- a/packages/client/src/api/test-run.api.ts
+++ b/packages/client/src/api/test-run.api.ts
@@ -18,6 +18,7 @@ export interface TestRunDataLocations {
   coverageScreenshotReplaysByFile?: S3Location;
   coverageScreenshotReplaysByFileUnmapped?: S3Location;
   coverageByReplayPr?: S3Location;
+  diversityByReplay?: S3Location;
   relevantReplayContexts: S3Location;
 }
 


### PR DESCRIPTION
This opens the path towards storing new diversity measures. It has been tested locally on the following internal test run https://app.meticulous.ai/projects/meticulous/meticulous_app_passive_recordings/test-runs/JCBLtNpHMmt9Q6RFTthtDp9dzG 