### PR TITLE
Adding type for appGip

### DIFF
--- a/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
+++ b/packages/api/src/sdk-bundle-api/sdk-to-bundle/session-data.ts
@@ -139,6 +139,7 @@ export interface ApplicationSpecificData {
     isFallback?: boolean;
     gsp?: boolean;
     gip?: boolean;
+    appGip?: boolean;
     scriptLoader?: Record<string, unknown>;
     locale?: string;
     assetPrefix?: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds an optional field to a TypeScript interface with no runtime behavior changes; impact is limited to typing/serialization expectations for `ApplicationSpecificData.nextJs`.
> 
> **Overview**
> Extends `ApplicationSpecificData.nextJs` in `session-data.ts` with a new optional boolean flag, `appGip`, to represent an additional Next.js data-fetching mode in recorded session payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e54f1ff4a9091f2d73dffdbaf4a76bb07f4d197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->