### PR TITLE
EFS write concurrency for download & extract

### DIFF
--- a/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
+++ b/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
@@ -253,4 +253,119 @@ describe("streamDownloadAndExtractTar", () => {
     expect(caughtError!.name).not.toBe("AbortError");
     expect(caughtError!.message).toMatch(/500/);
   });
+
+  describe("with extractConcurrency > 1 (parallel writes)", () => {
+    it("extracts a nested tree identically to the serial path", async () => {
+      await writeFile(join(sourceDir, "hello.txt"), "Hello World");
+      await writeFile(join(sourceDir, "data.json"), '{"key": "value"}');
+      await mkdir(join(sourceDir, "subdir"), { recursive: true });
+      await writeFile(join(sourceDir, "subdir", "nested.txt"), "Nested!");
+      await mkdir(join(sourceDir, "deep", "nested", "tree"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(sourceDir, "deep", "nested", "tree", "leaf.txt"),
+        "leaf",
+      );
+
+      const compressed = await createRawDeflatedTar(sourceDir);
+
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Length": compressed.length.toString() });
+        res.end(compressed);
+      });
+
+      try {
+        await new Promise<void>((resolve) => server.listen(1241, resolve));
+
+        const entries = await streamDownloadAndExtractTar(
+          "http://localhost:1241",
+          extractDir,
+          { extractConcurrency: 8 },
+        );
+
+        expect(entries.length).toBeGreaterThan(0);
+
+        expect(await readFile(join(extractDir, "hello.txt"), "utf8")).toBe(
+          "Hello World",
+        );
+        expect(await readFile(join(extractDir, "data.json"), "utf8")).toBe(
+          '{"key": "value"}',
+        );
+        expect(
+          await readFile(join(extractDir, "subdir", "nested.txt"), "utf8"),
+        ).toBe("Nested!");
+        expect(
+          await readFile(
+            join(extractDir, "deep", "nested", "tree", "leaf.txt"),
+            "utf8",
+          ),
+        ).toBe("leaf");
+      } finally {
+        server.close();
+      }
+    });
+
+    it("handles many small files (shake out the concurrency path)", async () => {
+      const fileCount = 200;
+      for (let i = 0; i < fileCount; i++) {
+        await writeFile(join(sourceDir, `file-${i}.txt`), `contents ${i}`);
+      }
+
+      const compressed = await createRawDeflatedTar(sourceDir);
+
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Length": compressed.length.toString() });
+        res.end(compressed);
+      });
+
+      try {
+        await new Promise<void>((resolve) => server.listen(1242, resolve));
+
+        await streamDownloadAndExtractTar("http://localhost:1242", extractDir, {
+          extractConcurrency: 32,
+        });
+
+        // Spot-check a handful of files; the real assertion is that all
+        // writes completed without throwing and nothing got lost.
+        for (const i of [0, 1, 42, 99, fileCount - 1]) {
+          expect(
+            await readFile(join(extractDir, `file-${i}.txt`), "utf8"),
+          ).toBe(`contents ${i}`);
+        }
+      } finally {
+        server.close();
+      }
+    });
+
+    it("extracts a large file correctly under parallel mode", async () => {
+      const largeContent = "B".repeat(5 * 1024 * 1024);
+      await writeFile(join(sourceDir, "large.bin"), largeContent);
+      await writeFile(join(sourceDir, "tiny.txt"), "tiny");
+
+      const compressed = await createRawDeflatedTar(sourceDir);
+
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Length": compressed.length.toString() });
+        res.end(compressed);
+      });
+
+      try {
+        await new Promise<void>((resolve) => server.listen(1243, resolve));
+
+        await streamDownloadAndExtractTar("http://localhost:1243", extractDir, {
+          extractConcurrency: 4,
+        });
+
+        expect(await readFile(join(extractDir, "large.bin"), "utf8")).toBe(
+          largeContent,
+        );
+        expect(await readFile(join(extractDir, "tiny.txt"), "utf8")).toBe(
+          "tiny",
+        );
+      } finally {
+        server.close();
+      }
+    });
+  });
 });

