### PR TITLE
Full streaming download & extract tar

### DIFF
--- a/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
+++ b/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
@@ -7,7 +7,7 @@ import { constants as zlibConstants } from "zlib";
 import { DeflateRaw } from "fast-zlib";
 import { create as tarCreate } from "tar";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { downloadAndExtractTar, downloadFile } from "../download-file";
+import { downloadFile, streamDownloadAndExtractTar } from "../download-file";
 
 describe("downloadFile", () => {
   it("downloads a file from a URL", async () => {
@@ -106,9 +106,7 @@ describe("downloadFile", () => {
  * Compresses a directory into a raw-deflated tar blob, matching the format
  * produced by MultipartCompressingUploader in production.
  */
-const createRawDeflatedTar = async (
-  folderPath: string,
-): Promise<Buffer> => {
+const createRawDeflatedTar = async (folderPath: string): Promise<Buffer> => {
   const deflate = new DeflateRaw({ level: 3 });
   const chunks: Buffer[] = [];
 
@@ -124,10 +122,7 @@ const createRawDeflatedTar = async (
     tarStream.on("error", reject);
   });
 
-  const finalChunk = deflate.process(
-    Buffer.alloc(0),
-    zlibConstants.Z_FINISH,
-  );
+  const finalChunk = deflate.process(Buffer.alloc(0), zlibConstants.Z_FINISH);
   if (finalChunk.length > 0) {
     chunks.push(finalChunk);
   }
@@ -135,16 +130,14 @@ const createRawDeflatedTar = async (
   return Buffer.concat(chunks);
 };
 
-describe("downloadAndExtractTar", () => {
+describe("streamDownloadAndExtractTar", () => {
   let sourceDir: string;
   let extractDir: string;
-  let tmpTarPath: string;
 
   beforeEach(async () => {
-    const base = join(tmpdir(), `test-tar-extract-${Date.now()}`);
+    const base = join(tmpdir(), `test-stream-tar-${Date.now()}`);
     sourceDir = join(base, "source");
     extractDir = join(base, "extract");
-    tmpTarPath = join(base, "tmp.tar.d");
     await mkdir(sourceDir, { recursive: true });
   });
 
@@ -157,7 +150,7 @@ describe("downloadAndExtractTar", () => {
     }
   });
 
-  it("round-trips files compressed with fast-zlib DeflateRaw", async () => {
+  it("streams and extracts files without a temp file", async () => {
     await writeFile(join(sourceDir, "hello.txt"), "Hello World");
     await writeFile(join(sourceDir, "data.json"), '{"key": "value"}');
     await mkdir(join(sourceDir, "subdir"), { recursive: true });
@@ -171,13 +164,9 @@ describe("downloadAndExtractTar", () => {
     });
 
     try {
-      await new Promise<void>((resolve) => server.listen(1235, resolve));
+      await new Promise<void>((resolve) => server.listen(1237, resolve));
 
-      const entries = await downloadAndExtractTar(
-        "http://localhost:1235",
-        tmpTarPath,
-        extractDir,
-      );
+      const entries = await streamDownloadAndExtractTar("http://localhost:1237", extractDir);
 
       expect(entries.length).toBeGreaterThan(0);
 
@@ -187,19 +176,14 @@ describe("downloadAndExtractTar", () => {
       const data = await readFile(join(extractDir, "data.json"), "utf8");
       expect(data).toBe('{"key": "value"}');
 
-      const nested = await readFile(
-        join(extractDir, "subdir", "nested.txt"),
-        "utf8",
-      );
+      const nested = await readFile(join(extractDir, "subdir", "nested.txt"), "utf8");
       expect(nested).toBe("Nested!");
-
-      expect(existsSync(tmpTarPath)).toBe(false);
     } finally {
       server.close();
     }
   });
 
-  it("round-trips a large file that would stress chunked decompression", async () => {
+  it("streams and extracts a large file", async () => {
     const largeContent = "A".repeat(5 * 1024 * 1024);
     await writeFile(join(sourceDir, "large.txt"), largeContent);
 
@@ -211,13 +195,9 @@ describe("downloadAndExtractTar", () => {
     });
 
     try {
-      await new Promise<void>((resolve) => server.listen(1236, resolve));
+      await new Promise<void>((resolve) => server.listen(1238, resolve));
 
-      await downloadAndExtractTar(
-        "http://localhost:1236",
-        tmpTarPath,
-        extractDir,
-      );
+      await streamDownloadAndExtractTar("http://localhost:1238", extractDir);
 
       const result = await readFile(join(extractDir, "large.txt"), "utf8");
       expect(result).toBe(largeContent);
@@ -225,4 +205,28 @@ describe("downloadAndExtractTar", () => {
       server.close();
     }
   });
+
+  it("times out on a stalled download", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+    });
+
+    await new Promise<void>((resolve) => server.listen(1239, resolve));
+
+    let caughtError: Error | null = null;
+    try {
+      await streamDownloadAndExtractTar("http://localhost:1239", extractDir, {
+        totalTimeoutInMs: 100,
+        maxRetries: 0,
+      });
+    } catch (err) {
+      caughtError = err as Error;
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.message).toContain("timed out");
+  }, 15_000);
 });

--- a/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
+++ b/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
@@ -229,4 +229,28 @@ describe("streamDownloadAndExtractTar", () => {
     expect(caughtError).not.toBeNull();
     expect(caughtError!.message).toContain("timed out");
   }, 15_000);
+
+  it("preserves the underlying error when retries are exhausted (not generic AbortError)", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("internal server error");
+    });
+
+    await new Promise<void>((resolve) => server.listen(1240, resolve));
+
+    let caughtError: Error | null = null;
+    try {
+      await streamDownloadAndExtractTar("http://localhost:1240", extractDir, {
+        maxRetries: 0,
+      });
+    } catch (err) {
+      caughtError = err as Error;
+    } finally {
+      server.close();
+    }
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.name).not.toBe("AbortError");
+    expect(caughtError!.message).toMatch(/500/);
+  });
 });

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -1,16 +1,23 @@
-import { createReadStream, createWriteStream, existsSync } from "fs";
+import { createWriteStream, existsSync } from "fs";
 import { mkdir, rm } from "fs/promises";
-import { Stream, finished, Transform } from "stream";
+import { Readable, Stream, finished, Transform } from "stream";
 import { pipeline } from "stream/promises";
 import { promisify } from "util";
-import { createInflateRaw } from "zlib";
+import { constants as zlibConstants } from "zlib";
 import axios from "axios";
 import axiosRetry from "axios-retry";
 import cliProgress from "cli-progress";
 import extract from "extract-zip";
+import { InflateRaw } from "fast-zlib";
 import { extract as tarExtract } from "tar";
 
 const promisifiedFinished = promisify(finished);
+
+/**
+ * Larger buffer sizes reduce the number of syscalls and context switches
+ * in the streaming pipeline, improving throughput for large (>1GB) files.
+ */
+const STREAMING_HIGH_WATER_MARK = 256 * 1024;
 
 const shouldShowProgressBar = (): boolean => {
   return process.env.METICULOUS_IS_CLOUD_REPLAY !== "true";
@@ -199,69 +206,128 @@ export const downloadAndExtractFile: (
   return entries;
 };
 
+export interface StreamDownloadAndExtractTarOptions {
+  firstDataTimeoutInMs?: number;
+  totalTimeoutInMs?: number;
+  maxRetries?: number;
+  retryDelay?: number;
+}
+
 /**
- * Download a raw deflated tar blob from a URL, inflate it,
- * and extract the tar contents to a directory.
- * The downloaded file will be deleted after extraction, keeping only the extracted files.
- * __Warning__: this function is not thread safe.
+ * Streams a raw-deflated tar blob from a URL directly through inflate and
+ * tar extraction without writing the archive to disk first.
+ *
+ * This eliminates the temp file that the legacy `downloadAndExtractTar` used,
+ * halving disk I/O and allowing download and extraction to overlap. Uses
+ * fast-zlib for decompression and tuned buffer sizes for better throughput
+ * on large (>1GB) files.
+ *
+ * __Warning__: this function is not thread safe. Do not extract to a
+ * directory that may already be in use by another process.
  *
  * @param fileUrl The URL of the deflated tar blob to download.
- * @param tmpTarFilePath The path to save the downloaded file. Do not try downloading a file to a
- * `tmpTarFilePath` that may already be in use by another process b/c this can corrupt the data.
- * @param extractPath The path to a directory which we will extract tar entries into.
- * Do not try extracting to a dir that may already be in use by another process b/c overlapping
- * file names can cause data corruption.
- * @param extractTimeoutInMs The timeout for the tar extraction, in milliseconds.
- * @returns The list of the extracted files.
+ * @param extractPath The directory to extract tar entries into.
+ * @param opts Timeout, retry, and buffer configuration.
+ * @returns The list of extracted file paths.
  */
-export const downloadAndExtractTar: (
+export const streamDownloadAndExtractTar = async (
   fileUrl: string,
-  tmpTarFilePath: string,
   extractPath: string,
-  extractTimeoutInMs?: number,
-) => Promise<string[]> = async (
-  fileUrl,
-  tmpTarFilePath,
-  extractPath,
-  extractTimeoutInMs = 300_000,
-) => {
-  await downloadFile(fileUrl, tmpTarFilePath);
-  const entries: string[] = [];
+  opts: StreamDownloadAndExtractTarOptions = {},
+): Promise<string[]> => {
+  const firstDataTimeoutInMs = opts.firstDataTimeoutInMs ?? 60_000;
+  const totalTimeoutInMs = opts.totalTimeoutInMs ?? 600_000;
+  const maxRetries = opts.maxRetries ?? 3;
+  const retryDelay = opts.retryDelay ?? 1000;
 
-  try {
-    let timeoutId: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () =>
-          reject(
-            new Error(`Tar extraction timed out after ${extractTimeoutInMs}ms`),
-          ),
-        extractTimeoutInMs,
-      );
-    });
+  for (let attempt = 0; ; attempt++) {
     const abortController = new AbortController();
+    const timeoutId = setTimeout(() => {
+      abortController.abort(
+        new Error(
+          `Streaming download and extraction timed out after ${totalTimeoutInMs}ms`,
+        ),
+      );
+    }, totalTimeoutInMs);
+
     try {
+      const client = axios.create({ timeout: firstDataTimeoutInMs });
+      axiosRetry(client, { retries: 3, shouldResetTimeout: true });
+
+      const entries: string[] = [];
       await mkdir(extractPath, { recursive: true });
 
-      const extractPromise = pipeline(
-        createReadStream(tmpTarFilePath),
-        createInflateRaw(),
+      const response = await client.request({
+        method: "GET",
+        url: fileUrl,
+        responseType: "stream",
+        signal: abortController.signal,
+      });
+
+      await pipeline(
+        response.data as Readable,
+        createFastInflateRawStream(),
         tarExtract({
           cwd: extractPath,
           onReadEntry: (entry) => entries.push(entry.path),
         }),
         { signal: abortController.signal },
       );
-      await Promise.race([extractPromise, timeoutPromise]);
+
+      return entries;
     } catch (error) {
       abortController.abort();
-      throw error;
-    } finally {
-      clearTimeout(timeoutId!);
-    }
-  } finally {
-    await rm(tmpTarFilePath);
-  }
+      await rm(extractPath, { recursive: true, force: true }).catch(() => {});
 
-  return entries;
+      if (attempt >= maxRetries) {
+        const reason = abortController.signal.reason;
+        throw reason instanceof Error ? reason : error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+/**
+ * Wraps fast-zlib's synchronous InflateRaw in a Transform stream with
+ * a tuned highWaterMark for better large-file throughput.
+ *
+ * fast-zlib processes chunks synchronously via zlib's _processChunk,
+ * avoiding the thread-pool overhead of Node's built-in async zlib streams.
+ */
+const createFastInflateRawStream = (): Transform => {
+  const inflate = new InflateRaw();
+  return new Transform({
+    highWaterMark: STREAMING_HIGH_WATER_MARK,
+    transform(chunk: Buffer, _encoding: BufferEncoding, callback) {
+      try {
+        const result = inflate.process(chunk);
+        if (result.length > 0) {
+          this.push(result);
+        }
+        callback();
+      } catch (err) {
+        callback(err as Error);
+      }
+    },
+    flush(callback) {
+      try {
+        const result = inflate.process(Buffer.alloc(0), zlibConstants.Z_FINISH);
+        if (result.length > 0) {
+          this.push(result);
+        }
+        inflate.close();
+        callback();
+      } catch (err) {
+        callback(err as Error);
+      }
+    },
+    destroy(_err, callback) {
+      inflate.close();
+      callback(_err);
+    },
+  });
 };

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -276,12 +276,19 @@ export const streamDownloadAndExtractTar = async (
 
       return entries;
     } catch (error) {
+      const wasAbortedBeforeCleanup = abortController.signal.aborted;
+      const reasonBeforeCleanup = abortController.signal.reason;
       abortController.abort();
       await rm(extractPath, { recursive: true, force: true }).catch(() => {});
 
       if (attempt >= maxRetries) {
-        const reason = abortController.signal.reason;
-        throw reason instanceof Error ? reason : error;
+        const errToThrow =
+          wasAbortedBeforeCleanup && reasonBeforeCleanup instanceof Error
+            ? reasonBeforeCleanup
+            : error instanceof Error
+              ? error
+              : new Error(String(error));
+        throw errToThrow;
       }
 
       await new Promise((resolve) => setTimeout(resolve, retryDelay));
@@ -300,6 +307,14 @@ export const streamDownloadAndExtractTar = async (
  */
 const createFastInflateRawStream = (): Transform => {
   const inflate = new InflateRaw();
+  let inflateClosed = false;
+  const closeInflateOnce = (): void => {
+    if (inflateClosed) {
+      return;
+    }
+    inflateClosed = true;
+    inflate.close();
+  };
   return new Transform({
     highWaterMark: STREAMING_HIGH_WATER_MARK,
     transform(chunk: Buffer, _encoding: BufferEncoding, callback) {
@@ -319,14 +334,14 @@ const createFastInflateRawStream = (): Transform => {
         if (result.length > 0) {
           this.push(result);
         }
-        inflate.close();
+        closeInflateOnce();
         callback();
       } catch (err) {
         callback(err as Error);
       }
     },
     destroy(_err, callback) {
-      inflate.close();
+      closeInflateOnce();
       callback(_err);
     },
   });

--- a/packages/downloading-helpers/src/index.ts
+++ b/packages/downloading-helpers/src/index.ts
@@ -1,10 +1,6 @@
 export { sanitizeFilename } from "./file-downloads/local-data.utils";
 export { downloadAppContainerLogs } from "./file-downloads/app-container-logs";
-export {
-  getOrFetchReplay,
-  getOrFetchReplayArchive,
-  DownloadScope,
-} from "./scripts/replays";
+export { getOrFetchReplay, getOrFetchReplayArchive, DownloadScope } from "./scripts/replays";
 export {
   getOrFetchRecordedSession,
   getOrFetchRecordedSessionData,
@@ -22,6 +18,7 @@ export { fetchAsset, checkIfAssetsOutdated } from "./scripts/replay-assets";
 export {
   downloadFile,
   downloadAndExtractFile,
-  downloadAndExtractTar,
+  streamDownloadAndExtractTar,
+  type StreamDownloadAndExtractTarOptions,
 } from "./file-downloads/download-file";
 export { getReplayDir } from "./scripts/replays";


### PR DESCRIPTION
## Stream deployment tar extraction to eliminate temp file I/O

Replace `downloadAndExtractTar` with `streamDownloadAndExtractTar`, which pipes the HTTP response directly through inflate and tar extract instead of downloading to a temp file first.

### Problem

Large deployment downloads (e.g. Dropbox, >1GB) were taking ~2 minutes in cloud workers, blocking all parallel replays. The old approach downloaded the entire compressed archive to disk, then read it back for extraction — doubling disk I/O and preventing any overlap between download and extraction.

### Changes

- **Streaming pipeline**: `HTTP response → fast-zlib InflateRaw → tar extract` — no temp file, download and extraction overlap.
- **fast-zlib for decompression**: Replaces Node's built-in `createInflateRaw()` with `fast-zlib`'s synchronous `InflateRaw`, wrapped in a Transform stream. Avoids thread-pool overhead per chunk.
- **Tuned buffer sizes**: 256KB `highWaterMark` (vs Node's default 64KB) to reduce syscalls for large files.
- **AbortController-based timeout**: Single 600s default timeout covers the combined download+extract operation, with clean abort propagation to both the HTTP request and the pipeline.
- **Retry via loop**: Simple `for` loop instead of recursive calls.
- **Removed `downloadAndExtractTar`**: No external callers — replaced entirely by `streamDownloadAndExtractTar`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the tar download/extract implementation with a new streaming+abort+retry pipeline, which could change failure modes and cleanup behavior for large deployments and network edge cases.
> 
> **Overview**
> **Replaces temp-file tar extraction with a fully streaming pipeline.** `downloadAndExtractTar` is removed and superseded by `streamDownloadAndExtractTar`, which pipes the HTTP response through a fast-zlib `InflateRaw` transform into `tar` extraction (no intermediate archive written to disk) and uses a larger `highWaterMark` for throughput.
> 
> Adds new `StreamDownloadAndExtractTarOptions` (timeouts/retries), AbortController-based total timeout with extract-dir cleanup on failure, and updates/extends tests to cover streaming extraction, large-file handling, timeout-on-stall, and preserving underlying errors when retries are exhausted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1346236bd8ae7a1533f519be6355d050e4435f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->