### PR TITLE
Fix lint and build issues in workspace checks

### DIFF
--- a/packages/client/src/api/github-cloud-replay.api.ts
+++ b/packages/client/src/api/github-cloud-replay.api.ts
@@ -1,6 +1,6 @@
+import type { TestRun } from "@alwaysmeticulous/api";
 import { maybeEnrichFetchError } from "../errors";
 import { MeticulousClient } from "../types/client.types";
-import type { TestRun } from "@alwaysmeticulous/api";
 
 export interface GetBaseTestRunOptions {
   client: MeticulousClient;

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -61,13 +61,13 @@ export const downloadFile = async (
 
   const client = axios.create({ timeout: firstDataTimeoutInMs });
   axiosRetry(client, { retries: 3, shouldResetTimeout: true });
-  const source = axios.CancelToken.source();
+  const abortController = new AbortController();
 
   const response = await client.request({
     method: "GET",
     url: fileUrl,
     responseType: "stream",
-    cancelToken: source.token,
+    signal: abortController.signal,
   });
 
   const contentLength = parseInt(response.headers["content-length"] ?? "0", 10);
@@ -111,7 +111,7 @@ export const downloadFile = async (
   (response.data as Stream).pipe(progressTransform).pipe(writer);
   const timeoutId = setTimeout(async () => {
     const error = `Download timed out after ${downloadCompleteTimeoutInMs}ms`;
-    source.cancel(error);
+    abortController.abort(new Error(error));
     writer.destroy(new Error(error));
   }, downloadCompleteTimeoutInMs);
 

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -61,13 +61,13 @@ export const downloadFile = async (
 
   const client = axios.create({ timeout: firstDataTimeoutInMs });
   axiosRetry(client, { retries: 3, shouldResetTimeout: true });
-  const abortController = new AbortController();
+  const source = axios.CancelToken.source();
 
   const response = await client.request({
     method: "GET",
     url: fileUrl,
     responseType: "stream",
-    signal: abortController.signal,
+    cancelToken: source.token,
   });
 
   const contentLength = parseInt(response.headers["content-length"] ?? "0", 10);
@@ -111,7 +111,7 @@ export const downloadFile = async (
   (response.data as Stream).pipe(progressTransform).pipe(writer);
   const timeoutId = setTimeout(async () => {
     const error = `Download timed out after ${downloadCompleteTimeoutInMs}ms`;
-    abortController.abort(new Error(error));
+    source.cancel(error);
     writer.destroy(new Error(error));
   }, downloadCompleteTimeoutInMs);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fixed an `import/order` lint error in `packages/client/src/api/github-cloud-replay.api.ts` by reordering imports
- reverted previous changes to `packages/downloading-helpers/src/file-downloads/download-file.ts` per request

## Validation
- no additional checks were run after the targeted revert
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0b3e330-3a39-4713-8cb8-b4b6a67c1e00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0b3e330-3a39-4713-8cb8-b4b6a67c1e00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

