### PR TITLE
Deduplicate SDK fetch helper and make dispatcher initialization lazy

### DIFF
--- a/packages/common/src/fetch.utils.ts
+++ b/packages/common/src/fetch.utils.ts
@@ -10,8 +10,8 @@ const DEFAULT_PORTS: Partial<Record<string, number>> = {
   "https:": 443,
 };
 
-const directDispatcher = new Agent();
-const proxyDispatchers = new Map<string, Dispatcher>();
+let directDispatcher: Dispatcher | undefined;
+let proxyDispatchers: Map<string, Dispatcher> | undefined;
 
 export const meticulousFetch = (
   input: Parameters<typeof undiciFetch>[0],
@@ -28,19 +28,19 @@ function getDispatcherForInput(
 ): Dispatcher {
   const url = getUrlFromInput(input);
   if (!url) {
-    return directDispatcher;
+    return getDirectDispatcher();
   }
 
   const { httpProxy, httpsProxy, noProxy } = getProxyConfiguration();
   if (!shouldProxy(url, noProxy)) {
-    return directDispatcher;
+    return getDirectDispatcher();
   }
 
   if (url.protocol === "https:") {
-    return httpsProxy ? getProxyDispatcher(httpsProxy) : directDispatcher;
+    return httpsProxy ? getProxyDispatcher(httpsProxy) : getDirectDispatcher();
   }
 
-  return httpProxy ? getProxyDispatcher(httpProxy) : directDispatcher;
+  return httpProxy ? getProxyDispatcher(httpProxy) : getDirectDispatcher();
 }
 
 function getUrlFromInput(
@@ -139,6 +139,8 @@ function parseNoProxyEntries(
 }
 
 function getProxyDispatcher(uri: string): Dispatcher {
+  proxyDispatchers ??= new Map<string, Dispatcher>();
+
   const existingDispatcher = proxyDispatchers.get(uri);
   if (existingDispatcher) {
     return existingDispatcher;
@@ -147,4 +149,9 @@ function getProxyDispatcher(uri: string): Dispatcher {
   const dispatcher = new ProxyAgent({ uri });
   proxyDispatchers.set(uri, dispatcher);
   return dispatcher;
+}
+
+function getDirectDispatcher(): Dispatcher {
+  directDispatcher ??= new Agent();
+  return directDispatcher;
 }

--- a/packages/common/test/fetch.utils.spec.ts
+++ b/packages/common/test/fetch.utils.spec.ts
@@ -83,7 +83,7 @@ describe("meticulousFetch", () => {
     await expect(
       meticulousFetch("https://example.com/test"),
     ).resolves.toBe(response as never);
-    expect(agentMock).toHaveBeenCalledTimes(1);
+    expect(agentMock).not.toHaveBeenCalled();
     expect(proxyAgentMock).toHaveBeenCalledTimes(1);
     expect(undiciFetchMock).toHaveBeenCalledWith(
       "https://example.com/test",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly changes dispatcher instantiation timing in a shared fetch helper; behavior should be unchanged but could affect environments relying on eager `Agent` construction.
> 
> **Overview**
> `meticulousFetch` now lazily constructs and caches the undici direct `Agent` and the per-proxy `ProxyAgent` dispatchers via `getDirectDispatcher()`/`getProxyDispatcher()`, instead of creating the direct agent at module load.
> 
> Tests are updated to assert the direct `Agent` is *not* instantiated when a proxy dispatcher is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4edc1096def863b17813eee5d272dfa7809e48ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->