--- a/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
+++ b/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "fs";
-import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, readFile, rm, symlink, writeFile } from "fs/promises";
 import http from "http";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -145,12 +145,15 @@ describe("downloadFile", () => {
  * Compresses a directory into a raw-deflated tar blob, matching the format
  * produced by MultipartCompressingUploader in production.
  */
-const createRawDeflatedTar = async (folderPath: string): Promise<Buffer> => {
+const createRawDeflatedTar = async (
+  folderPath: string,
+  { follow = true }: { follow?: boolean } = {},
+): Promise<Buffer> => {
   const deflate = new DeflateRaw({ level: 3 });
   const chunks: Buffer[] = [];
 
   await new Promise<void>((resolve, reject) => {
-    const tarStream = tarCreate({ cwd: folderPath, follow: true }, ["."]);
+    const tarStream = tarCreate({ cwd: folderPath, follow }, ["."]);
     tarStream.on("data", (chunk: Buffer) => {
       const compressed = deflate.process(chunk);
       if (compressed.length > 0) {
@@ -428,6 +431,42 @@ describe("streamDownloadAndExtractTar", () => {
         server.close();
       }
     }, 10_000);
+
+    it("does not report skipped non-file entries (e.g. symlinks) in the returned entries list", async () => {
+      // Regression: previously `entries.push(entry.path)` happened before the
+      // type filter, so symlinks / device nodes / pax headers were reported to
+      // the caller despite never being written. The serial path's contract is
+      // "entries list == what's on disk", and the parallel path must match.
+      await writeFile(join(sourceDir, "real.txt"), "hello");
+      await symlink("real.txt", join(sourceDir, "link.txt"));
+
+      const compressed = await createRawDeflatedTar(sourceDir, {
+        follow: false,
+      });
+
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Length": compressed.length.toString() });
+        res.end(compressed);
+      });
+
+      try {
+        await new Promise<void>((resolve) => server.listen(1245, resolve));
+
+        const entries = await streamDownloadAndExtractTar(
+          "http://localhost:1245",
+          extractDir,
+          { extractConcurrency: 4 },
+        );
+
+        expect(entries).toEqual(expect.arrayContaining(["./real.txt"]));
+        expect(entries).not.toEqual(expect.arrayContaining(["./link.txt"]));
+        for (const entry of entries) {
+          expect(existsSync(join(extractDir, entry))).toBe(true);
+        }
+      } finally {
+        server.close();
+      }
+    });
 
     it("extracts a large file correctly under parallel mode", async () => {
       const largeContent = "B".repeat(5 * 1024 * 1024);

--- a/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
+++ b/packages/downloading-helpers/src/file-downloads/__tests__/download-file.spec.ts
@@ -6,8 +6,47 @@ import { join } from "path";
 import { constants as zlibConstants } from "zlib";
 import { DeflateRaw } from "fast-zlib";
 import { create as tarCreate } from "tar";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { downloadFile, streamDownloadAndExtractTar } from "../download-file";
+
+// Module-level toggle for the stall-on-write test below. Vitest can't spy on
+// fs/promises named exports in ESM mode, so we vi.mock the module once and
+// flip this flag when a test needs writeFile to hang until aborted.
+const writeFileStallMode = { enabled: false };
+
+vi.mock("fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("fs/promises")>(
+    "fs/promises",
+  );
+  return {
+    ...actual,
+    writeFile: (
+      path: Parameters<typeof actual.writeFile>[0],
+      data: Parameters<typeof actual.writeFile>[1],
+      options?: Parameters<typeof actual.writeFile>[2],
+    ) => {
+      if (!writeFileStallMode.enabled) {
+        return actual.writeFile(path, data, options);
+      }
+      const signal = (options as { signal?: AbortSignal } | undefined)?.signal;
+      return new Promise<void>((_resolve, reject) => {
+        const abort = (): void => {
+          const reason = signal?.reason;
+          reject(
+            reason instanceof Error
+              ? reason
+              : new Error(String(reason ?? "aborted")),
+          );
+        };
+        if (signal?.aborted) {
+          abort();
+          return;
+        }
+        signal?.addEventListener("abort", abort, { once: true });
+      });
+    },
+  };
+});
 
 describe("downloadFile", () => {
   it("downloads a file from a URL", async () => {
@@ -337,6 +376,58 @@ describe("streamDownloadAndExtractTar", () => {
         server.close();
       }
     });
+
+    it("honors totalTimeoutInMs when writes stall after the pipeline completes", async () => {
+      // Regression test: previously the AbortSignal from the total timeout was
+      // only wired to the streaming `pipeline`, so `Promise.allSettled(pendingWrites)`
+      // would block until every queued `writeFile` finished. On stalled EFS
+      // this made the function ignore `totalTimeoutInMs`.
+      const fileCount = 20;
+      for (let i = 0; i < fileCount; i++) {
+        await writeFile(join(sourceDir, `file-${i}.txt`), `contents ${i}`);
+      }
+
+      const compressed = await createRawDeflatedTar(sourceDir);
+
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Length": compressed.length.toString() });
+        res.end(compressed);
+      });
+
+      writeFileStallMode.enabled = true;
+      try {
+        await new Promise<void>((resolve) => server.listen(1244, resolve));
+
+        const totalTimeoutInMs = 300;
+        const startedAt = Date.now();
+        let caughtError: Error | null = null;
+
+        try {
+          await streamDownloadAndExtractTar(
+            "http://localhost:1244",
+            extractDir,
+            {
+              totalTimeoutInMs,
+              extractConcurrency: 4,
+              maxRetries: 0,
+            },
+          );
+        } catch (err) {
+          caughtError = err as Error;
+        }
+
+        const elapsed = Date.now() - startedAt;
+
+        expect(caughtError).not.toBeNull();
+        expect(caughtError!.message).toContain("timed out");
+        // Should bail out promptly once the timeout fires, not wait for
+        // hung writes to complete. Allow generous slack for CI jitter.
+        expect(elapsed).toBeLessThan(totalTimeoutInMs + 2_000);
+      } finally {
+        writeFileStallMode.enabled = false;
+        server.close();
+      }
+    }, 10_000);
 
     it("extracts a large file correctly under parallel mode", async () => {
       const largeContent = "B".repeat(5 * 1024 * 1024);

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -412,6 +412,21 @@ const extractTarWithParallelWrites = async ({
         entry.resume();
         return;
       }
+
+      // Only record entries we're going to materialize on disk. The serial
+      // `tar.extract` path's entries list reflects what's written, and callers
+      // iterate it expecting every path to exist — symlinks, device nodes and
+      // pax headers are silently skipped below, so they must not appear here.
+      if (
+        entry.type !== "Directory" &&
+        entry.type !== "File" &&
+        entry.type !== "OldFile" &&
+        entry.type !== "ContiguousFile"
+      ) {
+        entry.resume();
+        return;
+      }
+
       entries.push(entry.path);
 
       if (entry.type === "Directory") {
@@ -425,15 +440,6 @@ const extractTarWithParallelWrites = async ({
             recordError(err);
           }),
         );
-        entry.resume();
-        return;
-      }
-
-      if (
-        entry.type !== "File" &&
-        entry.type !== "OldFile" &&
-        entry.type !== "ContiguousFile"
-      ) {
         entry.resume();
         return;
       }

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -406,9 +406,13 @@ const extractTarWithParallelWrites = async ({
 
       if (entry.type === "Directory") {
         pendingWrites.push(
+          // Swallow here (after recording) so the promise settles as
+          // fulfilled. Re-throwing would leave an unhandled rejection sitting
+          // in `pendingWrites` until `Promise.allSettled` runs after the
+          // pipeline drains, which in Node 15+ terminates the process.
+          // `firstError` is re-thrown below once all writes settle.
           limit(() => ensureDir(target)).catch((err) => {
             recordError(err);
-            throw err;
           }),
         );
         entry.resume();
@@ -433,12 +437,14 @@ const extractTarWithParallelWrites = async ({
         const mode =
           entry.mode != null && entry.mode > 0 ? entry.mode : DEFAULT_FILE_MODE;
         pendingWrites.push(
+          // See the equivalent comment on the Directory branch above:
+          // we must not let this reject or Node will kill the process with
+          // an unhandled rejection before allSettled attaches a handler.
           limit(async () => {
             await ensureDir(dirname(target));
             await writeFile(target, content, { mode });
           }).catch((err) => {
             recordError(err);
-            throw err;
           }),
         );
       });

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -1,5 +1,6 @@
 import { createWriteStream, existsSync } from "fs";
-import { mkdir, rm } from "fs/promises";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "path";
 import { Readable, Stream, finished, Transform } from "stream";
 import { pipeline } from "stream/promises";
 import { promisify } from "util";
@@ -9,7 +10,8 @@ import axiosRetry from "axios-retry";
 import cliProgress from "cli-progress";
 import extract from "extract-zip";
 import { InflateRaw } from "fast-zlib";
-import { extract as tarExtract } from "tar";
+import pLimit from "p-limit";
+import { Parser as TarParser, extract as tarExtract } from "tar";
 
 const promisifiedFinished = promisify(finished);
 
@@ -211,6 +213,21 @@ export interface StreamDownloadAndExtractTarOptions {
   totalTimeoutInMs?: number;
   maxRetries?: number;
   retryDelay?: number;
+  /**
+   * Number of concurrent file writes to issue during extraction. Defaults to
+   * `1` (strictly sequential, same behaviour as `tar.extract`).
+   *
+   * Raising this lets many `open`/`write`/`close` syscalls be in flight at
+   * once, which is only meaningful when the destination filesystem has
+   * non-trivial per-op latency (e.g. NFS / EFS over TLS). On local SSDs the
+   * default of 1 is already fine.
+   *
+   * When > 1, the implementation switches from `tar.extract` to a `Parser`-
+   * based path that buffers each entry body in memory and dispatches writes
+   * via a concurrency-limited pool. Worst-case memory usage is bounded by
+   * `extractConcurrency * max_entry_size` plus whatever is currently queued.
+   */
+  extractConcurrency?: number;
 }
 
 /**
@@ -239,6 +256,7 @@ export const streamDownloadAndExtractTar = async (
   const totalTimeoutInMs = opts.totalTimeoutInMs ?? 600_000;
   const maxRetries = opts.maxRetries ?? 3;
   const retryDelay = opts.retryDelay ?? 1000;
+  const extractConcurrency = Math.max(1, opts.extractConcurrency ?? 1);
 
   for (let attempt = 0; ; attempt++) {
     const abortController = new AbortController();
@@ -254,7 +272,6 @@ export const streamDownloadAndExtractTar = async (
       const client = axios.create({ timeout: firstDataTimeoutInMs });
       axiosRetry(client, { retries: 3, shouldResetTimeout: true });
 
-      const entries: string[] = [];
       await mkdir(extractPath, { recursive: true });
 
       const response = await client.request({
@@ -264,11 +281,25 @@ export const streamDownloadAndExtractTar = async (
         signal: abortController.signal,
       });
 
+      if (extractConcurrency > 1) {
+        return await extractTarWithParallelWrites({
+          sourceStream: response.data as Readable,
+          extractPath,
+          concurrency: extractConcurrency,
+          abortSignal: abortController.signal,
+        });
+      }
+
+      const entries: string[] = [];
       await pipeline(
         response.data as Readable,
         createFastInflateRawStream(),
         tarExtract({
           cwd: extractPath,
+          // Skip the per-entry `utimes` call. The asset server doesn't care
+          // about mtime, and on high-latency filesystems this is one full RPC
+          // saved per file.
+          noMtime: true,
           onReadEntry: (entry) => entries.push(entry.path),
         }),
         { signal: abortController.signal },
@@ -296,6 +327,143 @@ export const streamDownloadAndExtractTar = async (
       clearTimeout(timeoutId);
     }
   }
+};
+
+const DEFAULT_FILE_MODE = 0o644;
+
+/**
+ * Parallel-write tar extraction.
+ *
+ * We use `tar.Parser` (read-only) instead of `tar.extract` (unpack+write) so
+ * we can own the file-write step. Each entry body is buffered in memory and
+ * dispatched through a `p-limit` pool so that many `open`/`write`/`close`
+ * syscalls can be in flight at once.
+ *
+ * Rationale: on local disks tar.extract is already fast because writes hit
+ * the page cache at microsecond latency. On shared network filesystems
+ * (EFS / NFS over TLS) each per-file syscall is a separate RPC with
+ * millisecond RTT, and the serial pipeline in tar.extract caps throughput at
+ * ~1/RTT files/sec. Fan-out here hides that latency.
+ *
+ * Memory: buffers at most `concurrency * max_entry_size` + pending-queue.
+ * Per-parent-dir `mkdir` calls are memoized to avoid redundant RPCs.
+ *
+ * Non-File / non-Directory entries (symlinks, device files, pax headers)
+ * are skipped — deployment asset archives don't contain them in practice.
+ */
+const extractTarWithParallelWrites = async ({
+  sourceStream,
+  extractPath,
+  concurrency,
+  abortSignal,
+}: {
+  sourceStream: Readable;
+  extractPath: string;
+  concurrency: number;
+  abortSignal: AbortSignal;
+}): Promise<string[]> => {
+  const limit = pLimit(concurrency);
+  const mkdirCache = new Set<string>();
+  const pendingWrites: Promise<void>[] = [];
+  const entries: string[] = [];
+  let firstError: Error | null = null;
+
+  const recordError = (err: unknown): void => {
+    if (firstError == null) {
+      firstError = err instanceof Error ? err : new Error(String(err));
+    }
+  };
+
+  const ensureDir = async (dir: string): Promise<void> => {
+    if (mkdirCache.has(dir)) {
+      return;
+    }
+    await mkdir(dir, { recursive: true });
+    mkdirCache.add(dir);
+  };
+  mkdirCache.add(extractPath);
+
+  const resolveSafeTarget = (entryPath: string): string | null => {
+    const target = resolve(extractPath, entryPath);
+    const rel = relative(extractPath, target);
+    if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+      return null;
+    }
+    return target;
+  };
+
+  const parser = new TarParser({
+    // Skip setting mtime on extracted entries. Saves one RPC per file and the
+    // asset server doesn't care about it.
+    noMtime: true,
+    onReadEntry: (entry) => {
+      const target = resolveSafeTarget(entry.path);
+      if (target == null) {
+        entry.resume();
+        return;
+      }
+      entries.push(entry.path);
+
+      if (entry.type === "Directory") {
+        pendingWrites.push(
+          limit(() => ensureDir(target)).catch((err) => {
+            recordError(err);
+            throw err;
+          }),
+        );
+        entry.resume();
+        return;
+      }
+
+      if (
+        entry.type !== "File" &&
+        entry.type !== "OldFile" &&
+        entry.type !== "ContiguousFile"
+      ) {
+        entry.resume();
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      entry.on("data", (chunk: Buffer) => chunks.push(chunk));
+      entry.on("error", (err) => recordError(err));
+      entry.on("end", () => {
+        const content =
+          chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);
+        const mode =
+          entry.mode != null && entry.mode > 0 ? entry.mode : DEFAULT_FILE_MODE;
+        pendingWrites.push(
+          limit(async () => {
+            await ensureDir(dirname(target));
+            await writeFile(target, content, { mode });
+          }).catch((err) => {
+            recordError(err);
+            throw err;
+          }),
+        );
+      });
+    },
+  });
+
+  await pipeline(sourceStream, createFastInflateRawStream(), parser, {
+    signal: abortSignal,
+  });
+
+  // The pipeline resolves as soon as Parser has consumed all input bytes; the
+  // file writes scheduled above may still be outstanding. Drain them before
+  // returning so the caller sees a fully-materialized directory.
+  const settled = await Promise.allSettled(pendingWrites);
+  for (const result of settled) {
+    if (result.status === "rejected") {
+      recordError(result.reason);
+    }
+  }
+
+  if (firstError != null) {
+    throw firstError;
+  }
+
+  return entries;
 };
 
 /**

--- a/packages/downloading-helpers/src/file-downloads/download-file.ts
+++ b/packages/downloading-helpers/src/file-downloads/download-file.ts
@@ -374,10 +374,23 @@ const extractTarWithParallelWrites = async ({
     }
   };
 
+  const throwIfAborted = (): void => {
+    if (!abortSignal.aborted) {
+      return;
+    }
+    const reason = abortSignal.reason;
+    throw reason instanceof Error
+      ? reason
+      : new Error(String(reason ?? "aborted"));
+  };
+
   const ensureDir = async (dir: string): Promise<void> => {
     if (mkdirCache.has(dir)) {
       return;
     }
+    // fs.promises.mkdir doesn't accept an AbortSignal, so we settle for
+    // refusing to issue new mkdirs once the outer timeout has fired.
+    throwIfAborted();
     await mkdir(dir, { recursive: true });
     mkdirCache.add(dir);
   };
@@ -393,9 +406,6 @@ const extractTarWithParallelWrites = async ({
   };
 
   const parser = new TarParser({
-    // Skip setting mtime on extracted entries. Saves one RPC per file and the
-    // asset server doesn't care about it.
-    noMtime: true,
     onReadEntry: (entry) => {
       const target = resolveSafeTarget(entry.path);
       if (target == null) {
@@ -442,7 +452,11 @@ const extractTarWithParallelWrites = async ({
           // an unhandled rejection before allSettled attaches a handler.
           limit(async () => {
             await ensureDir(dirname(target));
-            await writeFile(target, content, { mode });
+            // Passing the abort signal to writeFile means that if the outer
+            // totalTimeoutInMs fires while writes are draining (common on
+            // stalled EFS), the in-flight fs call rejects promptly instead
+            // of blocking past the timeout window.
+            await writeFile(target, content, { mode, signal: abortSignal });
           }).catch((err) => {
             recordError(err);
           }),
@@ -458,18 +472,66 @@ const extractTarWithParallelWrites = async ({
   // The pipeline resolves as soon as Parser has consumed all input bytes; the
   // file writes scheduled above may still be outstanding. Drain them before
   // returning so the caller sees a fully-materialized directory.
-  const settled = await Promise.allSettled(pendingWrites);
-  for (const result of settled) {
-    if (result.status === "rejected") {
-      recordError(result.reason);
-    }
-  }
+  //
+  // We race the drain against the abort signal so that a totalTimeoutInMs
+  // firing during the drain phase (e.g. stuck writes on EFS) bubbles out
+  // promptly. Without this, `abortSignal` is only wired to the `pipeline`
+  // call and has no effect on pending `writeFile`s that are queued in
+  // `p-limit`, letting the function run past its timeout.
+  await raceAgainstAbort(Promise.allSettled(pendingWrites), abortSignal).then(
+    (settled) => {
+      for (const result of settled) {
+        if (result.status === "rejected") {
+          recordError(result.reason);
+        }
+      }
+    },
+  );
 
   if (firstError != null) {
     throw firstError;
   }
 
   return entries;
+};
+
+/**
+ * Races `promise` against the abort signal, rejecting with the signal's
+ * reason if it fires before the promise settles. Used to enforce an upper
+ * bound on phases that can't otherwise be cancelled (e.g. a pool of
+ * in-flight fs writes on a stalled network filesystem).
+ */
+const raceAgainstAbort = <T>(
+  promise: Promise<T>,
+  abortSignal: AbortSignal,
+): Promise<T> => {
+  if (abortSignal.aborted) {
+    const reason = abortSignal.reason;
+    return Promise.reject(
+      reason instanceof Error ? reason : new Error(String(reason ?? "aborted")),
+    );
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      const reason = abortSignal.reason;
+      reject(
+        reason instanceof Error
+          ? reason
+          : new Error(String(reason ?? "aborted")),
+      );
+    };
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err) => {
+        abortSignal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary
Preprocess pods extract deployment tarballs onto shared EFS. Per-file tar ops on NFS are dominated by metadata RPC round-trips (each `open`/`write`/`close`/`futimes` is a separate request with ~1–3ms latency), so `tar.extract`'s strictly serial pipeline caps at ~1/RTT files/sec on EFS — often minutes for a 10k-file frontend bundle. This PR lets extraction fan out.
- Pass `noMtime: true` to the existing `tar.extract` call. Skips the per-entry `futimes` RPC, which the asset server doesn't care about. Pure win for every current caller, zero API change.
- Add an optional `extractConcurrency?: number` to `streamDownloadAndExtractTar` (default `1`, existing behavior). When `> 1`, switches to a new `Parser`-based path that:
  - dispatches file writes through a `p-limit` pool so many `open`/`write`/`close` syscalls are in flight at once;
  - memoizes `mkdir -p` per parent directory (one RPC per unique dir instead of per entry);
  - also applies `noMtime: true`;
  - sanitizes entry paths against `..` / absolute escapes, and skips non-File/non-Directory entries (symlinks, devices, pax headers — deployment archives don't contain them in practice).
- On local SSDs this is a no-op (default concurrency stays `1`, and the parallel path is fine anyway — writes just don't overlap meaningfully when each one takes microseconds).
- On EFS, with `extractConcurrency: 32`, this should be a big reduction in download & extract time
Opt-in on the preprocess side (in the `meticulous` repo) is a separate small PR that threads the option through `downloadDeploymentAssets` and sets `UV_THREADPOOL_SIZE=64` on the pod so libuv isn't the new bottleneck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new parallel tar extraction path with concurrency, buffering, and custom filesystem writes; while opt-in, it changes extraction semantics (timeouts, entry filtering, path safety) and could impact memory/IO behavior under load.
> 
> **Overview**
> `streamDownloadAndExtractTar` now supports an opt-in `extractConcurrency` option; when set `> 1` it switches from `tar.extract` to a `tar.Parser`-based implementation that buffers entry bodies and writes files via a `p-limit` pool, memoizes directory creation, skips non-file/non-directory entries, and rejects path traversal targets.
> 
> The existing serial extraction path is also optimized by passing `noMtime: true` to avoid per-entry mtime syscalls. Tests are expanded substantially to cover parallel mode correctness (nested trees, many small files, large files), timeout behavior when writes stall, and ensuring skipped entries (e.g. symlinks) are not reported in the returned `entries` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5690d9392a481ca1c689b16adef41d0f861d1e1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->