### PR TITLE
Add optional rankPosition to TestCase

### DIFF
--- a/packages/api/src/replay/test-run.types.ts
+++ b/packages/api/src/replay/test-run.types.ts
@@ -36,6 +36,12 @@ export interface TestCase {
   relevanceToPR?: SessionRelevance;
   title?: string;
   options?: TestCaseReplayOptions;
+
+  /**
+   * 1-indexed session-selection rank (1 = highest value) snapshotted at test-run
+   * creation time. Used to prioritize MaybeRelevant sessions when sampling.
+   */
+  rankPosition?: number;
 }
 
 export interface TestCaseReplayOptions extends Partial<ScreenshotDiffOptions> {


### PR DESCRIPTION
## Summary

Adds an optional `rankPosition?: number` field to the `TestCase` interface in `@alwaysmeticulous/api`.

This lets consumers snapshot each session's 1-indexed session-selection rank (1 = highest value) directly onto the test case, so downstream sampling logic (e.g. picking the top N% of `MaybeRelevant` sessions) can use a stable ranking without carrying a parallel `sessionId -> rank` map.

## Context

Used by a follow-up change in the main `meticulous` repo that samples `MaybeRelevant` sessions by rank instead of by hash. Snapshotting the rank onto each `TestCase` keeps the result deterministic across re-runs even if `Project.autoSelectedSessions` is recomputed later.

## Test plan

- [x] `pnpm build` in `packages/api` passes
- [ ] Consume from main `meticulous` repo and verify types flow through

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only, backwards-compatible API surface change (optional field) with no runtime behavior modifications.
> 
> **Overview**
> Adds an optional `rankPosition?: number` to the `TestCase` type in `packages/api/src/replay/test-run.types.ts`, documenting it as a 1-indexed snapshot of session-selection rank at test-run creation time.
> 
> This enables downstream consumers (including `TestCaseResult`, which extends `TestCase`) to prioritize/sort sessions using a stable recorded rank without maintaining a separate sessionId-to-rank mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5098838f029ef1bc8f7632d89be9b8089bc47e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->